### PR TITLE
fix: vendored openssl for musl builds

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -82,8 +82,6 @@ jobs:
 
       - name: Build
         if: steps.version.outputs.skip != 'true'
-        env:
-          OPENSSL_STATIC: '1'
         run: |
           cargo build --release --target x86_64-unknown-linux-musl
           strip target/x86_64-unknown-linux-musl/release/nauka

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,6 @@ jobs:
         if: matrix.target != 'aarch64-unknown-linux-musl'
         env:
           NAUKA_VERSION: ${{ needs.version.outputs.next }}
-          OPENSSL_STATIC: '1'
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Build (cross)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,6 +1413,7 @@ dependencies = [
  "nauka-core",
  "nauka-hypervisor",
  "nauka-state",
+ "openssl",
  "rustls 0.23.37",
  "serde_json",
  "tokio",
@@ -1589,6 +1590,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.5+3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,6 +1606,7 @@ checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ axum = "0.8"
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 hyper = "1"
+openssl = { version = "0.10", features = ["vendored"] }

--- a/bin/nauka/Cargo.toml
+++ b/bin/nauka/Cargo.toml
@@ -29,3 +29,4 @@ rustls = { version = "0.23", features = ["ring"] }
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing-appender = "0.2"
+openssl.workspace = true


### PR DESCRIPTION
## Summary
- Add `openssl = { version = "0.10", features = ["vendored"] }` to workspace deps
- Removes need for system `libssl-dev` on musl targets
- Fixes cross-compilation for `aarch64-unknown-linux-musl`
- Removes now-unnecessary `OPENSSL_STATIC` env var from workflows

## Test plan
- [ ] CI passes (fmt, clippy, tests)
- [ ] Release (dev) musl build succeeds
- [ ] Release multi-arch build succeeds (x86_64-musl + aarch64-musl)