### PR TITLE
fix: add manual trigger to nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,11 +3,7 @@ name: Nightly
 on:
   push:
     branches: [main]
-    paths:
-      - 'layers/*/src/**'
-      - 'bin/*/src/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
Add `workflow_dispatch` to nightly workflow so it can be triggered manually from Actions tab.

Currently nightly only triggers on push to main with source code changes. This lets you run it on-demand.