### PR TITLE
feat: add self-update command with channel-aware updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,6 +632,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,8 +810,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -804,9 +823,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1027,6 +1048,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1295,7 +1317,10 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -1330,6 +1355,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -1409,13 +1440,17 @@ dependencies = [
  "anyhow",
  "axum 0.8.8",
  "clap",
+ "flate2",
  "http 1.4.0",
  "nauka-core",
  "nauka-hypervisor",
  "nauka-state",
  "openssl",
+ "reqwest",
  "rustls 0.23.37",
  "serde_json",
+ "sha2",
+ "tar",
  "tokio",
  "tower 0.5.3",
  "tracing",
@@ -1635,7 +1670,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1687,6 +1722,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -1796,6 +1837,61 @@ name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.37",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "quote"
@@ -1935,6 +2031,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2000,6 +2105,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2007,6 +2114,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.26.4",
  "tower 0.5.3",
  "tower-http",
  "tower-service",
@@ -2014,6 +2122,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2029,6 +2138,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2108,6 +2223,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2446,6 +2562,17 @@ name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
 
 [[package]]
 name = "tempfile"
@@ -3110,6 +3237,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3332,6 +3468,16 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/bin/nauka/Cargo.toml
+++ b/bin/nauka/Cargo.toml
@@ -30,3 +30,7 @@ tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing-appender = "0.2"
 openssl.workspace = true
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+sha2 = "0.10"
+flate2 = "1"
+tar = "0.4"

--- a/bin/nauka/src/main.rs
+++ b/bin/nauka/src/main.rs
@@ -3,6 +3,8 @@ use clap::Command;
 
 use nauka_core::resource::{dispatch, generate_command, ResourceRegistry};
 
+mod update;
+
 /// Build the resource registry with all known resources.
 fn build_registry() -> ResourceRegistry {
     let mut registry = ResourceRegistry::new();
@@ -68,9 +70,10 @@ async fn main() -> Result<()> {
 
     let mut app = Command::new("nauka")
         .about("Nauka — turn dedicated servers into a programmable cloud")
-        .version(env!("CARGO_PKG_VERSION"))
+        .version(option_env!("NAUKA_VERSION").unwrap_or(env!("CARGO_PKG_VERSION")))
         .subcommand_required(true)
         .arg_required_else_help(true)
+        .subcommand(update::command())
         .subcommand(
             Command::new("serve")
                 .about("Start the API server")
@@ -96,6 +99,7 @@ async fn main() -> Result<()> {
     let matches = app.get_matches();
 
     match matches.subcommand() {
+        Some(("update", sub_matches)) => update::run(sub_matches).await,
         Some(("serve", sub_matches)) => serve(sub_matches).await,
         Some((sub_name, sub_matches)) => {
             if let Some(reg) = registry.find(sub_name) {

--- a/bin/nauka/src/update.rs
+++ b/bin/nauka/src/update.rs
@@ -1,0 +1,282 @@
+//! Self-update command — downloads and replaces the running binary.
+//!
+//! Detects the current channel (nightly, beta, stable) from the embedded
+//! build version and stays on it by default. `--channel` overrides.
+
+use anyhow::{bail, Context, Result};
+use sha2::{Digest, Sha256};
+use std::io::Read;
+
+use nauka_core::version::{backup_current_binary, Channel, Version};
+
+const REPO: &str = "sifrah/nauka";
+const GITHUB_API: &str = "https://api.github.com";
+
+/// Build the `nauka update` clap command.
+pub fn command() -> clap::Command {
+    clap::Command::new("update")
+        .about("Update nauka to the latest version")
+        .arg(
+            clap::Arg::new("channel")
+                .long("channel")
+                .short('c')
+                .help("Target channel (nightly, beta, stable). Defaults to current channel")
+                .value_name("CHANNEL"),
+        )
+        .arg(
+            clap::Arg::new("force")
+                .long("force")
+                .short('f')
+                .help("Force update even if already up to date")
+                .action(clap::ArgAction::SetTrue),
+        )
+        .arg(
+            clap::Arg::new("yes")
+                .long("yes")
+                .short('y')
+                .help("Skip confirmation prompt")
+                .action(clap::ArgAction::SetTrue),
+        )
+}
+
+/// Run the self-update flow.
+pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
+    let current = Version::current();
+    let force = matches.get_flag("force");
+    let skip_confirm = matches.get_flag("yes");
+
+    // Determine target channel
+    let channel: Channel = match matches.get_one::<String>("channel") {
+        Some(ch) => ch.parse().map_err(|e| anyhow::anyhow!("{e}"))?,
+        None => current.channel,
+    };
+
+    eprintln!("  Current version: {current} ({channel})");
+
+    // Find latest release for channel
+    let (tag, version) = find_latest_release(channel).await?;
+    eprintln!("  Latest {channel}: {version}");
+
+    // Check if update is needed
+    if !force && !version.is_newer_than(&current) && channel == current.channel {
+        eprintln!("  Already up to date.");
+        return Ok(());
+    }
+
+    // Confirm
+    if !skip_confirm {
+        eprint!("  Update {current} -> {version}? [y/N] ");
+        let mut buf = String::new();
+        std::io::stdin().read_line(&mut buf)?;
+        if !buf.trim().eq_ignore_ascii_case("y") {
+            eprintln!("  Aborted.");
+            return Ok(());
+        }
+    }
+
+    // Detect platform
+    let target = detect_target()?;
+    let archive_name = format!("nauka-{tag}-{target}.tar.gz");
+    let archive_url = format!(
+        "https://github.com/{REPO}/releases/download/{tag}/{archive_name}"
+    );
+    let checksums_url = format!(
+        "https://github.com/{REPO}/releases/download/{tag}/SHA256SUMS.txt"
+    );
+
+    let client = reqwest::Client::builder()
+        .user_agent("nauka-self-update")
+        .build()?;
+
+    // Download archive
+    eprint!("  Downloading {archive_name}...");
+    let archive_bytes = client
+        .get(&archive_url)
+        .send()
+        .await?
+        .error_for_status()
+        .context("failed to download release archive")?
+        .bytes()
+        .await?;
+    eprintln!(" done ({:.1} MB)", archive_bytes.len() as f64 / 1_048_576.0);
+
+    // Download and verify checksum
+    eprint!("  Verifying checksum...");
+    let checksums_text = client
+        .get(&checksums_url)
+        .send()
+        .await?
+        .error_for_status()
+        .context("failed to download SHA256SUMS.txt")?
+        .text()
+        .await?;
+
+    let expected_hash = checksums_text
+        .lines()
+        .find(|line| line.contains(&archive_name))
+        .and_then(|line| line.split_whitespace().next())
+        .ok_or_else(|| anyhow::anyhow!("no checksum found for {archive_name}"))?;
+
+    let mut hasher = Sha256::new();
+    hasher.update(&archive_bytes);
+    let actual_hash = format!("{:x}", hasher.finalize());
+
+    if actual_hash != expected_hash {
+        bail!(
+            "checksum mismatch:\n  expected: {expected_hash}\n  actual:   {actual_hash}"
+        );
+    }
+    eprintln!(" ok");
+
+    // Extract binary from tarball
+    eprint!("  Extracting...");
+    let decoder = flate2::read::GzDecoder::new(&archive_bytes[..]);
+    let mut archive = tar::Archive::new(decoder);
+    let mut new_binary = Vec::new();
+
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let path = entry.path()?;
+        if path.file_name().and_then(|n| n.to_str()) == Some("nauka") {
+            entry.read_to_end(&mut new_binary)?;
+            break;
+        }
+    }
+
+    if new_binary.is_empty() {
+        bail!("archive does not contain 'nauka' binary");
+    }
+    eprintln!(" done");
+
+    // Backup current binary
+    eprint!("  Backing up current binary...");
+    backup_current_binary().map_err(|e| anyhow::anyhow!("{e}"))?;
+    eprintln!(" done");
+
+    // Replace current binary
+    eprint!("  Installing...");
+    let current_exe = std::env::current_exe()?;
+
+    // On Unix: remove then write (avoids "Text file busy")
+    std::fs::remove_file(&current_exe)
+        .context("failed to remove current binary")?;
+    std::fs::write(&current_exe, &new_binary)
+        .context("failed to write new binary")?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&current_exe, std::fs::Permissions::from_mode(0o755))?;
+    }
+
+    eprintln!(" done");
+    eprintln!("  Updated to {version}");
+
+    Ok(())
+}
+
+/// Find the latest GitHub release for a channel.
+/// Returns (tag, parsed version).
+async fn find_latest_release(channel: Channel) -> Result<(String, Version)> {
+    let client = reqwest::Client::builder()
+        .user_agent("nauka-self-update")
+        .build()?;
+
+    match channel {
+        Channel::Stable => {
+            // Use the /releases/latest endpoint (returns latest non-prerelease)
+            let url = format!("{GITHUB_API}/repos/{REPO}/releases/latest");
+            let release: serde_json::Value = client
+                .get(&url)
+                .header("Accept", "application/vnd.github+json")
+                .send()
+                .await?
+                .error_for_status()
+                .context("failed to fetch latest stable release")?
+                .json()
+                .await?;
+
+            let tag = release["tag_name"]
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("no tag_name in release response"))?
+                .to_string();
+            let version = Version::parse(&tag)?;
+            Ok((tag, version))
+        }
+        _ => {
+            // List recent releases and find the latest matching channel
+            let url = format!("{GITHUB_API}/repos/{REPO}/releases?per_page=30");
+            let releases: Vec<serde_json::Value> = client
+                .get(&url)
+                .header("Accept", "application/vnd.github+json")
+                .send()
+                .await?
+                .error_for_status()
+                .context("failed to fetch releases")?
+                .json()
+                .await?;
+
+            let channel_str = channel.as_str();
+            for release in &releases {
+                if let Some(tag) = release["tag_name"].as_str() {
+                    if tag.contains(channel_str) {
+                        let version = Version::parse(tag)?;
+                        if version.channel == channel {
+                            return Ok((tag.to_string(), version));
+                        }
+                    }
+                }
+            }
+
+            bail!("no {channel} release found");
+        }
+    }
+}
+
+/// Detect the target triple for the current platform.
+fn detect_target() -> Result<String> {
+    let arch = if cfg!(target_arch = "x86_64") {
+        "x86_64"
+    } else if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else {
+        bail!("unsupported architecture");
+    };
+
+    let os = if cfg!(target_os = "linux") {
+        "unknown-linux-musl"
+    } else if cfg!(target_os = "macos") {
+        "apple-darwin"
+    } else {
+        bail!("unsupported operating system");
+    };
+
+    Ok(format!("{arch}-{os}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_target_succeeds() {
+        let target = detect_target().unwrap();
+        assert!(
+            target.contains("apple-darwin") || target.contains("linux-musl"),
+            "unexpected target: {target}"
+        );
+    }
+
+    #[test]
+    fn update_command_parses() {
+        let cmd = command();
+        let matches = cmd
+            .try_get_matches_from(["update", "--channel", "nightly", "--force"])
+            .unwrap();
+        assert_eq!(
+            matches.get_one::<String>("channel").unwrap(),
+            "nightly"
+        );
+        assert!(matches.get_flag("force"));
+    }
+}

--- a/bin/nauka/src/update.rs
+++ b/bin/nauka/src/update.rs
@@ -77,12 +77,8 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     // Detect platform
     let target = detect_target()?;
     let archive_name = format!("nauka-{tag}-{target}.tar.gz");
-    let archive_url = format!(
-        "https://github.com/{REPO}/releases/download/{tag}/{archive_name}"
-    );
-    let checksums_url = format!(
-        "https://github.com/{REPO}/releases/download/{tag}/SHA256SUMS.txt"
-    );
+    let archive_url = format!("https://github.com/{REPO}/releases/download/{tag}/{archive_name}");
+    let checksums_url = format!("https://github.com/{REPO}/releases/download/{tag}/SHA256SUMS.txt");
 
     let client = reqwest::Client::builder()
         .user_agent("nauka-self-update")
@@ -122,9 +118,7 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     let actual_hash = format!("{:x}", hasher.finalize());
 
     if actual_hash != expected_hash {
-        bail!(
-            "checksum mismatch:\n  expected: {expected_hash}\n  actual:   {actual_hash}"
-        );
+        bail!("checksum mismatch:\n  expected: {expected_hash}\n  actual:   {actual_hash}");
     }
     eprintln!(" ok");
 
@@ -158,10 +152,8 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     let current_exe = std::env::current_exe()?;
 
     // On Unix: remove then write (avoids "Text file busy")
-    std::fs::remove_file(&current_exe)
-        .context("failed to remove current binary")?;
-    std::fs::write(&current_exe, &new_binary)
-        .context("failed to write new binary")?;
+    std::fs::remove_file(&current_exe).context("failed to remove current binary")?;
+    std::fs::write(&current_exe, &new_binary).context("failed to write new binary")?;
 
     #[cfg(unix)]
     {
@@ -273,10 +265,7 @@ mod tests {
         let matches = cmd
             .try_get_matches_from(["update", "--channel", "nightly", "--force"])
             .unwrap();
-        assert_eq!(
-            matches.get_one::<String>("channel").unwrap(),
-            "nightly"
-        );
+        assert_eq!(matches.get_one::<String>("channel").unwrap(), "nightly");
         assert!(matches.get_flag("force"));
     }
 }

--- a/layers/core/src/version.rs
+++ b/layers/core/src/version.rs
@@ -144,8 +144,7 @@ impl Version {
     /// CI sets `NAUKA_VERSION` (e.g. `2.0.0-nightly.5`) at compile time.
     /// Falls back to `CARGO_PKG_VERSION` for local builds.
     pub fn current() -> Self {
-        let version_str =
-            option_env!("NAUKA_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
+        let version_str = option_env!("NAUKA_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
         Self::parse(version_str).unwrap_or(Self {
             major: 0,
             minor: 0,

--- a/layers/core/src/version.rs
+++ b/layers/core/src/version.rs
@@ -1,7 +1,7 @@
 //! Version management and update channels.
 //!
-//! Supports 4 channels: dev, beta, rc, stable.
-//! Versions are semver with channel suffix: `v2.1.0-dev.47`, `v2.1.0`, etc.
+//! Supports 4 channels: nightly, beta, rc, stable.
+//! Versions are semver with channel suffix: `v2.1.0-nightly.47`, `v2.1.0`, etc.
 //!
 //! ```
 //! use nauka_core::version::{Version, Channel};
@@ -24,7 +24,7 @@ use crate::error::NaukaError;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Channel {
-    Dev,
+    Nightly,
     Beta,
     Rc,
     Stable,
@@ -34,7 +34,7 @@ impl Channel {
     /// Stability rank (higher = more stable).
     pub fn rank(&self) -> u8 {
         match self {
-            Self::Dev => 0,
+            Self::Nightly => 0,
             Self::Beta => 1,
             Self::Rc => 2,
             Self::Stable => 3,
@@ -43,7 +43,7 @@ impl Channel {
 
     pub fn as_str(&self) -> &'static str {
         match self {
-            Self::Dev => "dev",
+            Self::Nightly => "nightly",
             Self::Beta => "beta",
             Self::Rc => "rc",
             Self::Stable => "stable",
@@ -61,12 +61,12 @@ impl FromStr for Channel {
     type Err = NaukaError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
-            "dev" => Ok(Self::Dev),
+            "nightly" | "dev" => Ok(Self::Nightly),
             "beta" => Ok(Self::Beta),
             "rc" => Ok(Self::Rc),
             "stable" | "latest" => Ok(Self::Stable),
             _ => Err(NaukaError::validation(format!(
-                "unknown channel '{s}'. Must be: dev, beta, rc, stable"
+                "unknown channel '{s}'. Must be: nightly, beta, rc, stable"
             ))),
         }
     }
@@ -140,12 +140,17 @@ impl Version {
     }
 
     /// Current binary version (injected at build time or from Cargo.toml).
+    ///
+    /// CI sets `NAUKA_VERSION` (e.g. `2.0.0-nightly.5`) at compile time.
+    /// Falls back to `CARGO_PKG_VERSION` for local builds.
     pub fn current() -> Self {
-        Self::parse(env!("CARGO_PKG_VERSION")).unwrap_or(Self {
+        let version_str =
+            option_env!("NAUKA_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
+        Self::parse(version_str).unwrap_or(Self {
             major: 0,
             minor: 0,
             patch: 0,
-            channel: Channel::Dev,
+            channel: Channel::Nightly,
             build: 0,
         })
     }
@@ -353,7 +358,8 @@ mod tests {
 
     #[test]
     fn channel_parse() {
-        assert_eq!("dev".parse::<Channel>().unwrap(), Channel::Dev);
+        assert_eq!("nightly".parse::<Channel>().unwrap(), Channel::Nightly);
+        assert_eq!("dev".parse::<Channel>().unwrap(), Channel::Nightly);
         assert_eq!("beta".parse::<Channel>().unwrap(), Channel::Beta);
         assert_eq!("rc".parse::<Channel>().unwrap(), Channel::Rc);
         assert_eq!("stable".parse::<Channel>().unwrap(), Channel::Stable);
@@ -367,7 +373,7 @@ mod tests {
 
     #[test]
     fn channel_rank() {
-        assert!(Channel::Dev.rank() < Channel::Beta.rank());
+        assert!(Channel::Nightly.rank() < Channel::Beta.rank());
         assert!(Channel::Beta.rank() < Channel::Rc.rank());
         assert!(Channel::Rc.rank() < Channel::Stable.rank());
     }
@@ -393,9 +399,16 @@ mod tests {
     }
 
     #[test]
-    fn parse_dev() {
+    fn parse_nightly() {
+        let v = Version::parse("2.1.0-nightly.47").unwrap();
+        assert_eq!(v.channel, Channel::Nightly);
+        assert_eq!(v.build, 47);
+    }
+
+    #[test]
+    fn parse_dev_alias() {
         let v = Version::parse("2.1.0-dev.47").unwrap();
-        assert_eq!(v.channel, Channel::Dev);
+        assert_eq!(v.channel, Channel::Nightly);
         assert_eq!(v.build, 47);
     }
 
@@ -458,19 +471,19 @@ mod tests {
 
     #[test]
     fn ordering_channel() {
-        let dev = Version::parse("2.1.0-dev.1").unwrap();
+        let nightly = Version::parse("2.1.0-nightly.1").unwrap();
         let beta = Version::parse("2.1.0-beta.1").unwrap();
         let rc = Version::parse("2.1.0-rc.1").unwrap();
         let stable = Version::parse("2.1.0").unwrap();
-        assert!(dev < beta);
+        assert!(nightly < beta);
         assert!(beta < rc);
         assert!(rc < stable);
     }
 
     #[test]
     fn ordering_build() {
-        let a = Version::parse("2.1.0-dev.1").unwrap();
-        let b = Version::parse("2.1.0-dev.47").unwrap();
+        let a = Version::parse("2.1.0-nightly.1").unwrap();
+        let b = Version::parse("2.1.0-nightly.47").unwrap();
         assert!(b > a);
     }
 
@@ -510,7 +523,7 @@ mod tests {
 
     #[test]
     fn is_prerelease() {
-        assert!(Version::parse("2.0.0-dev.1").unwrap().is_prerelease());
+        assert!(Version::parse("2.0.0-nightly.1").unwrap().is_prerelease());
         assert!(Version::parse("2.0.0-beta.1").unwrap().is_prerelease());
         assert!(!Version::parse("2.0.0").unwrap().is_prerelease());
     }
@@ -602,12 +615,12 @@ mod tests {
 
     #[test]
     fn version_diff_channel_change() {
-        let from = Version::parse("2.1.0-dev.47").unwrap();
+        let from = Version::parse("2.1.0-nightly.47").unwrap();
         let to = Version::parse("2.1.0-beta.1").unwrap();
         let diff = VersionDiff::between(&from, &to);
         assert!(diff.channel_change.is_some());
         let (from_ch, to_ch) = diff.channel_change.unwrap();
-        assert_eq!(from_ch, "dev");
+        assert_eq!(from_ch, "nightly");
         assert_eq!(to_ch, "beta");
     }
 


### PR DESCRIPTION
## Summary
- Adds `nauka update` command that downloads and replaces the running binary from GitHub Releases
- Detects current channel (nightly/beta/stable) from `NAUKA_VERSION` env var embedded at build time, stays on it by default
- Supports `--channel` override to switch channels, `--force` to re-download, `--yes` to skip confirmation
- Renames `Channel::Dev` to `Channel::Nightly` to align with CI tags and user-facing terminology
- Includes SHA256 checksum verification and backup before replacement

## Test plan
- [x] `cargo build` passes
- [x] `cargo clippy` clean
- [x] `cargo test -p nauka-core -- version` — all 38 version tests pass
- [x] `cargo test -p nauka -- update` — update module tests pass
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)