### PR TITLE
fix: recompile when NAUKA_VERSION env var changes

### DIFF
--- a/bin/nauka/build.rs
+++ b/bin/nauka/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    // Re-run this build script (and recompile the crate) whenever
+    // NAUKA_VERSION changes. Without this, cargo may serve a cached
+    // build that has a stale option_env!("NAUKA_VERSION") value.
+    println!("cargo::rerun-if-env-changed=NAUKA_VERSION");
+}

--- a/layers/core/build.rs
+++ b/layers/core/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    // Re-run this build script (and recompile the crate) whenever
+    // NAUKA_VERSION changes. Without this, cargo may serve a cached
+    // build that has a stale option_env!("NAUKA_VERSION") value.
+    println!("cargo::rerun-if-env-changed=NAUKA_VERSION");
+}


### PR DESCRIPTION
## Summary
- Adds `build.rs` to `nauka-core` and `bin/nauka` with `cargo::rerun-if-env-changed=NAUKA_VERSION`
- Without this, CI's Rust cache (`Swatinem/rust-cache`) can serve a stale `option_env!("NAUKA_VERSION")`, making `--version` show `2.0.0` instead of the real nightly/beta version

## Test plan
- [x] `NAUKA_VERSION=0.0.1-nightly.99 cargo build && ./target/debug/nauka --version` → `nauka 0.0.1-nightly.99`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)