### PR TITLE
fix: install script picks highest version, not first API match

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -105,8 +105,8 @@ if [ "$CHANNEL" = "stable" ]; then
 else
   start_spinner "Fetching latest ${CHANNEL} release..."
   VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=30" \
-    | grep '"tag_name"' | grep "${CHANNEL}" | head -1 \
-    | sed 's/.*"tag_name": *"//;s/".*//')" || true
+    | grep '"tag_name"' | grep "${CHANNEL}" \
+    | sed 's/.*"tag_name": *"//;s/".*//' | sort -V | tail -1)" || true
   if [ -z "$VERSION" ]; then
     stop_spinner "No ${CHANNEL} release found" fail
     exit 1


### PR DESCRIPTION
## Summary
- Same bug as PR #10 but in `scripts/install.sh`
- `head -1` took the first GitHub API match instead of the highest version
- Fix: `sort -V | tail -1` to pick the highest version tag

## Test plan
- [ ] `curl ... | sh -s -- --nightly` installs the latest nightly, not an older one