### PR TITLE
fix: improve fabric reliability

### DIFF
--- a/layers/hypervisor/src/fabric/health.rs
+++ b/layers/hypervisor/src/fabric/health.rs
@@ -22,6 +22,11 @@ pub const DEFAULT_INTERVAL_SECS: u64 = 30;
 /// so 5 minutes without one means the peer is likely down.
 pub const DEFAULT_STALE_THRESHOLD_SECS: u64 = 300;
 
+/// Grace period for newly added peers (5 minutes).
+/// A peer that was just added hasn't had time to establish a WireGuard
+/// handshake yet — don't mark it unreachable until the grace period expires.
+pub const NEW_PEER_GRACE_SECS: u64 = 300;
+
 /// Result of a single health check sweep.
 #[derive(Debug, Clone)]
 pub struct HealthCheckResult {
@@ -81,6 +86,12 @@ pub fn check_once(
     for peer in &mut state.peers.peers {
         let was_active = peer.is_active();
 
+        // Grace period: don't mark a newly added peer as unreachable
+        // if it hasn't had time to establish a WireGuard handshake yet.
+        let is_new_peer = peer.last_handshake == 0
+            && peer.added_at > 0
+            && now.saturating_sub(peer.added_at) < NEW_PEER_GRACE_SECS;
+
         if let Some(wg_peer) = handshakes
             .iter()
             .find(|h| h.public_key == peer.wg_public_key)
@@ -91,9 +102,15 @@ pub fn check_once(
                 && now.saturating_sub(wg_peer.latest_handshake) <= stale_threshold_secs
             {
                 peer.status = super::peer::PeerStatus::Active;
+            } else if is_new_peer {
+                // Keep Active during grace period — handshake not yet expected
+                peer.status = super::peer::PeerStatus::Active;
             } else {
                 peer.status = super::peer::PeerStatus::Unreachable;
             }
+        } else if is_new_peer {
+            // Not in WireGuard yet, but just added — give it time
+            peer.status = super::peer::PeerStatus::Active;
         } else {
             // Peer not in WireGuard at all — unreachable
             peer.status = super::peer::PeerStatus::Unreachable;

--- a/layers/hypervisor/src/fabric/ops.rs
+++ b/layers/hypervisor/src/fabric/ops.rs
@@ -185,11 +185,17 @@ pub async fn listen_for_peers(
     super::peering_server::listen(db_opener, pin, bind_addr, timeout, 0).await
 }
 
-/// Periodic full mesh reconciliation.
+/// Reconciliation interval in seconds (matches the sleep in the spawned task).
+const RECONCILE_INTERVAL_SECS: u64 = 30;
+
+/// Periodic mesh reconciliation.
 ///
-/// Reads the complete peer list and announces every peer to every other peer.
-/// Idempotent — peers that already know each other skip the announce.
-/// Runs on the peering node to guarantee eventual full mesh convergence.
+/// Only announces peers whose `added_at` falls within the last two
+/// reconciliation intervals — recently joined nodes that other peers
+/// may not have learned about yet. This keeps the cost proportional
+/// to the join rate (O(new × n)) instead of the total mesh size (O(n²)).
+///
+/// Idempotent — known peers are skipped by the announce handler.
 async fn reconcile_mesh(wg_port: u16) {
     let db = {
         let dir = nauka_core::process::nauka_dir();
@@ -208,8 +214,27 @@ async fn reconcile_mesh(wg_port: u16) {
         return; // nothing to reconcile with 0 or 1 peer
     }
 
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    // Only announce peers added in the last 2 intervals (with margin).
+    let recent_cutoff = now.saturating_sub(RECONCILE_INTERVAL_SECS * 2);
+
+    let recent_peers: Vec<_> = state
+        .peers
+        .peers
+        .iter()
+        .filter(|p| p.added_at >= recent_cutoff)
+        .collect();
+
+    if recent_peers.is_empty() {
+        return; // no new peers to announce
+    }
+
     let mut total_sent = 0usize;
-    for peer in &state.peers.peers {
+    for peer in &recent_peers {
         let info = super::peering::PeerInfo {
             name: peer.name.clone(),
             region: peer.region.clone(),
@@ -233,7 +258,11 @@ async fn reconcile_mesh(wg_port: u16) {
     }
 
     if total_sent > 0 {
-        tracing::info!(announcements = total_sent, "mesh reconciliation complete");
+        tracing::info!(
+            announcements = total_sent,
+            recent_peers = recent_peers.len(),
+            "mesh reconciliation complete"
+        );
     }
 }
 
@@ -510,21 +539,42 @@ pub fn stop(db: &LayerDb) -> Result<(), NaukaError> {
     backend.stop()
 }
 
+/// Number of removal broadcast attempts before giving up.
+const LEAVE_BROADCAST_ATTEMPTS: usize = 2;
+/// Delay between removal broadcast retries.
+const LEAVE_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
+
 /// Leave the cluster — notify peers, uninstall service, remove state.
 pub async fn leave(db: &LayerDb) -> Result<(), NaukaError> {
-    // Notify peers before tearing down (best-effort, over mesh)
+    // Notify peers before tearing down (best-effort, over mesh).
+    // Retry once so transient failures don't leave peers thinking we're still around.
     if let Some(state) = FabricState::load(db).ok().flatten() {
         if !state.peers.is_empty() {
             let peers: Vec<_> = state.peers.peers.clone();
-            let (ok, fail) = super::announce::broadcast_peer_remove(
-                &state.hypervisor.name,
-                &state.hypervisor.wg_public_key,
-                &peers,
-                state.hypervisor.wg_port,
-            )
-            .await;
-            if ok > 0 || fail > 0 {
-                tracing::info!(successes = ok, failures = fail, "peer removal broadcast");
+            let remaining = peers.clone();
+
+            for attempt in 1..=LEAVE_BROADCAST_ATTEMPTS {
+                let (ok, fail) = super::announce::broadcast_peer_remove(
+                    &state.hypervisor.name,
+                    &state.hypervisor.wg_public_key,
+                    &remaining,
+                    state.hypervisor.wg_port,
+                )
+                .await;
+                tracing::info!(
+                    attempt,
+                    successes = ok,
+                    failures = fail,
+                    "peer removal broadcast"
+                );
+
+                if fail == 0 || attempt == LEAVE_BROADCAST_ATTEMPTS {
+                    break;
+                }
+
+                // Retry only the peers that failed
+                // broadcast_peer_remove doesn't return which failed, so wait and retry all remaining
+                tokio::time::sleep(LEAVE_RETRY_DELAY).await;
             }
         }
 

--- a/layers/hypervisor/src/fabric/peering_server.rs
+++ b/layers/hypervisor/src/fabric/peering_server.rs
@@ -272,7 +272,15 @@ async fn handle_join(
         .add(new_peer)
         .map_err(|e| NaukaError::internal(format!("peer add failed: {e}")))?;
 
-    // Update WireGuard FIRST — if this fails, state is unchanged
+    // Save state FIRST — state is the source of truth.
+    // If the process crashes after this point, WireGuard will be reconciled
+    // from state on the next `wg-quick up` / service restart.
+    state
+        .save(db)
+        .map_err(|e| NaukaError::internal(e.to_string()))?;
+
+    // Update WireGuard config. If this fails, state is still correct and
+    // WG will catch up on next restart — log a warning but don't fail the join.
     let peers_for_wg: Vec<_> = state
         .peers
         .peers
@@ -287,17 +295,14 @@ async fn handle_join(
         })
         .collect();
 
-    service::update_config(
+    if let Err(e) = service::update_config(
         &state.hypervisor.wg_private_key,
         state.hypervisor.wg_port,
         &state.hypervisor.mesh_ipv6,
         &peers_for_wg,
-    )?;
-
-    // Save state AFTER WireGuard succeeds — no split-brain
-    state
-        .save(db)
-        .map_err(|e| NaukaError::internal(e.to_string()))?;
+    ) {
+        tracing::warn!(error = %e, "WireGuard config update failed (will reconcile on restart)");
+    }
 
     let announcer_name = state.hypervisor.name.clone();
     let wg_port = state.hypervisor.wg_port;


### PR DESCRIPTION
## Summary
- **State-first ordering** in peering server: save state before updating WireGuard config to prevent split-brain on crash (state is source of truth, WG reconciles on restart)
- **Health check grace period**: newly added peers get 5min before being marked unreachable (time to establish WG handshake)
- **Reconciliation O(n²) → O(new × n)**: only announce peers added in the last 60s instead of re-announcing the entire mesh every 30s
- **Leave broadcast retry**: 2 attempts with 2s delay so peers learn about departures more reliably

## Test plan
- [x] `cargo build` — clean
- [x] `cargo clippy` — clean
- [x] `cargo test` — 113 passed (1 pre-existing failure unrelated: `doctor::disk_free_check` on macOS)
- [ ] Deploy 2+ node cluster, verify join flow persists state before WG update
- [ ] Kill peering server mid-join, verify state is consistent on restart
- [ ] Verify newly joined peer stays Active during grace period in `nauka hv status`
- [ ] Verify large cluster doesn't over-announce after reconciliation stabilizes
- [ ] Verify `nauka hv leave` notifies peers on first or second attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)