### PR TITLE
feat: UX improvements — green ✓, Steps, parallel announce

### DIFF
--- a/bin/nauka/src/update.rs
+++ b/bin/nauka/src/update.rs
@@ -7,6 +7,7 @@ use anyhow::{bail, Context, Result};
 use sha2::{Digest, Sha256};
 use std::io::Read;
 
+use nauka_core::ui;
 use nauka_core::version::{backup_current_binary, Channel, Version};
 
 const REPO: &str = "sifrah/nauka";
@@ -84,8 +85,10 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         .user_agent("nauka-self-update")
         .build()?;
 
+    let steps = ui::Steps::new(4);
+
     // Download archive
-    eprint!("  Downloading {archive_name}...");
+    steps.set(&format!("Downloading {archive_name}"));
     let archive_bytes = client
         .get(&archive_url)
         .send()
@@ -94,10 +97,10 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         .context("failed to download release archive")?
         .bytes()
         .await?;
-    eprintln!(" done ({:.1} MB)", archive_bytes.len() as f64 / 1_048_576.0);
+    steps.inc();
 
     // Download and verify checksum
-    eprint!("  Verifying checksum...");
+    steps.set("Verifying checksum");
     let checksums_text = client
         .get(&checksums_url)
         .send()
@@ -118,12 +121,13 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     let actual_hash = format!("{:x}", hasher.finalize());
 
     if actual_hash != expected_hash {
+        steps.finish_err("Checksum mismatch");
         bail!("checksum mismatch:\n  expected: {expected_hash}\n  actual:   {actual_hash}");
     }
-    eprintln!(" ok");
+    steps.inc();
 
     // Extract binary from tarball
-    eprint!("  Extracting...");
+    steps.set("Extracting");
     let decoder = flate2::read::GzDecoder::new(&archive_bytes[..]);
     let mut archive = tar::Archive::new(decoder);
     let mut new_binary = Vec::new();
@@ -138,17 +142,16 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     }
 
     if new_binary.is_empty() {
+        steps.finish_err("Binary not found in archive");
         bail!("archive does not contain 'nauka' binary");
     }
-    eprintln!(" done");
 
     // Backup current binary
-    eprint!("  Backing up current binary...");
     backup_current_binary().map_err(|e| anyhow::anyhow!("{e}"))?;
-    eprintln!(" done");
+    steps.inc();
 
     // Replace current binary
-    eprint!("  Installing...");
+    steps.set("Installing");
     let current_exe = std::env::current_exe()?;
 
     // On Unix: remove then write (avoids "Text file busy")
@@ -160,9 +163,9 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(&current_exe, std::fs::Permissions::from_mode(0o755))?;
     }
+    steps.inc();
 
-    eprintln!(" done");
-    eprintln!("  Updated to {version}");
+    steps.finish(&format!("Updated to {version}"));
 
     Ok(())
 }

--- a/layers/core/src/ui/spinner.rs
+++ b/layers/core/src/ui/spinner.rs
@@ -17,31 +17,31 @@ pub fn spinner(msg: &str) -> ProgressBar {
     pb
 }
 
-/// Finish a spinner with a success message.
+/// Finish a spinner with a success message (green ✓).
 pub fn finish_ok(pb: &ProgressBar, msg: &str) {
     pb.set_style(
         ProgressStyle::default_spinner()
-            .template("  ✓  {msg}")
+            .template("  \x1b[32m✓\x1b[0m  {msg}")
             .unwrap(),
     );
     pb.finish_with_message(msg.to_string());
 }
 
-/// Finish a spinner with a success message + right-aligned detail.
+/// Finish a spinner with a success message + right-aligned detail (green ✓).
 pub fn finish_ok_detail(pb: &ProgressBar, msg: &str, detail: &str) {
     pb.set_style(
         ProgressStyle::default_spinner()
-            .template("  ✓  {msg}")
+            .template("  \x1b[32m✓\x1b[0m  {msg}")
             .unwrap(),
     );
     pb.finish_with_message(format!("{msg:<40} {detail}"));
 }
 
-/// Finish a spinner with a failure message.
+/// Finish a spinner with a failure message (red ✖).
 pub fn finish_fail(pb: &ProgressBar, msg: &str) {
     pb.set_style(
         ProgressStyle::default_spinner()
-            .template("  ✖  {msg}")
+            .template("  \x1b[31m✖\x1b[0m  {msg}")
             .unwrap(),
     );
     pb.finish_with_message(msg.to_string());
@@ -105,26 +105,32 @@ impl Steps {
         self.total
     }
 
-    /// Finish with a success message — replaces the whole line.
+    /// Finish with a success message — replaces the whole line (green ✓).
     pub fn finish(&self, msg: &str) {
         if self.is_tty {
             self.pb.set_position(self.total);
-            self.pb
-                .set_style(ProgressStyle::default_bar().template("  ✓  {msg}").unwrap());
+            self.pb.set_style(
+                ProgressStyle::default_bar()
+                    .template("  \x1b[32m✓\x1b[0m  {msg}")
+                    .unwrap(),
+            );
             self.pb.finish_with_message(msg.to_string());
         } else {
-            eprintln!("  {msg}");
+            eprintln!("  \x1b[32m✓\x1b[0m  {msg}");
         }
     }
 
-    /// Finish with a failure message.
+    /// Finish with a failure message (red ✖).
     pub fn finish_err(&self, msg: &str) {
         if self.is_tty {
-            self.pb
-                .set_style(ProgressStyle::default_bar().template("  ✖  {msg}").unwrap());
+            self.pb.set_style(
+                ProgressStyle::default_bar()
+                    .template("  \x1b[31m✖\x1b[0m  {msg}")
+                    .unwrap(),
+            );
             self.pb.finish_with_message(msg.to_string());
         } else {
-            eprintln!("  {msg}");
+            eprintln!("  \x1b[31m✖\x1b[0m  {msg}");
         }
     }
 }
@@ -146,9 +152,13 @@ pub fn progress(msg: &str, total: u64) -> ProgressBar {
     pb
 }
 
-/// Finish a progress bar with a success message.
+/// Finish a progress bar with a success message (green ✓).
 pub fn progress_finish(pb: &ProgressBar, msg: &str) {
-    pb.set_style(ProgressStyle::default_bar().template("  ✓  {msg}").unwrap());
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template("  \x1b[32m✓\x1b[0m  {msg}")
+            .unwrap(),
+    );
     pb.finish_with_message(msg.to_string());
 }
 

--- a/layers/hypervisor/src/fabric/announce.rs
+++ b/layers/hypervisor/src/fabric/announce.rs
@@ -34,11 +34,11 @@ pub const ANNOUNCE_PORT_OFFSET: u16 = 2;
 /// Default timeout for each announce connection.
 const ANNOUNCE_TIMEOUT_SECS: u64 = 5;
 
-/// Broadcast a new peer to all existing peers.
+/// Broadcast a new peer to all existing peers (in parallel).
 ///
 /// Connects to each peer's announce port (mesh_ipv6:wg_port+2) and sends
 /// a PeerAnnounce message. Best-effort: failures are logged but don't
-/// stop the broadcast.
+/// stop the broadcast. Skips peers marked as unreachable.
 ///
 /// Returns (successes, failures).
 pub async fn broadcast_new_peer(
@@ -52,29 +52,47 @@ pub async fn broadcast_new_peer(
         announced_by: announced_by.to_string(),
     });
 
+    // Skip unreachable peers — no point waiting for a timeout
+    let reachable: Vec<_> = existing_peers
+        .iter()
+        .filter(|p| p.status != super::peer::PeerStatus::Unreachable)
+        .collect();
+
+    // Broadcast in parallel — don't let one dead peer block the rest
+    let mut handles = Vec::with_capacity(reachable.len());
+    for peer in &reachable {
+        let addr = format!("[{}]:{}", peer.mesh_ipv6, wg_port + ANNOUNCE_PORT_OFFSET);
+        let peer_name = peer.name.clone();
+        let new_peer_name = new_peer.name.clone();
+        let msg = msg.clone();
+        handles.push(tokio::spawn(async move {
+            match send_message(&addr, &msg).await {
+                Ok(()) => {
+                    tracing::info!(
+                        peer = %peer_name,
+                        new_peer = %new_peer_name,
+                        "announced new peer"
+                    );
+                    true
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        peer = %peer_name,
+                        error = %e,
+                        "failed to announce new peer"
+                    );
+                    false
+                }
+            }
+        }));
+    }
+
     let mut successes = 0;
     let mut failures = 0;
-
-    for peer in existing_peers {
-        let addr = format!("[{}]:{}", peer.mesh_ipv6, wg_port + ANNOUNCE_PORT_OFFSET);
-
-        match send_message(&addr, &msg).await {
-            Ok(()) => {
-                tracing::info!(
-                    peer = %peer.name,
-                    new_peer = %new_peer.name,
-                    "announced new peer"
-                );
-                successes += 1;
-            }
-            Err(e) => {
-                tracing::warn!(
-                    peer = %peer.name,
-                    error = %e,
-                    "failed to announce new peer"
-                );
-                failures += 1;
-            }
+    for handle in handles {
+        match handle.await {
+            Ok(true) => successes += 1,
+            _ => failures += 1,
         }
     }
 
@@ -106,7 +124,7 @@ async fn send_message(addr: &str, msg: &AnnounceMessage) -> Result<(), NaukaErro
     Ok(())
 }
 
-/// Broadcast a peer removal to all existing peers (best-effort).
+/// Broadcast a peer removal to all existing peers in parallel (best-effort).
 /// Called during `leave` before tearing down the network.
 pub async fn broadcast_peer_remove(
     name: &str,
@@ -119,20 +137,32 @@ pub async fn broadcast_peer_remove(
         wg_public_key: wg_public_key.to_string(),
     });
 
-    let mut successes = 0;
-    let mut failures = 0;
-
+    let mut handles = Vec::with_capacity(existing_peers.len());
     for peer in existing_peers {
         let addr = format!("[{}]:{}", peer.mesh_ipv6, wg_port + ANNOUNCE_PORT_OFFSET);
-        match send_message(&addr, &msg).await {
-            Ok(()) => {
-                tracing::info!(peer = %peer.name, leaving = %name, "sent peer removal");
-                successes += 1;
+        let peer_name = peer.name.clone();
+        let leaving_name = name.to_string();
+        let msg = msg.clone();
+        handles.push(tokio::spawn(async move {
+            match send_message(&addr, &msg).await {
+                Ok(()) => {
+                    tracing::info!(peer = %peer_name, leaving = %leaving_name, "sent peer removal");
+                    true
+                }
+                Err(e) => {
+                    tracing::warn!(peer = %peer_name, error = %e, "failed to send peer removal");
+                    false
+                }
             }
-            Err(e) => {
-                tracing::warn!(peer = %peer.name, error = %e, "failed to send peer removal");
-                failures += 1;
-            }
+        }));
+    }
+
+    let mut successes = 0;
+    let mut failures = 0;
+    for handle in handles {
+        match handle.await {
+            Ok(true) => successes += 1,
+            _ => failures += 1,
         }
     }
 

--- a/layers/hypervisor/src/handlers.rs
+++ b/layers/hypervisor/src/handlers.rs
@@ -404,9 +404,9 @@ async fn handle_join(req: OperationRequest) -> anyhow::Result<OperationResponse>
         network_mode,
     };
 
-    // Join: 2 steps (fabric) + 4 steps (control plane) + 1 step (announce) = 7
+    // Join: 2 steps (fabric) + 3 steps (control plane) + 1 step (announce) = 6
     let step_count = if network_mode == fabric::NetworkMode::WireGuard {
-        7
+        6
     } else {
         3
     };
@@ -636,24 +636,34 @@ async fn handle_leave() -> anyhow::Result<OperationResponse> {
         .flatten()
         .map(|s| s.hypervisor.mesh_ipv6);
 
+    let steps = ui::Steps::new(4);
+
     // Storage first (stop ZeroFS instances)
+    steps.set("Stopping storage");
     let _ = storage::ops::leave();
+    steps.inc();
 
     // Controlplane (deregister TiKV store, then uninstall)
+    steps.set("Leaving control plane");
     if let Some(ipv6) = mesh_ipv6 {
         let _ = controlplane::ops::leave_with_mesh(&ipv6);
     } else {
         let _ = controlplane::ops::leave();
     }
+    steps.inc();
 
-    // Announce listener
+    // Notify peers + tear down mesh
+    steps.set("Notifying peers");
     let _ = fabric::announce::uninstall_service();
-
-    // Fabric last (notifies peers, then tears down mesh)
     fabric::ops::leave(&db).await?;
-    Ok(OperationResponse::Message(
-        "left the cluster. All services uninstalled.".into(),
-    ))
+    steps.inc();
+
+    // Final cleanup
+    steps.set("Removing services");
+    steps.inc();
+
+    steps.finish("Left the cluster");
+    Ok(OperationResponse::None)
 }
 
 async fn handle_list() -> anyhow::Result<OperationResponse> {


### PR DESCRIPTION
## Summary
- Green ✓ on success, red ✖ on failure (ANSI colors in spinner/Steps)
- Fix join step count (7→6 — `controlplane::ops::join` uses 3 steps, not 4)
- Add Steps progress bar to `leave` command (4 steps)
- Replace raw `eprint` with Steps in `update` command
- Announce broadcasts run in parallel (tokio::spawn per peer)
- Skip unreachable peers in `broadcast_new_peer`

## Test plan
- [x] `cargo build` / `cargo clippy` / `cargo test` — all clean
- [x] Deployed on 3 Hetzner VMs (HYPERVISOR, HYPERVISOR-1, HYPERVISOR-2)
- [x] `nauka hypervisor init --peering` — ✓ green, Steps work
- [x] `nauka hypervisor join` from 2 nodes — 6/6 steps, no stuck progress
- [x] `nauka hypervisor leave` — 4-step progress with ✓ green
- [x] 3-node mesh fully converged (all nodes see all peers)
- [x] Leave/rejoin cycle — peer removal broadcast received by all peers
- [x] No announce timeout warnings (parallel + skip unreachable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)