### PR TITLE
fix: 3rd node skipped PD (off-by-one), clean up join UX

### DIFF
--- a/layers/hypervisor/src/controlplane/ops.rs
+++ b/layers/hypervisor/src/controlplane/ops.rs
@@ -86,11 +86,12 @@ pub fn join(
 
     let primary_pd = &existing_pd_endpoints[0];
 
-    // Use peer count to decide: first 2 joiners run PD, rest run TiKV-only
-    // peer_count=1 means we're the 2nd node (1 peer = the init node)
-    // peer_count=2 means we're the 3rd node (2 peers)
-    // peer_count>=3 means 4th+ node → TiKV only
-    let run_pd = peer_count < (MAX_PD_MEMBERS - 1); // -1 because init node already has PD
+    // Use peer count to decide: first N-1 joiners run PD, rest run TiKV-only.
+    // Init node already has PD, so we need MAX_PD_MEMBERS - 1 more joiners with PD.
+    // peer_count=1 → 2nd node → PD (total PD: 2)
+    // peer_count=2 → 3rd node → PD (total PD: 3 = MAX_PD_MEMBERS)
+    // peer_count≥3 → 4th+ node → TiKV only
+    let run_pd = peer_count < MAX_PD_MEMBERS;
 
     if run_pd {
         steps.set(&format!(

--- a/layers/hypervisor/src/handlers.rs
+++ b/layers/hypervisor/src/handlers.rs
@@ -503,16 +503,13 @@ async fn handle_join(req: OperationRequest) -> anyhow::Result<OperationResponse>
             .map(|p| format!("http://[{}]:{}", p.mesh_ipv6, controlplane::PD_CLIENT_PORT))
             .collect();
         let peer_count = state.peers.len();
-        if let Err(e) = controlplane::ops::join(
+        controlplane::ops::join(
             &node_name,
             &result.hypervisor.mesh_ipv6,
             &pd_endpoints,
             peer_count,
             &steps,
-        ) {
-            tracing::warn!(error = %e, "control plane join issue (services may still be starting)");
-            steps.finish_err(&format!("Control plane setup incomplete: {e}"));
-        }
+        )?;
     }
 
     // Fetch region storage config from distributed KV and setup locally

--- a/layers/hypervisor/src/storage/ops.rs
+++ b/layers/hypervisor/src/storage/ops.rs
@@ -111,12 +111,12 @@ pub async fn fetch_region_config(
             Ok(db) => match db.get(TIKV_STORAGE_NS, region).await {
                 Ok(result) => return Ok(result),
                 Err(e) => {
-                    tracing::warn!(attempt, error = %e, "TiKV read failed, retrying...");
+                    tracing::debug!(attempt, error = %e, "TiKV read failed, retrying...");
                     last_err = Some(e);
                 }
             },
             Err(e) => {
-                tracing::warn!(attempt, error = %e, "TiKV connect failed, retrying...");
+                tracing::debug!(attempt, error = %e, "TiKV connect failed, retrying...");
                 last_err = Some(e);
             }
         }


### PR DESCRIPTION
## Summary
- **Off-by-one bug**: `run_pd` condition was `peer_count < MAX_PD_MEMBERS - 1`, excluding the 3rd node from running PD. Fixed to `peer_count < MAX_PD_MEMBERS`.
- **Control plane join is now fatal**: no more half-initialized state where mesh is up but TiKV is missing
- **TiKV retry logs demoted to DEBUG**: users no longer see `WARN` lines about leader election retries

## Root cause
The 3rd node (peer_count=2) fell into `join_tikv_only` instead of `join_with_pd`, causing:
1. PD connectivity check with only 30s timeout (instead of 120s)
2. No PD/TiKV installed on the node
3. Scary WARN messages visible to the user

## Test plan
- [x] `cargo build` + `cargo clippy` clean
- [x] Binary deployed to live HYPERVISOR + HYPERVISOR-2 for testing