### PR TITLE
fix: only show errors on stderr, warnings go to log file

### DIFF
--- a/bin/nauka/src/main.rs
+++ b/bin/nauka/src/main.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<()> {
                     fmt::layer()
                         .with_target(true)
                         .with_writer(std::io::stderr)
-                        .with_filter(EnvFilter::new("warn")),
+                        .with_filter(EnvFilter::new("error")),
                 );
             tracing::subscriber::set_global_default(subscriber).ok();
             Some(file_guard)


### PR DESCRIPTION
## Summary
- Change stderr tracing filter from `warn` to `error`
- Warnings (retries, announce failures, etc.) now only appear in `/var/log/nauka/nauka.log`
- Users only see actual errors on their terminal

Fixes confusing WARN messages during `peering` and `join`.