### PR TITLE
fix: announce broadcast used sender's port instead of peer's port

### DIFF
--- a/layers/hypervisor/src/fabric/announce.rs
+++ b/layers/hypervisor/src/fabric/announce.rs
@@ -61,7 +61,11 @@ pub async fn broadcast_new_peer(
     // Broadcast in parallel — don't let one dead peer block the rest
     let mut handles = Vec::with_capacity(reachable.len());
     for peer in &reachable {
-        let addr = format!("[{}]:{}", peer.mesh_ipv6, peer.wg_port + ANNOUNCE_PORT_OFFSET);
+        let addr = format!(
+            "[{}]:{}",
+            peer.mesh_ipv6,
+            peer.wg_port + ANNOUNCE_PORT_OFFSET
+        );
         let peer_name = peer.name.clone();
         let new_peer_name = new_peer.name.clone();
         let msg = msg.clone();
@@ -139,7 +143,11 @@ pub async fn broadcast_peer_remove(
 
     let mut handles = Vec::with_capacity(existing_peers.len());
     for peer in existing_peers {
-        let addr = format!("[{}]:{}", peer.mesh_ipv6, peer.wg_port + ANNOUNCE_PORT_OFFSET);
+        let addr = format!(
+            "[{}]:{}",
+            peer.mesh_ipv6,
+            peer.wg_port + ANNOUNCE_PORT_OFFSET
+        );
         let peer_name = peer.name.clone();
         let leaving_name = name.to_string();
         let msg = msg.clone();

--- a/layers/hypervisor/src/fabric/announce.rs
+++ b/layers/hypervisor/src/fabric/announce.rs
@@ -45,7 +45,7 @@ pub async fn broadcast_new_peer(
     new_peer: &PeerInfo,
     announced_by: &str,
     existing_peers: &[Peer],
-    wg_port: u16,
+    _wg_port: u16,
 ) -> (usize, usize) {
     let msg = AnnounceMessage::Announce(PeerAnnounce {
         peer: new_peer.clone(),
@@ -61,7 +61,7 @@ pub async fn broadcast_new_peer(
     // Broadcast in parallel — don't let one dead peer block the rest
     let mut handles = Vec::with_capacity(reachable.len());
     for peer in &reachable {
-        let addr = format!("[{}]:{}", peer.mesh_ipv6, wg_port + ANNOUNCE_PORT_OFFSET);
+        let addr = format!("[{}]:{}", peer.mesh_ipv6, peer.wg_port + ANNOUNCE_PORT_OFFSET);
         let peer_name = peer.name.clone();
         let new_peer_name = new_peer.name.clone();
         let msg = msg.clone();
@@ -130,7 +130,7 @@ pub async fn broadcast_peer_remove(
     name: &str,
     wg_public_key: &str,
     existing_peers: &[Peer],
-    wg_port: u16,
+    _wg_port: u16,
 ) -> (usize, usize) {
     let msg = AnnounceMessage::Remove(PeerRemove {
         name: name.to_string(),
@@ -139,7 +139,7 @@ pub async fn broadcast_peer_remove(
 
     let mut handles = Vec::with_capacity(existing_peers.len());
     for peer in existing_peers {
-        let addr = format!("[{}]:{}", peer.mesh_ipv6, wg_port + ANNOUNCE_PORT_OFFSET);
+        let addr = format!("[{}]:{}", peer.mesh_ipv6, peer.wg_port + ANNOUNCE_PORT_OFFSET);
         let peer_name = peer.name.clone();
         let leaving_name = name.to_string();
         let msg = msg.clone();

--- a/layers/hypervisor/src/fabric/ops.rs
+++ b/layers/hypervisor/src/fabric/ops.rs
@@ -540,9 +540,9 @@ pub fn stop(db: &LayerDb) -> Result<(), NaukaError> {
 }
 
 /// Number of removal broadcast attempts before giving up.
-const LEAVE_BROADCAST_ATTEMPTS: usize = 2;
+const LEAVE_BROADCAST_ATTEMPTS: usize = 4;
 /// Delay between removal broadcast retries.
-const LEAVE_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
+const LEAVE_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(3);
 
 /// Leave the cluster — notify peers, uninstall service, remove state.
 pub async fn leave(db: &LayerDb) -> Result<(), NaukaError> {


### PR DESCRIPTION
## Summary
- **Root cause**: `broadcast_peer_remove` and `broadcast_new_peer` sent to `peer.mesh_ipv6:sender_wg_port+2` instead of `peer.mesh_ipv6:peer.wg_port+2`. If peers use different ports, announcements go to the wrong port.
- Fixed to use each peer's own `wg_port` for the announce address
- Increased leave broadcast retries: 2→4 attempts, 2s→3s delay

## Impact
This fixes ghost peers remaining in the list after `leave` — the PeerRemove notification was being sent to the wrong port.