### PR TITLE
feat(org): nested CLI hierarchy + REST API with scope extraction

### DIFF
--- a/bin/nauka/src/main.rs
+++ b/bin/nauka/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Command;
 
-use nauka_core::resource::{dispatch, generate_command, ResourceRegistry};
+use nauka_core::resource::{dispatch, generate_command_with_children, ResourceRegistry};
 
 mod update;
 
@@ -12,10 +12,8 @@ fn build_registry() -> ResourceRegistry {
     // Hypervisor — the core resource
     registry.register(nauka_hypervisor::handlers::registration());
 
-    // Org hierarchy
-    registry.register(nauka_org::handlers::org_registration());
-    registry.register(nauka_org::handlers::project_registration());
-    registry.register(nauka_org::handlers::env_registration());
+    // Org hierarchy (org → project → env)
+    registry.register(nauka_org::registration());
 
     registry
 }
@@ -94,9 +92,11 @@ async fn main() -> Result<()> {
                 ),
         );
 
-    // Add resource subcommands (hypervisor, future: vm, vpc, etc.)
+    // Add resource subcommands (hypervisor, org, etc.)
     for reg in registry.iter() {
-        app = app.subcommand(generate_command(&reg.def));
+        let child_refs: Vec<&nauka_core::resource::ResourceRegistration> =
+            reg.children.iter().collect();
+        app = app.subcommand(generate_command_with_children(&reg.def, &child_refs));
     }
 
     let matches = app.get_matches();

--- a/layers/core/src/api/route_gen.rs
+++ b/layers/core/src/api/route_gen.rs
@@ -7,7 +7,7 @@
 
 use axum::extract::{Json, Path, Query};
 use axum::response::IntoResponse;
-use axum::routing::{get, post, MethodRouter};
+use axum::routing::{get, post};
 use axum::Router;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -18,126 +18,228 @@ use crate::resource::{
     OperationRequest, OperationResponse, OperationSemantics, ResourceRegistration, ScopeValues,
 };
 
-/// Build an axum Router from resource registrations.
+/// Build an axum Router from resource registrations (including children).
 ///
-/// For resources with scope parents, generates nested routes:
-/// `/{prefix}/{parent}/{parent_id}/{resource}` etc.
+/// Flattens the registration tree and generates routes for each resource.
+/// Children inherit their parent scope through their ResourceDef parents field.
 pub fn build_router(registrations: Vec<ResourceRegistration>, prefix: &str) -> Router {
+    // Flatten tree into a list of Arc<ResourceRegistration>
+    let mut all = Vec::new();
+    for reg in registrations {
+        flatten_registrations(reg, &mut all);
+    }
+
     let mut router = Router::new();
+    for reg in &all {
+        router = add_resource_routes(router, reg, prefix);
+    }
+    router
+}
 
-    let shared: Vec<Arc<ResourceRegistration>> = registrations.into_iter().map(Arc::new).collect();
+/// Flatten a registration tree into a flat list.
+fn flatten_registrations(reg: ResourceRegistration, out: &mut Vec<Arc<ResourceRegistration>>) {
+    let ResourceRegistration {
+        def,
+        handler,
+        children,
+    } = reg;
+    for child in children {
+        flatten_registrations(child, out);
+    }
+    out.push(Arc::new(ResourceRegistration {
+        def,
+        handler,
+        children: vec![],
+    }));
+}
 
-    for reg in &shared {
-        let kind = reg.def.identity.cli_name;
+/// Add routes for a single (flattened) resource.
+fn add_resource_routes(
+    mut router: Router,
+    reg: &Arc<ResourceRegistration>,
+    prefix: &str,
+) -> Router {
+    let kind = reg.def.identity.cli_name;
+    let parents = &reg.def.scope.parents;
+    let base = build_base_path(prefix, kind, parents);
+    let has_parents = !parents.is_empty();
 
-        // #10: Build route path from scope parents
-        let base = build_base_path(prefix, kind, &reg.def.scope.parents);
+    // Collect parent param names for scope extraction
+    let parent_kinds: Vec<String> = parents.iter().map(|p| format!("{}_id", p.kind)).collect();
 
-        // Collect which methods we need on /{base} and /{base}/{id}
-        let mut collection_methods: Option<MethodRouter> = None;
-        let mut instance_methods: Option<MethodRouter> = None;
+    // ── Collection routes (list + create on /base) ──
 
-        for op in &reg.def.operations {
-            let r = Arc::clone(reg);
-            let op_name = op.name.to_string();
+    for op in &reg.def.operations {
+        let r = Arc::clone(reg);
+        let op_name = op.name.to_string();
+        let pkinds = parent_kinds.clone();
 
-            match &op.semantics {
-                // #3: List with pagination query params
-                OperationSemantics::List => {
-                    let name = op_name.clone();
-                    let handler = get(move |Query(params): Query<HashMap<String, String>>| {
-                        let r = Arc::clone(&r);
-                        let name = name.clone();
-                        async move { handle_operation(&r, &name, None, params).await }
-                    });
-                    collection_methods = Some(match collection_methods {
-                        Some(m) => m.merge(handler),
-                        None => handler,
-                    });
-                }
-                OperationSemantics::Create => {
-                    let name = op_name.clone();
-                    let handler = post(move |Json(body): Json<HashMap<String, String>>| {
-                        let r = Arc::clone(&r);
-                        let name = name.clone();
-                        async move {
-                            let resource_name = body.get("name").cloned();
-                            handle_operation(&r, &name, resource_name, body).await
-                        }
-                    });
-                    collection_methods = Some(match collection_methods {
-                        Some(m) => m.merge(handler),
-                        None => handler,
-                    });
-                }
-                // #11: GET and DELETE on same path — merged into one MethodRouter
-                OperationSemantics::Get => {
-                    let name = op_name.clone();
-                    let handler = get(move |Path(id): Path<String>| {
-                        let r = Arc::clone(&r);
-                        let name = name.clone();
-                        async move { handle_operation(&r, &name, Some(id), HashMap::new()).await }
-                    });
-                    instance_methods = Some(match instance_methods {
-                        Some(m) => m.merge(handler),
-                        None => handler,
-                    });
-                }
-                OperationSemantics::Delete => {
-                    let name = op_name.clone();
-                    let handler = axum::routing::delete(move |Path(id): Path<String>| {
-                        let r = Arc::clone(&r);
-                        let name = name.clone();
-                        async move { handle_operation(&r, &name, Some(id), HashMap::new()).await }
-                    });
-                    instance_methods = Some(match instance_methods {
-                        Some(m) => m.merge(handler),
-                        None => handler,
-                    });
-                }
-                OperationSemantics::Update { .. } => {
-                    let name = op_name.clone();
-                    let handler = axum::routing::patch(
-                        move |Path(id): Path<String>, Json(body): Json<HashMap<String, String>>| {
+        match &op.semantics {
+            OperationSemantics::List => {
+                if has_parents {
+                    let handler = get(
+                        move |Path(path_params): Path<HashMap<String, String>>,
+                              Query(query): Query<HashMap<String, String>>| {
                             let r = Arc::clone(&r);
-                            let name = name.clone();
-                            async move { handle_operation(&r, &name, Some(id), body).await }
+                            let op = op_name.clone();
+                            let pk = pkinds.clone();
+                            async move {
+                                let scope = extract_scope(&path_params, &pk);
+                                handle_scoped(&r, &op, None, query, scope).await
+                            }
                         },
                     );
-                    instance_methods = Some(match instance_methods {
-                        Some(m) => m.merge(handler),
-                        None => handler,
+                    router = router.route(&base, handler);
+                } else {
+                    let handler = get(move |Query(query): Query<HashMap<String, String>>| {
+                        let r = Arc::clone(&r);
+                        let op = op_name.clone();
+                        async move { handle_scoped(&r, &op, None, query, ScopeValues::default()).await }
                     });
-                }
-                OperationSemantics::Action => {
-                    let name = op_name.clone();
-                    let route = format!("{base}/{}", op.name);
-                    router = router.route(
-                        &route,
-                        post(move |Json(body): Json<HashMap<String, String>>| {
-                            let r = Arc::clone(&r);
-                            let name = name.clone();
-                            async move {
-                                let resource_name = body.get("name").cloned();
-                                handle_operation(&r, &name, resource_name, body).await
-                            }
-                        }),
-                    );
+                    router = router.route(&base, handler);
                 }
             }
+            OperationSemantics::Create => {
+                if has_parents {
+                    let handler = post(
+                        move |Path(path_params): Path<HashMap<String, String>>,
+                              Json(body): Json<HashMap<String, String>>| {
+                            let r = Arc::clone(&r);
+                            let op = op_name.clone();
+                            let pk = pkinds.clone();
+                            async move {
+                                let scope = extract_scope(&path_params, &pk);
+                                let name = body.get("name").cloned();
+                                handle_scoped(&r, &op, name, body, scope).await
+                            }
+                        },
+                    );
+                    router = router.route(&base, handler);
+                } else {
+                    let handler = post(move |Json(body): Json<HashMap<String, String>>| {
+                        let r = Arc::clone(&r);
+                        let op = op_name.clone();
+                        async move {
+                            let name = body.get("name").cloned();
+                            handle_scoped(&r, &op, name, body, ScopeValues::default()).await
+                        }
+                    });
+                    router = router.route(&base, handler);
+                }
+            }
+            _ => {}
         }
+    }
 
-        // Register merged routes
-        if let Some(methods) = collection_methods {
-            router = router.route(&base, methods);
-        }
-        if let Some(methods) = instance_methods {
-            let instance_path = format!("{base}/{{id}}");
-            router = router.route(&instance_path, methods);
+    // ── Instance routes (get + delete on /base/{id}) ──
+
+    let instance_path = format!("{base}/{{id}}");
+
+    for op in &reg.def.operations {
+        let r = Arc::clone(reg);
+        let op_name = op.name.to_string();
+        let pkinds = parent_kinds.clone();
+
+        match &op.semantics {
+            OperationSemantics::Get => {
+                if has_parents {
+                    let handler = get(move |Path(path_params): Path<HashMap<String, String>>| {
+                        let r = Arc::clone(&r);
+                        let op = op_name.clone();
+                        let pk = pkinds.clone();
+                        async move {
+                            let scope = extract_scope(&path_params, &pk);
+                            let id = path_params.get("id").cloned();
+                            handle_scoped(&r, &op, id, HashMap::new(), scope).await
+                        }
+                    });
+                    router = router.route(&instance_path, handler);
+                } else {
+                    let handler = get(move |Path(id): Path<String>| {
+                        let r = Arc::clone(&r);
+                        let op = op_name.clone();
+                        async move {
+                            handle_scoped(&r, &op, Some(id), HashMap::new(), ScopeValues::default())
+                                .await
+                        }
+                    });
+                    router = router.route(&instance_path, handler);
+                }
+            }
+            OperationSemantics::Delete => {
+                if has_parents {
+                    let handler = axum::routing::delete(
+                        move |Path(path_params): Path<HashMap<String, String>>| {
+                            let r = Arc::clone(&r);
+                            let op = op_name.clone();
+                            let pk = pkinds.clone();
+                            async move {
+                                let scope = extract_scope(&path_params, &pk);
+                                let id = path_params.get("id").cloned();
+                                handle_scoped(&r, &op, id, HashMap::new(), scope).await
+                            }
+                        },
+                    );
+                    router = router.route(&instance_path, handler);
+                } else {
+                    let handler = axum::routing::delete(move |Path(id): Path<String>| {
+                        let r = Arc::clone(&r);
+                        let op = op_name.clone();
+                        async move {
+                            handle_scoped(&r, &op, Some(id), HashMap::new(), ScopeValues::default())
+                                .await
+                        }
+                    });
+                    router = router.route(&instance_path, handler);
+                }
+            }
+            OperationSemantics::Action => {
+                let route = format!("{base}/{}", op.name);
+                if has_parents {
+                    let handler = post(
+                        move |Path(path_params): Path<HashMap<String, String>>,
+                              Json(body): Json<HashMap<String, String>>| {
+                            let r = Arc::clone(&r);
+                            let op = op_name.clone();
+                            let pk = pkinds.clone();
+                            async move {
+                                let scope = extract_scope(&path_params, &pk);
+                                let name = body.get("name").cloned();
+                                handle_scoped(&r, &op, name, body, scope).await
+                            }
+                        },
+                    );
+                    router = router.route(&route, handler);
+                } else {
+                    let handler = post(move |Json(body): Json<HashMap<String, String>>| {
+                        let r = Arc::clone(&r);
+                        let op = op_name.clone();
+                        async move {
+                            let name = body.get("name").cloned();
+                            handle_scoped(&r, &op, name, body, ScopeValues::default()).await
+                        }
+                    });
+                    router = router.route(&route, handler);
+                }
+            }
+            _ => {}
         }
     }
 
     router
+}
+
+/// Extract scope values from path params (e.g., org_id → org).
+fn extract_scope(path_params: &HashMap<String, String>, parent_kinds: &[String]) -> ScopeValues {
+    let mut scope = ScopeValues::default();
+    for param in parent_kinds {
+        if let Some(value) = path_params.get(param) {
+            // param is "org_id" → scope key is "org"
+            let key = param.strip_suffix("_id").unwrap_or(param);
+            scope.set(key, value.clone());
+        }
+    }
+    scope
 }
 
 /// #10: Build a route path incorporating scope parents.
@@ -158,11 +260,13 @@ fn build_base_path(prefix: &str, kind: &str, parents: &[crate::resource::ParentR
     format!("{path}/{kind}")
 }
 
-async fn handle_operation(
+/// Handle an operation with scope values pre-populated.
+async fn handle_scoped(
     reg: &ResourceRegistration,
     operation: &str,
     name: Option<String>,
     fields: HashMap<String, String>,
+    scope: ScopeValues,
 ) -> impl IntoResponse {
     let op_def = reg.def.operations.iter().find(|o| o.name == operation);
     if let Some(op_def) = op_def {
@@ -176,7 +280,7 @@ async fn handle_operation(
     let request = OperationRequest {
         operation: operation.to_string(),
         name,
-        scope: ScopeValues::default(),
+        scope,
         fields,
     };
 
@@ -203,30 +307,39 @@ pub fn list_routes(registrations: &[ResourceRegistration], prefix: &str) -> Vec<
     let mut routes = Vec::new();
 
     for reg in registrations {
-        let kind = reg.def.identity.cli_name;
-        let base = build_base_path(prefix, kind, &reg.def.scope.parents);
-
-        for op in &reg.def.operations {
-            let (method, path) = match &op.semantics {
-                OperationSemantics::List => ("GET", base.clone()),
-                OperationSemantics::Create => ("POST", base.clone()),
-                OperationSemantics::Get => ("GET", format!("{base}/{{id}}")),
-                OperationSemantics::Delete => ("DELETE", format!("{base}/{{id}}")),
-                OperationSemantics::Update { .. } => ("PATCH", format!("{base}/{{id}}")),
-                OperationSemantics::Action => ("POST", format!("{base}/{}", op.name)),
-            };
-
-            routes.push(RouteInfo {
-                method: method.to_string(),
-                path,
-                operation: op.name.to_string(),
-                resource: kind.to_string(),
-                description: op.description.to_string(),
-            });
-        }
+        collect_routes(reg, prefix, &mut routes);
     }
 
     routes
+}
+
+fn collect_routes(reg: &ResourceRegistration, prefix: &str, routes: &mut Vec<RouteInfo>) {
+    let kind = reg.def.identity.cli_name;
+    let base = build_base_path(prefix, kind, &reg.def.scope.parents);
+
+    for op in &reg.def.operations {
+        let (method, path) = match &op.semantics {
+            OperationSemantics::List => ("GET", base.clone()),
+            OperationSemantics::Create => ("POST", base.clone()),
+            OperationSemantics::Get => ("GET", format!("{base}/{{id}}")),
+            OperationSemantics::Delete => ("DELETE", format!("{base}/{{id}}")),
+            OperationSemantics::Update { .. } => ("PATCH", format!("{base}/{{id}}")),
+            OperationSemantics::Action => ("POST", format!("{base}/{}", op.name)),
+        };
+
+        routes.push(RouteInfo {
+            method: method.to_string(),
+            path,
+            operation: op.name.to_string(),
+            resource: kind.to_string(),
+            description: op.description.to_string(),
+        });
+    }
+
+    // Recurse into children
+    for child in &reg.children {
+        collect_routes(child, prefix, routes);
+    }
 }
 
 /// #7: OpenAPI-compatible route listing.
@@ -311,7 +424,11 @@ mod tests {
             })
         });
 
-        ResourceRegistration { def, handler }
+        ResourceRegistration {
+            def,
+            handler,
+            children: vec![],
+        }
     }
 
     fn scoped_resource() -> ResourceRegistration {
@@ -332,7 +449,11 @@ mod tests {
         let handler: HandlerFn =
             Box::new(|_req| Box::pin(async move { Ok(OperationResponse::ResourceList(vec![])) }));
 
-        ResourceRegistration { def, handler }
+        ResourceRegistration {
+            def,
+            handler,
+            children: vec![],
+        }
     }
 
     // ── Route generation ──
@@ -413,26 +534,52 @@ mod tests {
         assert_eq!(path, "/v1/org/{org_id}/project/{project_id}/vpc");
     }
 
+    // ── Scope extraction ──
+
+    #[test]
+    fn extract_scope_from_path() {
+        let mut params = HashMap::new();
+        params.insert("org_id".to_string(), "org-123".to_string());
+        params.insert("project_id".to_string(), "proj-456".to_string());
+        let scope = extract_scope(&params, &["org_id".to_string(), "project_id".to_string()]);
+        assert_eq!(scope.get("org"), Some("org-123"));
+        assert_eq!(scope.get("project"), Some("proj-456"));
+    }
+
     // ── Handler ──
 
     #[tokio::test]
     async fn handle_operation_list() {
         let reg = test_resource();
-        let resp = handle_operation(&reg, "list", None, HashMap::new()).await;
+        let resp = handle_scoped(&reg, "list", None, HashMap::new(), ScopeValues::default()).await;
         assert!(resp.into_response().status().is_success());
     }
 
     #[tokio::test]
     async fn handle_operation_create() {
         let reg = test_resource();
-        let resp = handle_operation(&reg, "create", Some("w1".into()), HashMap::new()).await;
+        let resp = handle_scoped(
+            &reg,
+            "create",
+            Some("w1".into()),
+            HashMap::new(),
+            ScopeValues::default(),
+        )
+        .await;
         assert!(resp.into_response().status().is_success());
     }
 
     #[tokio::test]
     async fn handle_operation_delete() {
         let reg = test_resource();
-        let resp = handle_operation(&reg, "delete", Some("w1".into()), HashMap::new()).await;
+        let resp = handle_scoped(
+            &reg,
+            "delete",
+            Some("w1".into()),
+            HashMap::new(),
+            ScopeValues::default(),
+        )
+        .await;
         assert!(resp.into_response().status().is_success());
     }
 

--- a/layers/core/src/api/server.rs
+++ b/layers/core/src/api/server.rs
@@ -216,7 +216,11 @@ mod tests {
             })
         });
 
-        ResourceRegistration { def, handler }
+        ResourceRegistration {
+            def,
+            handler,
+            children: vec![],
+        }
     }
 
     #[test]

--- a/layers/core/src/resource/cli_gen.rs
+++ b/layers/core/src/resource/cli_gen.rs
@@ -7,6 +7,14 @@ use super::ResourceDef;
 
 /// Generate a complete clap [`Command`] from a [`ResourceDef`].
 pub fn generate_command(def: &ResourceDef) -> Command {
+    generate_command_with_children(def, &[])
+}
+
+/// Generate a command with child resource subcommands.
+pub fn generate_command_with_children(
+    def: &ResourceDef,
+    children: &[&super::registry::ResourceRegistration],
+) -> Command {
     let mut cmd = Command::new(def.identity.cli_name)
         .about(def.identity.description)
         .subcommand_required(true)
@@ -18,6 +26,13 @@ pub fn generate_command(def: &ResourceDef) -> Command {
 
     for op in &def.operations {
         cmd = cmd.subcommand(generate_operation(def, op));
+    }
+
+    // Add child resource subcommands (e.g., org → project → env)
+    for child in children {
+        let child_refs: Vec<&super::registry::ResourceRegistration> =
+            child.children.iter().collect();
+        cmd = cmd.subcommand(generate_command_with_children(&child.def, &child_refs));
     }
 
     cmd

--- a/layers/core/src/resource/dispatch.rs
+++ b/layers/core/src/resource/dispatch.rs
@@ -23,6 +23,16 @@ pub async fn dispatch(
     op_name: &str,
     matches: &ArgMatches,
 ) -> anyhow::Result<()> {
+    // Check if op_name is a child resource (e.g., "project" under "org")
+    if let Some(child) = reg
+        .children
+        .iter()
+        .find(|c| c.def.identity.cli_name == op_name || c.def.identity.aliases.contains(&op_name))
+    {
+        let (child_op, child_matches) = matches.subcommand().expect("subcommand enforced by clap");
+        return Box::pin(dispatch(child, child_op, child_matches)).await;
+    }
+
     let def = &reg.def;
     let op = def
         .operations

--- a/layers/core/src/resource/registry.rs
+++ b/layers/core/src/resource/registry.rs
@@ -80,10 +80,12 @@ pub type HandlerFn = Box<
         + Sync,
 >;
 
-/// A complete resource registration: definition + handler.
+/// A complete resource registration: definition + handler + children.
 pub struct ResourceRegistration {
     pub def: ResourceDef,
     pub handler: HandlerFn,
+    /// Child resources (e.g., org → project → env).
+    pub children: Vec<ResourceRegistration>,
 }
 
 /// The resource registry — holds all registered resources.

--- a/layers/core/tests/e2e/resource_framework_test.rs
+++ b/layers/core/tests/e2e/resource_framework_test.rs
@@ -37,7 +37,11 @@ fn test_resource() -> ResourceRegistration {
         })
     });
 
-    ResourceRegistration { def, handler }
+    ResourceRegistration {
+        def,
+        handler,
+        children: vec![],
+    }
 }
 
 #[test]

--- a/layers/core/tests/resource_framework.rs
+++ b/layers/core/tests/resource_framework.rs
@@ -382,6 +382,7 @@ fn registry_find_by_name() {
     reg.register(ResourceRegistration {
         def: test_resource(),
         handler: Box::new(|_| Box::pin(async { Ok(OperationResponse::None) })),
+        children: vec![],
     });
     assert!(reg.find("widget").is_some());
     assert!(reg.find("wdg").is_some());
@@ -395,6 +396,7 @@ fn registry_len() {
     reg.register(ResourceRegistration {
         def: test_resource(),
         handler: Box::new(|_| Box::pin(async { Ok(OperationResponse::None) })),
+        children: vec![],
     });
     assert_eq!(reg.len(), 1);
 }

--- a/layers/hypervisor/src/handlers.rs
+++ b/layers/hypervisor/src/handlers.rs
@@ -214,6 +214,7 @@ pub fn registration() -> ResourceRegistration {
     ResourceRegistration {
         def: resource_def(),
         handler: handler(),
+        children: vec![],
     }
 }
 

--- a/layers/org/src/handlers.rs
+++ b/layers/org/src/handlers.rs
@@ -1,62 +1,13 @@
-//! Resource definitions + handlers for Org, Project, Environment.
-//!
-//! Each ResourceDef auto-generates CLI commands (clap) and API routes (axum).
-//! Handlers are thin — they delegate to store operations.
+//! Org resource definition + handler.
 
 use std::future::Future;
 use std::pin::Pin;
 
 use nauka_core::resource::*;
-use nauka_hypervisor::controlplane;
-use nauka_hypervisor::fabric;
-use nauka_state::LocalDb;
 
 use crate::store::OrgStore;
 
-// ═══════════════════════════════════════════════════
-// Connect to ClusterDb via PD endpoints from fabric state
-// ═══════════════════════════════════════════════════
-
-async fn connect_store() -> anyhow::Result<OrgStore> {
-    let dir = nauka_core::process::nauka_dir();
-    let _ = std::fs::create_dir_all(&dir);
-    let db = LocalDb::open("hypervisor")?;
-
-    let state = fabric::state::FabricState::load(&db)
-        .map_err(|e| anyhow::anyhow!("{e}"))?
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "cluster not initialized.\n\n\
-                 Initialize a cluster first with:\n\
-                 \x20 nauka hypervisor init"
-            )
-        })?;
-
-    // Build PD endpoints from self + peers
-    let self_endpoint = format!(
-        "http://[{}]:{}",
-        state.hypervisor.mesh_ipv6,
-        controlplane::PD_CLIENT_PORT,
-    );
-    let mut endpoints = vec![self_endpoint];
-    for peer in &state.peers.peers {
-        endpoints.push(format!(
-            "http://[{}]:{}",
-            peer.mesh_ipv6,
-            controlplane::PD_CLIENT_PORT,
-        ));
-    }
-    let refs: Vec<&str> = endpoints.iter().map(|s| s.as_str()).collect();
-
-    let cluster_db = controlplane::ClusterDb::connect(&refs).await?;
-    Ok(OrgStore::new(cluster_db))
-}
-
-// ═══════════════════════════════════════════════════
-// Org
-// ═══════════════════════════════════════════════════
-
-fn org_def() -> ResourceDef {
+pub fn resource_def() -> ResourceDef {
     ResourceDef::build("org", "Manage organizations")
         .alias("organization")
         .plural("orgs")
@@ -77,333 +28,48 @@ fn org_def() -> ResourceDef {
         .done()
 }
 
-fn org_handler() -> HandlerFn {
+pub fn handler() -> HandlerFn {
     Box::new(
         |req: OperationRequest| -> Pin<
             Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
         > {
             Box::pin(async move {
+                let store = OrgStore::new(crate::connect_cluster_db().await?);
                 match req.operation.as_str() {
                     "create" => {
-                        let name = req
-                            .name
-                            .ok_or_else(|| anyhow::anyhow!("missing org name"))?;
+                        let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name"))?;
                         nauka_core::validate::name(&name)?;
-                        let store = connect_store().await?;
-                        let org = store.create_org(&name).await?;
+                        let org = store.create(&name).await?;
                         Ok(OperationResponse::Resource(serde_json::json!({
-                            "name": org.name,
-                            "id": org.id.as_str(),
+                            "name": org.name, "id": org.id.as_str(),
                             "created_at": org.created_at,
                         })))
                     }
                     "list" => {
-                        let store = connect_store().await?;
-                        let orgs = store.list_orgs().await?;
-                        let items: Vec<serde_json::Value> = orgs
-                            .iter()
-                            .map(|o| {
-                                serde_json::json!({
-                                    "name": o.name,
-                                    "id": o.id.as_str(),
-                                    "created_at": o.created_at,
-                                })
-                            })
-                            .collect();
+                        let orgs = store.list().await?;
+                        let items: Vec<serde_json::Value> = orgs.iter().map(|o| serde_json::json!({
+                            "name": o.name, "id": o.id.as_str(),
+                            "created_at": o.created_at,
+                        })).collect();
                         Ok(OperationResponse::ResourceList(items))
                     }
                     "get" => {
-                        let name = req
-                            .name
-                            .ok_or_else(|| anyhow::anyhow!("missing org name or ID"))?;
-                        let store = connect_store().await?;
-                        let org = store
-                            .get_org(&name)
-                            .await?
+                        let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name or ID"))?;
+                        let org = store.get(&name).await?
                             .ok_or_else(|| anyhow::anyhow!("org '{name}' not found"))?;
                         Ok(OperationResponse::Resource(serde_json::json!({
-                            "name": org.name,
-                            "id": org.id.as_str(),
+                            "name": org.name, "id": org.id.as_str(),
                             "created_at": org.created_at,
                         })))
                     }
                     "delete" => {
-                        let name = req
-                            .name
-                            .ok_or_else(|| anyhow::anyhow!("missing org name or ID"))?;
-                        let store = connect_store().await?;
-                        store.delete_org(&name).await?;
-                        Ok(OperationResponse::Message(format!(
-                            "org '{name}' deleted."
-                        )))
+                        let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name or ID"))?;
+                        store.delete(&name).await?;
+                        Ok(OperationResponse::Message(format!("org '{name}' deleted.")))
                     }
                     other => Ok(OperationResponse::Message(format!("unknown: {other}"))),
                 }
             })
         },
     )
-}
-
-pub fn org_registration() -> ResourceRegistration {
-    ResourceRegistration {
-        def: org_def(),
-        handler: org_handler(),
-    }
-}
-
-// ═══════════════════════════════════════════════════
-// Project
-// ═══════════════════════════════════════════════════
-
-fn project_def() -> ResourceDef {
-    ResourceDef::build("project", "Manage projects within an organization")
-        .plural("projects")
-        .parent("org", "--org", "Organization")
-        .crud()
-        .column("NAME", "name")
-        .column("ORG", "org_name")
-        .column("ID", "id")
-        .column_def(ColumnDef::new("CREATED", "created_at").with_format(DisplayFormat::Timestamp))
-        .empty_message(
-            "No projects found. Create one with: nauka project create <name> --org <org>",
-        )
-        .detail_section(
-            None,
-            vec![
-                DetailField::new("Name", "name"),
-                DetailField::new("ID", "id"),
-                DetailField::new("Organization", "org_name"),
-                DetailField::new("Created", "created_at").with_format(DisplayFormat::Timestamp),
-            ],
-        )
-        .done()
-}
-
-fn project_handler() -> HandlerFn {
-    Box::new(
-        |req: OperationRequest| -> Pin<
-            Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
-        > {
-            Box::pin(async move {
-                match req.operation.as_str() {
-                    "create" => {
-                        let name = req
-                            .name
-                            .ok_or_else(|| anyhow::anyhow!("missing project name"))?;
-                        let org = req
-                            .scope
-                            .get("org")
-                            .ok_or_else(|| anyhow::anyhow!("--org is required"))?
-                            .to_string();
-                        nauka_core::validate::name(&name)?;
-                        let store = connect_store().await?;
-                        let project = store.create_project(&name, &org).await?;
-                        Ok(OperationResponse::Resource(serde_json::json!({
-                            "name": project.name,
-                            "id": project.id.as_str(),
-                            "org_name": project.org_name,
-                            "created_at": project.created_at,
-                        })))
-                    }
-                    "list" => {
-                        let org = req.scope.get("org").map(|s| s.to_string());
-                        let store = connect_store().await?;
-                        let projects = store.list_projects(org.as_deref()).await?;
-                        let items: Vec<serde_json::Value> = projects
-                            .iter()
-                            .map(|p| {
-                                serde_json::json!({
-                                    "name": p.name,
-                                    "id": p.id.as_str(),
-                                    "org_name": p.org_name,
-                                    "created_at": p.created_at,
-                                })
-                            })
-                            .collect();
-                        Ok(OperationResponse::ResourceList(items))
-                    }
-                    "get" => {
-                        let name = req
-                            .name
-                            .ok_or_else(|| anyhow::anyhow!("missing project name or ID"))?;
-                        let org = req.scope.get("org").map(|s| s.to_string());
-                        let store = connect_store().await?;
-                        let project = store
-                            .get_project(&name, org.as_deref())
-                            .await?
-                            .ok_or_else(|| anyhow::anyhow!("project '{name}' not found"))?;
-                        Ok(OperationResponse::Resource(serde_json::json!({
-                            "name": project.name,
-                            "id": project.id.as_str(),
-                            "org_name": project.org_name,
-                            "created_at": project.created_at,
-                        })))
-                    }
-                    "delete" => {
-                        let name = req
-                            .name
-                            .ok_or_else(|| anyhow::anyhow!("missing project name or ID"))?;
-                        let org = req
-                            .scope
-                            .get("org")
-                            .ok_or_else(|| anyhow::anyhow!("--org is required"))?
-                            .to_string();
-                        let store = connect_store().await?;
-                        store.delete_project(&name, &org).await?;
-                        Ok(OperationResponse::Message(format!(
-                            "project '{name}' deleted."
-                        )))
-                    }
-                    other => Ok(OperationResponse::Message(format!("unknown: {other}"))),
-                }
-            })
-        },
-    )
-}
-
-pub fn project_registration() -> ResourceRegistration {
-    ResourceRegistration {
-        def: project_def(),
-        handler: project_handler(),
-    }
-}
-
-// ═══════════════════════════════════════════════════
-// Environment
-// ═══════════════════════════════════════════════════
-
-fn env_def() -> ResourceDef {
-    ResourceDef::build("env", "Manage environments within a project")
-        .alias("environment")
-        .plural("environments")
-        .parent("org", "--org", "Organization")
-        .parent("project", "--project", "Project")
-        .crud()
-        .column("NAME", "name")
-        .column("PROJECT", "project_name")
-        .column("ORG", "org_name")
-        .column("ID", "id")
-        .column_def(ColumnDef::new("CREATED", "created_at").with_format(DisplayFormat::Timestamp))
-        .empty_message(
-            "No environments found. Create one with: nauka env create <name> --project <project> --org <org>",
-        )
-        .detail_section(
-            None,
-            vec![
-                DetailField::new("Name", "name"),
-                DetailField::new("ID", "id"),
-                DetailField::new("Project", "project_name"),
-                DetailField::new("Organization", "org_name"),
-                DetailField::new("Created", "created_at").with_format(DisplayFormat::Timestamp),
-            ],
-        )
-        .done()
-}
-
-fn env_handler() -> HandlerFn {
-    Box::new(
-        |req: OperationRequest| -> Pin<
-            Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
-        > {
-            Box::pin(async move {
-                match req.operation.as_str() {
-                    "create" => {
-                        let name = req
-                            .name
-                            .ok_or_else(|| anyhow::anyhow!("missing environment name"))?;
-                        let org = req
-                            .scope
-                            .get("org")
-                            .ok_or_else(|| anyhow::anyhow!("--org is required"))?
-                            .to_string();
-                        let project = req
-                            .scope
-                            .get("project")
-                            .ok_or_else(|| anyhow::anyhow!("--project is required"))?
-                            .to_string();
-                        nauka_core::validate::name(&name)?;
-                        let store = connect_store().await?;
-                        let env = store.create_env(&name, &project, &org).await?;
-                        Ok(OperationResponse::Resource(serde_json::json!({
-                            "name": env.name,
-                            "id": env.id.as_str(),
-                            "project_name": env.project_name,
-                            "org_name": env.org_name,
-                            "created_at": env.created_at,
-                        })))
-                    }
-                    "list" => {
-                        let org = req.scope.get("org").map(|s| s.to_string());
-                        let project = req.scope.get("project").map(|s| s.to_string());
-                        let store = connect_store().await?;
-                        let envs = store
-                            .list_envs(project.as_deref(), org.as_deref())
-                            .await?;
-                        let items: Vec<serde_json::Value> = envs
-                            .iter()
-                            .map(|e| {
-                                serde_json::json!({
-                                    "name": e.name,
-                                    "id": e.id.as_str(),
-                                    "project_name": e.project_name,
-                                    "org_name": e.org_name,
-                                    "created_at": e.created_at,
-                                })
-                            })
-                            .collect();
-                        Ok(OperationResponse::ResourceList(items))
-                    }
-                    "get" => {
-                        let name = req
-                            .name
-                            .ok_or_else(|| anyhow::anyhow!("missing environment name or ID"))?;
-                        let org = req.scope.get("org").map(|s| s.to_string());
-                        let project = req.scope.get("project").map(|s| s.to_string());
-                        let store = connect_store().await?;
-                        let env = store
-                            .get_env(&name, project.as_deref(), org.as_deref())
-                            .await?
-                            .ok_or_else(|| {
-                                anyhow::anyhow!("environment '{name}' not found")
-                            })?;
-                        Ok(OperationResponse::Resource(serde_json::json!({
-                            "name": env.name,
-                            "id": env.id.as_str(),
-                            "project_name": env.project_name,
-                            "org_name": env.org_name,
-                            "created_at": env.created_at,
-                        })))
-                    }
-                    "delete" => {
-                        let name = req
-                            .name
-                            .ok_or_else(|| anyhow::anyhow!("missing environment name or ID"))?;
-                        let org = req
-                            .scope
-                            .get("org")
-                            .ok_or_else(|| anyhow::anyhow!("--org is required"))?
-                            .to_string();
-                        let project = req
-                            .scope
-                            .get("project")
-                            .ok_or_else(|| anyhow::anyhow!("--project is required"))?
-                            .to_string();
-                        let store = connect_store().await?;
-                        store.delete_env(&name, &project, &org).await?;
-                        Ok(OperationResponse::Message(format!(
-                            "environment '{name}' deleted."
-                        )))
-                    }
-                    other => Ok(OperationResponse::Message(format!("unknown: {other}"))),
-                }
-            })
-        },
-    )
-}
-
-pub fn env_registration() -> ResourceRegistration {
-    ResourceRegistration {
-        def: env_def(),
-        handler: env_handler(),
-    }
 }

--- a/layers/org/src/lib.rs
+++ b/layers/org/src/lib.rs
@@ -1,13 +1,70 @@
 //! Organization layer — resource hierarchy for multi-tenancy.
 //!
-//! Three resources form the ownership tree:
+//! Structure mirrors the resource hierarchy:
 //! - **Org** — top-level organization (globally unique name)
-//! - **Project** — scoped within an Org
-//! - **Environment** — scoped within a Project (prod, staging, dev)
+//!   - **Project** — scoped within an Org
+//!     - **Env** — scoped within a Project (prod, staging, dev)
 //!
-//! All future resources (VPC, Subnet, VM) are scoped under this hierarchy.
-//! State is stored in ClusterDb (TiKV) for distributed consistency.
+//! CLI: `nauka org`, `nauka org project`, `nauka org project env`
 
 pub mod handlers;
+pub mod project;
 pub mod store;
 pub mod types;
+
+use nauka_core::resource::ResourceRegistration;
+use nauka_hypervisor::controlplane;
+use nauka_hypervisor::fabric;
+use nauka_state::LocalDb;
+
+/// Top-level registration: org with project (with env) as children.
+pub fn registration() -> ResourceRegistration {
+    ResourceRegistration {
+        def: handlers::resource_def(),
+        handler: handlers::handler(),
+        children: vec![project::handlers::registration()],
+    }
+}
+
+/// Connect to ClusterDb via PD endpoints from fabric state.
+pub(crate) async fn connect_cluster_db() -> anyhow::Result<controlplane::ClusterDb> {
+    let dir = nauka_core::process::nauka_dir();
+    let _ = std::fs::create_dir_all(&dir);
+    let db = LocalDb::open("hypervisor")?;
+
+    let state = fabric::state::FabricState::load(&db)
+        .map_err(|e| anyhow::anyhow!("{e}"))?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "cluster not initialized.\n\n\
+                 Initialize a cluster first with:\n\
+                 \x20 nauka hypervisor init"
+            )
+        })?;
+
+    let self_endpoint = format!(
+        "http://[{}]:{}",
+        state.hypervisor.mesh_ipv6,
+        controlplane::PD_CLIENT_PORT,
+    );
+    let mut endpoints = vec![self_endpoint];
+    for peer in &state.peers.peers {
+        endpoints.push(format!(
+            "http://[{}]:{}",
+            peer.mesh_ipv6,
+            controlplane::PD_CLIENT_PORT,
+        ));
+    }
+    let refs: Vec<&str> = endpoints.iter().map(|s| s.as_str()).collect();
+
+    controlplane::ClusterDb::connect(&refs)
+        .await
+        .map_err(Into::into)
+}
+
+pub(crate) fn now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}

--- a/layers/org/src/overview.mdx
+++ b/layers/org/src/overview.mdx
@@ -1,0 +1,106 @@
+---
+title: Organization Layer
+description: The organization layer provides the resource hierarchy for multi-tenancy -- Org, Project, and Environment -- that all cloud resources are scoped under.
+sidebar:
+  order: 1
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Before you can create VPCs, VMs, or volumes, you need to set up the organizational hierarchy. Every resource in Nauka belongs to an **Organization → Project → Environment** tree. This mirrors how teams actually work: a company (org) has multiple products (projects), each running in separate environments (production, staging, dev).
+
+## Hierarchy
+
+```
+Org (acme)
+├── Project (backend)
+│   ├── Env (production)
+│   └── Env (staging)
+└── Project (frontend)
+    └── Env (production)
+```
+
+- **Org** -- A top-level organization. Globally unique name. All billing, users, and resources roll up here.
+- **Project** -- A workspace within an org. Groups related resources together. Names are unique within the org.
+- **Environment** -- A deployment target within a project. Typically maps to a lifecycle stage (production, staging, dev). Names are unique within the project.
+
+## CLI
+
+The CLI reflects the hierarchy directly:
+
+```bash
+# Organizations
+nauka org create acme
+nauka org list
+nauka org get acme
+nauka org delete acme
+
+# Projects (nested under org)
+nauka org project create backend --org acme
+nauka org project list --org acme
+nauka org project get backend --org acme
+nauka org project delete backend --org acme
+
+# Environments (nested under project)
+nauka org project env create production --org acme --project backend
+nauka org project env list --org acme --project backend
+nauka org project env get production --org acme --project backend
+nauka org project env delete production --org acme --project backend
+```
+
+<Aside type="tip">
+You can omit `--org` on list and get operations if the name is unambiguous. It is always required on create and delete.
+</Aside>
+
+## Prerequisites
+
+The org layer stores state in TiKV (the distributed control plane). A cluster must be initialized before creating organizations:
+
+```bash
+nauka hypervisor init --region eu --zone fsn1 \
+  --s3-endpoint https://s3.example.com \
+  --s3-bucket my-bucket \
+  --s3-access-key AKID \
+  --s3-secret-key SECRET
+```
+
+If TiKV is not running, org commands return a clear error:
+
+```
+Error: cluster not initialized.
+
+Initialize a cluster first with:
+  nauka hypervisor init
+```
+
+## Deletion safety
+
+Resources cannot be deleted while they have children:
+
+```bash
+$ nauka org delete acme
+Error: org 'acme' has 2 project(s). Delete them first.
+
+$ nauka org project delete backend --org acme
+Error: project 'backend' has 1 environment(s). Delete them first.
+```
+
+Delete from the bottom up: environments first, then projects, then orgs.
+
+## Name validation
+
+All resource names follow DNS label rules (RFC 1123):
+
+- 3--63 characters
+- Lowercase alphanumeric and hyphens only
+- Must start with a letter
+- Must end with a letter or digit
+- No consecutive hyphens
+
+## State storage
+
+Org, project, and environment data is stored in the TiKV cluster, replicated across all nodes in the mesh. This means:
+
+- Any node can create, read, or delete org resources
+- Data survives individual node failures (with 3+ nodes)
+- No external database required

--- a/layers/org/src/project/env/handlers.rs
+++ b/layers/org/src/project/env/handlers.rs
@@ -1,0 +1,101 @@
+//! Environment resource definition + handler.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use nauka_core::resource::*;
+
+use super::store::EnvStore;
+
+pub fn resource_def() -> ResourceDef {
+    ResourceDef::build("env", "Manage environments within a project")
+        .alias("environment")
+        .plural("environments")
+        .parent("org", "--org", "Organization")
+        .parent("project", "--project", "Project")
+        .crud()
+        .column("NAME", "name")
+        .column("PROJECT", "project_name")
+        .column("ORG", "org_name")
+        .column("ID", "id")
+        .column_def(ColumnDef::new("CREATED", "created_at").with_format(DisplayFormat::Timestamp))
+        .empty_message(
+            "No environments found. Create one with: nauka org project env create <name> --project <project> --org <org>",
+        )
+        .detail_section(
+            None,
+            vec![
+                DetailField::new("Name", "name"),
+                DetailField::new("ID", "id"),
+                DetailField::new("Project", "project_name"),
+                DetailField::new("Organization", "org_name"),
+                DetailField::new("Created", "created_at").with_format(DisplayFormat::Timestamp),
+            ],
+        )
+        .done()
+}
+
+pub fn handler() -> HandlerFn {
+    Box::new(
+        |req: OperationRequest| -> Pin<
+            Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
+        > {
+            Box::pin(async move {
+                let store = EnvStore::new(crate::connect_cluster_db().await?);
+                match req.operation.as_str() {
+                    "create" => {
+                        let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name"))?;
+                        let org = req.scope.get("org").ok_or_else(|| anyhow::anyhow!("--org is required"))?.to_string();
+                        let project = req.scope.get("project").ok_or_else(|| anyhow::anyhow!("--project is required"))?.to_string();
+                        nauka_core::validate::name(&name)?;
+                        let env = store.create(&name, &project, &org).await?;
+                        Ok(OperationResponse::Resource(serde_json::json!({
+                            "name": env.name, "id": env.id.as_str(),
+                            "project_name": env.project_name, "org_name": env.org_name,
+                            "created_at": env.created_at,
+                        })))
+                    }
+                    "list" => {
+                        let org = req.scope.get("org").map(|s| s.to_string());
+                        let project = req.scope.get("project").map(|s| s.to_string());
+                        let envs = store.list(project.as_deref(), org.as_deref()).await?;
+                        let items: Vec<serde_json::Value> = envs.iter().map(|e| serde_json::json!({
+                            "name": e.name, "id": e.id.as_str(),
+                            "project_name": e.project_name, "org_name": e.org_name,
+                            "created_at": e.created_at,
+                        })).collect();
+                        Ok(OperationResponse::ResourceList(items))
+                    }
+                    "get" => {
+                        let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name or ID"))?;
+                        let org = req.scope.get("org").map(|s| s.to_string());
+                        let project = req.scope.get("project").map(|s| s.to_string());
+                        let env = store.get(&name, project.as_deref(), org.as_deref()).await?
+                            .ok_or_else(|| anyhow::anyhow!("environment '{name}' not found"))?;
+                        Ok(OperationResponse::Resource(serde_json::json!({
+                            "name": env.name, "id": env.id.as_str(),
+                            "project_name": env.project_name, "org_name": env.org_name,
+                            "created_at": env.created_at,
+                        })))
+                    }
+                    "delete" => {
+                        let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name or ID"))?;
+                        let org = req.scope.get("org").ok_or_else(|| anyhow::anyhow!("--org is required"))?.to_string();
+                        let project = req.scope.get("project").ok_or_else(|| anyhow::anyhow!("--project is required"))?.to_string();
+                        store.delete(&name, &project, &org).await?;
+                        Ok(OperationResponse::Message(format!("environment '{name}' deleted.")))
+                    }
+                    other => Ok(OperationResponse::Message(format!("unknown: {other}"))),
+                }
+            })
+        },
+    )
+}
+
+pub fn registration() -> ResourceRegistration {
+    ResourceRegistration {
+        def: resource_def(),
+        handler: handler(),
+        children: vec![],
+    }
+}

--- a/layers/org/src/project/env/mod.rs
+++ b/layers/org/src/project/env/mod.rs
@@ -1,0 +1,5 @@
+//! Environment — a deployment target within a project (prod, staging, dev).
+
+pub mod handlers;
+pub mod store;
+pub mod types;

--- a/layers/org/src/project/env/overview.mdx
+++ b/layers/org/src/project/env/overview.mdx
@@ -1,0 +1,82 @@
+---
+title: Environments
+description: Environments represent deployment targets within a project -- production, staging, dev -- and scope all future cloud resources.
+sidebar:
+  order: 3
+---
+
+An environment is a deployment target within a project. Most teams use environments to separate lifecycle stages: production runs live traffic, staging validates releases, dev is for daily work. All future resources (VPCs, VMs, volumes) will be created within an environment.
+
+## Creating an environment
+
+```bash
+nauka org project env create production --org acme --project backend
+```
+
+```
+  Name:            production
+  ID:              env-01KNPWMAGT4XA9N6QBWGARDT09
+  Project:         backend
+  Organization:    acme
+  Created:         2026-04-08 15:50 UTC
+```
+
+Both `--org` and `--project` are required on create.
+
+## Listing environments
+
+```bash
+# All environments in a project
+nauka org project env list --org acme --project backend
+
+# All environments across all projects and orgs
+nauka org project env list
+```
+
+```
+NAME        PROJECT  ORG   ID                              CREATED
+-------------------------------------------------------------------------------
+production  backend  acme  env-01KNPWMAGT4XA9N6QBWGARDT09  2026-04-08 15:50 UTC
+staging     backend  acme  env-01KNPWMAHFHGSMFX22WFKDGRM9  2026-04-08 15:50 UTC
+```
+
+## Inspecting an environment
+
+```bash
+nauka org project env get production --org acme --project backend
+```
+
+Or by ID:
+
+```bash
+nauka org project env get env-01KNPWMAGT4XA9N6QBWGARDT09
+```
+
+## Deleting an environment
+
+```bash
+nauka org project env delete staging --org acme --project backend
+```
+
+In the future, an environment containing active resources (VPCs, VMs) cannot be deleted until those resources are cleaned up first.
+
+## Typical setup
+
+A common pattern for a small team:
+
+```bash
+# Create the org
+nauka org create mycompany
+
+# Create a project per service
+nauka org project create api --org mycompany
+nauka org project create web --org mycompany
+
+# Create environments for each
+nauka org project env create production --org mycompany --project api
+nauka org project env create staging    --org mycompany --project api
+nauka org project env create production --org mycompany --project web
+nauka org project env create staging    --org mycompany --project web
+```
+
+This gives you isolated environments for each service, ready for VPC and VM creation.

--- a/layers/org/src/project/env/store.rs
+++ b/layers/org/src/project/env/store.rs
@@ -1,0 +1,159 @@
+//! Environment persistence in ClusterDb (TiKV).
+
+use nauka_core::id::EnvId;
+use nauka_hypervisor::controlplane::ClusterDb;
+
+use super::types::Environment;
+use crate::project;
+
+const NS_ENV: &str = "env";
+const NS_ENV_IDX: &str = "env-idx";
+const REG_ENVS: (&str, &str) = ("_reg", "env-ids");
+
+pub struct EnvStore {
+    db: ClusterDb,
+}
+
+impl EnvStore {
+    pub fn new(db: ClusterDb) -> Self {
+        Self { db }
+    }
+
+    pub async fn create(
+        &self,
+        name: &str,
+        project_name: &str,
+        org_name: &str,
+    ) -> anyhow::Result<Environment> {
+        let proj_store = project::store::ProjectStore::new(self.db.clone());
+        let project = proj_store
+            .get(project_name, Some(org_name))
+            .await?
+            .ok_or_else(|| {
+                anyhow::anyhow!("project '{project_name}' not found in org '{org_name}'")
+            })?;
+
+        let idx_key = format!("{}/{}", project.id.as_str(), name);
+        let existing: Option<String> = self.db.get(NS_ENV_IDX, &idx_key).await?;
+        if existing.is_some() {
+            anyhow::bail!("environment '{name}' already exists in project '{project_name}'");
+        }
+
+        let env = Environment {
+            id: EnvId::generate(),
+            name: name.to_string(),
+            project_id: project.id.clone(),
+            project_name: project.name.clone(),
+            org_id: project.org_id.clone(),
+            org_name: project.org_name.clone(),
+            created_at: crate::now(),
+        };
+
+        self.db.put(NS_ENV, env.id.as_str(), &env).await?;
+        self.db
+            .put(NS_ENV_IDX, &idx_key, &env.id.as_str().to_string())
+            .await?;
+        add_id(&self.db, env.id.as_str()).await?;
+
+        Ok(env)
+    }
+
+    pub async fn get(
+        &self,
+        name_or_id: &str,
+        project_name: Option<&str>,
+        org_name: Option<&str>,
+    ) -> anyhow::Result<Option<Environment>> {
+        if EnvId::looks_like_id(name_or_id) {
+            return self.db.get(NS_ENV, name_or_id).await.map_err(Into::into);
+        }
+
+        let project_name = project_name
+            .ok_or_else(|| anyhow::anyhow!("--project required to resolve environment by name"))?;
+        let proj_store = project::store::ProjectStore::new(self.db.clone());
+        let project = proj_store
+            .get(project_name, org_name)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("project '{project_name}' not found"))?;
+
+        let idx_key = format!("{}/{}", project.id.as_str(), name_or_id);
+        let id: Option<String> = self.db.get(NS_ENV_IDX, &idx_key).await?;
+        match id {
+            Some(id) => self.db.get(NS_ENV, &id).await.map_err(Into::into),
+            None => Ok(None),
+        }
+    }
+
+    pub async fn list(
+        &self,
+        project_name: Option<&str>,
+        org_name: Option<&str>,
+    ) -> anyhow::Result<Vec<Environment>> {
+        let ids = load_ids(&self.db).await?;
+        let mut envs = Vec::new();
+        for id in &ids {
+            if let Some(e) = self.db.get::<Environment>(NS_ENV, id).await? {
+                envs.push(e);
+            }
+        }
+
+        // Filter accepts both names and IDs (API passes IDs, CLI passes names)
+        match (project_name, org_name) {
+            (Some(proj), Some(org)) => Ok(envs
+                .into_iter()
+                .filter(|e| {
+                    (e.project_name == proj || e.project_id.as_str() == proj)
+                        && (e.org_name == org || e.org_id.as_str() == org)
+                })
+                .collect()),
+            (Some(proj), None) => Ok(envs
+                .into_iter()
+                .filter(|e| e.project_name == proj || e.project_id.as_str() == proj)
+                .collect()),
+            (None, Some(org)) => Ok(envs
+                .into_iter()
+                .filter(|e| e.org_name == org || e.org_id.as_str() == org)
+                .collect()),
+            (None, None) => Ok(envs),
+        }
+    }
+
+    pub async fn delete(
+        &self,
+        name_or_id: &str,
+        project_name: &str,
+        org_name: &str,
+    ) -> anyhow::Result<()> {
+        let env = self
+            .get(name_or_id, Some(project_name), Some(org_name))
+            .await?
+            .ok_or_else(|| {
+                anyhow::anyhow!("environment '{name_or_id}' not found in project '{project_name}'")
+            })?;
+
+        let idx_key = format!("{}/{}", env.project_id.as_str(), env.name);
+        self.db.delete(NS_ENV, env.id.as_str()).await?;
+        self.db.delete(NS_ENV_IDX, &idx_key).await?;
+        remove_id(&self.db, env.id.as_str()).await?;
+        Ok(())
+    }
+}
+
+async fn load_ids(db: &ClusterDb) -> anyhow::Result<Vec<String>> {
+    let ids: Option<Vec<String>> = db.get(REG_ENVS.0, REG_ENVS.1).await?;
+    Ok(ids.unwrap_or_default())
+}
+
+async fn add_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
+    let mut ids = load_ids(db).await?;
+    ids.push(id.to_string());
+    db.put(REG_ENVS.0, REG_ENVS.1, &ids).await?;
+    Ok(())
+}
+
+async fn remove_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
+    let mut ids = load_ids(db).await?;
+    ids.retain(|i| i != id);
+    db.put(REG_ENVS.0, REG_ENVS.1, &ids).await?;
+    Ok(())
+}

--- a/layers/org/src/project/env/types.rs
+++ b/layers/org/src/project/env/types.rs
@@ -1,0 +1,16 @@
+//! Environment data type.
+
+use nauka_core::id::{EnvId, OrgId, ProjectId};
+use serde::{Deserialize, Serialize};
+
+/// An environment within a project (e.g., production, staging, dev).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Environment {
+    pub id: EnvId,
+    pub name: String,
+    pub project_id: ProjectId,
+    pub project_name: String,
+    pub org_id: OrgId,
+    pub org_name: String,
+    pub created_at: u64,
+}

--- a/layers/org/src/project/handlers.rs
+++ b/layers/org/src/project/handlers.rs
@@ -1,0 +1,90 @@
+//! Project resource definition + handler.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use nauka_core::resource::*;
+
+use super::store::ProjectStore;
+
+pub fn resource_def() -> ResourceDef {
+    ResourceDef::build("project", "Manage projects within an organization")
+        .plural("projects")
+        .parent("org", "--org", "Organization")
+        .crud()
+        .column("NAME", "name")
+        .column("ORG", "org_name")
+        .column("ID", "id")
+        .column_def(ColumnDef::new("CREATED", "created_at").with_format(DisplayFormat::Timestamp))
+        .empty_message(
+            "No projects found. Create one with: nauka org project create <name> --org <org>",
+        )
+        .detail_section(
+            None,
+            vec![
+                DetailField::new("Name", "name"),
+                DetailField::new("ID", "id"),
+                DetailField::new("Organization", "org_name"),
+                DetailField::new("Created", "created_at").with_format(DisplayFormat::Timestamp),
+            ],
+        )
+        .done()
+}
+
+pub fn handler() -> HandlerFn {
+    Box::new(
+        |req: OperationRequest| -> Pin<
+            Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
+        > {
+            Box::pin(async move {
+                let store = ProjectStore::new(crate::connect_cluster_db().await?);
+                match req.operation.as_str() {
+                    "create" => {
+                        let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name"))?;
+                        let org = req.scope.get("org").ok_or_else(|| anyhow::anyhow!("--org is required"))?.to_string();
+                        nauka_core::validate::name(&name)?;
+                        let project = store.create(&name, &org).await?;
+                        Ok(OperationResponse::Resource(serde_json::json!({
+                            "name": project.name, "id": project.id.as_str(),
+                            "org_name": project.org_name, "created_at": project.created_at,
+                        })))
+                    }
+                    "list" => {
+                        let org = req.scope.get("org").map(|s| s.to_string());
+                        let projects = store.list(org.as_deref()).await?;
+                        let items: Vec<serde_json::Value> = projects.iter().map(|p| serde_json::json!({
+                            "name": p.name, "id": p.id.as_str(),
+                            "org_name": p.org_name, "created_at": p.created_at,
+                        })).collect();
+                        Ok(OperationResponse::ResourceList(items))
+                    }
+                    "get" => {
+                        let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name or ID"))?;
+                        let org = req.scope.get("org").map(|s| s.to_string());
+                        let project = store.get(&name, org.as_deref()).await?
+                            .ok_or_else(|| anyhow::anyhow!("project '{name}' not found"))?;
+                        Ok(OperationResponse::Resource(serde_json::json!({
+                            "name": project.name, "id": project.id.as_str(),
+                            "org_name": project.org_name, "created_at": project.created_at,
+                        })))
+                    }
+                    "delete" => {
+                        let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name or ID"))?;
+                        let org = req.scope.get("org").ok_or_else(|| anyhow::anyhow!("--org is required"))?.to_string();
+                        store.delete(&name, &org).await?;
+                        Ok(OperationResponse::Message(format!("project '{name}' deleted.")))
+                    }
+                    other => Ok(OperationResponse::Message(format!("unknown: {other}"))),
+                }
+            })
+        },
+    )
+}
+
+pub fn registration() -> ResourceRegistration {
+    ResourceRegistration {
+        def: resource_def(),
+        handler: handler(),
+        children: vec![super::env::handlers::registration()],
+    }
+}

--- a/layers/org/src/project/mod.rs
+++ b/layers/org/src/project/mod.rs
@@ -1,0 +1,6 @@
+//! Project — a workspace within an organization, contains environments.
+
+pub mod env;
+pub mod handlers;
+pub mod store;
+pub mod types;

--- a/layers/org/src/project/overview.mdx
+++ b/layers/org/src/project/overview.mdx
@@ -1,0 +1,68 @@
+---
+title: Projects
+description: Projects group related resources within an organization -- a workspace boundary for VPCs, VMs, and environments.
+sidebar:
+  order: 2
+---
+
+A project is a workspace within an organization. It groups related infrastructure together -- typically one project per product, service, or team. All resources (VPCs, VMs, volumes) created later will be scoped within a project.
+
+## Creating a project
+
+```bash
+nauka org project create backend --org acme
+```
+
+```
+  Name:            backend
+  ID:              proj-01KNPWMAFFSVR61MKK74E7ZKRF
+  Organization:    acme
+  Created:         2026-04-08 15:50 UTC
+```
+
+The `--org` flag specifies which organization the project belongs to. Project names must be unique within their org (you can have a `backend` project in both `acme` and `beta-corp`).
+
+## Listing projects
+
+```bash
+# All projects across all orgs
+nauka org project list
+
+# Projects in a specific org
+nauka org project list --org acme
+```
+
+```
+NAME      ORG   ID                               CREATED
+---------------------------------------------------------------------
+backend   acme  proj-01KNPWMAFFSVR61MKK74E7ZKRF  2026-04-08 15:50 UTC
+frontend  acme  proj-01KNPWMAG51XJCSFVNAJ691H72  2026-04-08 15:50 UTC
+```
+
+## Inspecting a project
+
+```bash
+nauka org project get backend --org acme
+```
+
+You can also get a project by its ID directly (no `--org` needed):
+
+```bash
+nauka org project get proj-01KNPWMAFFSVR61MKK74E7ZKRF
+```
+
+## Deleting a project
+
+```bash
+nauka org project delete backend --org acme
+```
+
+A project cannot be deleted if it still has environments. Delete environments first:
+
+```
+Error: project 'backend' has 2 environment(s). Delete them first.
+```
+
+## What comes next
+
+Once a project exists, create environments within it to represent deployment stages (production, staging, dev). Future resources like VPCs and VMs will be scoped under a project + environment combination.

--- a/layers/org/src/project/store.rs
+++ b/layers/org/src/project/store.rs
@@ -1,0 +1,135 @@
+//! Project persistence in ClusterDb (TiKV).
+
+use nauka_core::id::ProjectId;
+use nauka_hypervisor::controlplane::ClusterDb;
+
+use super::types::Project;
+
+const NS_PROJ: &str = "proj";
+const NS_PROJ_IDX: &str = "proj-idx";
+const REG_PROJECTS: (&str, &str) = ("_reg", "proj-ids");
+
+pub struct ProjectStore {
+    db: ClusterDb,
+}
+
+impl ProjectStore {
+    pub fn new(db: ClusterDb) -> Self {
+        Self { db }
+    }
+
+    pub async fn create(&self, name: &str, org_name: &str) -> anyhow::Result<Project> {
+        let org_store = crate::store::OrgStore::new(self.db.clone());
+        let org = org_store
+            .get(org_name)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("org '{org_name}' not found"))?;
+
+        let idx_key = format!("{}/{}", org.id.as_str(), name);
+        let existing: Option<String> = self.db.get(NS_PROJ_IDX, &idx_key).await?;
+        if existing.is_some() {
+            anyhow::bail!("project '{name}' already exists in org '{org_name}'");
+        }
+
+        let project = Project {
+            id: ProjectId::generate(),
+            name: name.to_string(),
+            org_id: org.id.clone(),
+            org_name: org.name.clone(),
+            created_at: crate::now(),
+        };
+
+        self.db.put(NS_PROJ, project.id.as_str(), &project).await?;
+        self.db
+            .put(NS_PROJ_IDX, &idx_key, &project.id.as_str().to_string())
+            .await?;
+        add_id(&self.db, project.id.as_str()).await?;
+
+        Ok(project)
+    }
+
+    pub async fn get(
+        &self,
+        name_or_id: &str,
+        org_name: Option<&str>,
+    ) -> anyhow::Result<Option<Project>> {
+        if ProjectId::looks_like_id(name_or_id) {
+            return self.db.get(NS_PROJ, name_or_id).await.map_err(Into::into);
+        }
+
+        let org_name =
+            org_name.ok_or_else(|| anyhow::anyhow!("--org required to resolve project by name"))?;
+        let org_store = crate::store::OrgStore::new(self.db.clone());
+        let org = org_store
+            .get(org_name)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("org '{org_name}' not found"))?;
+
+        let idx_key = format!("{}/{}", org.id.as_str(), name_or_id);
+        let id: Option<String> = self.db.get(NS_PROJ_IDX, &idx_key).await?;
+        match id {
+            Some(id) => self.db.get(NS_PROJ, &id).await.map_err(Into::into),
+            None => Ok(None),
+        }
+    }
+
+    pub async fn list(&self, org_name: Option<&str>) -> anyhow::Result<Vec<Project>> {
+        let ids = load_ids(&self.db).await?;
+        let mut projects = Vec::new();
+        for id in &ids {
+            if let Some(p) = self.db.get::<Project>(NS_PROJ, id).await? {
+                projects.push(p);
+            }
+        }
+
+        match org_name {
+            Some(name) => Ok(projects
+                .into_iter()
+                .filter(|p| p.org_name == name || p.org_id.as_str() == name)
+                .collect()),
+            None => Ok(projects),
+        }
+    }
+
+    pub async fn delete(&self, name_or_id: &str, org_name: &str) -> anyhow::Result<()> {
+        let project = self.get(name_or_id, Some(org_name)).await?.ok_or_else(|| {
+            anyhow::anyhow!("project '{name_or_id}' not found in org '{org_name}'")
+        })?;
+
+        // Check for child environments
+        let env_store = super::env::store::EnvStore::new(self.db.clone());
+        let envs = env_store.list(Some(&project.name), Some(org_name)).await?;
+        if !envs.is_empty() {
+            anyhow::bail!(
+                "project '{}' has {} environment(s). Delete them first.",
+                project.name,
+                envs.len()
+            );
+        }
+
+        let idx_key = format!("{}/{}", project.org_id.as_str(), project.name);
+        self.db.delete(NS_PROJ, project.id.as_str()).await?;
+        self.db.delete(NS_PROJ_IDX, &idx_key).await?;
+        remove_id(&self.db, project.id.as_str()).await?;
+        Ok(())
+    }
+}
+
+async fn load_ids(db: &ClusterDb) -> anyhow::Result<Vec<String>> {
+    let ids: Option<Vec<String>> = db.get(REG_PROJECTS.0, REG_PROJECTS.1).await?;
+    Ok(ids.unwrap_or_default())
+}
+
+async fn add_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
+    let mut ids = load_ids(db).await?;
+    ids.push(id.to_string());
+    db.put(REG_PROJECTS.0, REG_PROJECTS.1, &ids).await?;
+    Ok(())
+}
+
+async fn remove_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
+    let mut ids = load_ids(db).await?;
+    ids.retain(|i| i != id);
+    db.put(REG_PROJECTS.0, REG_PROJECTS.1, &ids).await?;
+    Ok(())
+}

--- a/layers/org/src/project/types.rs
+++ b/layers/org/src/project/types.rs
@@ -1,0 +1,14 @@
+//! Project data type.
+
+use nauka_core::id::{OrgId, ProjectId};
+use serde::{Deserialize, Serialize};
+
+/// A project within an organization.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Project {
+    pub id: ProjectId,
+    pub name: String,
+    pub org_id: OrgId,
+    pub org_name: String,
+    pub created_at: u64,
+}

--- a/layers/org/src/store.rs
+++ b/layers/org/src/store.rs
@@ -1,39 +1,14 @@
-//! Persistence for Org/Project/Environment in ClusterDb (TiKV).
-//!
-//! Key layout:
-//! - `org/{org_id}`                          → Org JSON
-//! - `org-idx/{name}`                        → org_id string
-//! - `org-ids`                               → Vec<String> of all org IDs
-//! - `proj/{project_id}`                     → Project JSON
-//! - `proj-idx/{org_id}/{name}`              → project_id string
-//! - `proj-ids`                              → Vec<String> of all project IDs
-//! - `env/{env_id}`                          → Environment JSON
-//! - `env-idx/{project_id}/{name}`           → env_id string
-//! - `env-ids`                               → Vec<String> of all env IDs
-//!
-//! We avoid TiKV scan (broken in tikv-client 0.4) by maintaining
-//! a registry key (`*-ids`) with all IDs. List fetches the registry
-//! then gets each entry individually.
+//! Org persistence in ClusterDb (TiKV).
 
-use nauka_core::id::{EnvId, OrgId, ProjectId};
+use nauka_core::id::OrgId;
 use nauka_hypervisor::controlplane::ClusterDb;
 
-use crate::types::{Environment, Org, Project};
+use crate::types::Org;
 
-/// Namespaces — each resource type gets a unique prefix.
 const NS_ORG: &str = "org";
 const NS_ORG_IDX: &str = "org-idx";
-const NS_PROJ: &str = "proj";
-const NS_PROJ_IDX: &str = "proj-idx";
-const NS_ENV: &str = "env";
-const NS_ENV_IDX: &str = "env-idx";
-
-/// Registry keys — single key holding all IDs for each type.
 const REG_ORGS: (&str, &str) = ("_reg", "org-ids");
-const REG_PROJECTS: (&str, &str) = ("_reg", "proj-ids");
-const REG_ENVS: (&str, &str) = ("_reg", "env-ids");
 
-/// Store wrapping ClusterDb for org hierarchy CRUD.
 pub struct OrgStore {
     db: ClusterDb,
 }
@@ -43,63 +18,35 @@ impl OrgStore {
         Self { db }
     }
 
-    // ── Registry helpers ──
-
-    async fn load_ids(&self, reg: (&str, &str)) -> anyhow::Result<Vec<String>> {
-        let ids: Option<Vec<String>> = self.db.get(reg.0, reg.1).await?;
-        Ok(ids.unwrap_or_default())
-    }
-
-    async fn save_ids(&self, reg: (&str, &str), ids: &[String]) -> anyhow::Result<()> {
-        self.db.put(reg.0, reg.1, &ids.to_vec()).await?;
-        Ok(())
-    }
-
-    async fn add_id(&self, reg: (&str, &str), id: &str) -> anyhow::Result<()> {
-        let mut ids = self.load_ids(reg).await?;
-        ids.push(id.to_string());
-        self.save_ids(reg, &ids).await
-    }
-
-    async fn remove_id(&self, reg: (&str, &str), id: &str) -> anyhow::Result<()> {
-        let mut ids = self.load_ids(reg).await?;
-        ids.retain(|i| i != id);
-        self.save_ids(reg, &ids).await
-    }
-
-    // ═══════════════════════════════════════════════════
-    // Org
-    // ═══════════════════════════════════════════════════
-
-    pub async fn create_org(&self, name: &str) -> anyhow::Result<Org> {
-        if self.get_org_by_name(name).await?.is_some() {
+    pub async fn create(&self, name: &str) -> anyhow::Result<Org> {
+        if self.get_by_name(name).await?.is_some() {
             anyhow::bail!("org '{name}' already exists");
         }
 
         let org = Org {
             id: OrgId::generate(),
             name: name.to_string(),
-            created_at: now(),
+            created_at: crate::now(),
         };
 
         self.db.put(NS_ORG, org.id.as_str(), &org).await?;
         self.db
             .put(NS_ORG_IDX, &org.name, &org.id.as_str().to_string())
             .await?;
-        self.add_id(REG_ORGS, org.id.as_str()).await?;
+        add_id(&self.db, org.id.as_str()).await?;
 
         Ok(org)
     }
 
-    pub async fn get_org(&self, name_or_id: &str) -> anyhow::Result<Option<Org>> {
+    pub async fn get(&self, name_or_id: &str) -> anyhow::Result<Option<Org>> {
         if OrgId::looks_like_id(name_or_id) {
             self.db.get(NS_ORG, name_or_id).await.map_err(Into::into)
         } else {
-            self.get_org_by_name(name_or_id).await
+            self.get_by_name(name_or_id).await
         }
     }
 
-    async fn get_org_by_name(&self, name: &str) -> anyhow::Result<Option<Org>> {
+    async fn get_by_name(&self, name: &str) -> anyhow::Result<Option<Org>> {
         let id: Option<String> = self.db.get(NS_ORG_IDX, name).await?;
         match id {
             Some(id) => self.db.get(NS_ORG, &id).await.map_err(Into::into),
@@ -107,8 +54,8 @@ impl OrgStore {
         }
     }
 
-    pub async fn list_orgs(&self) -> anyhow::Result<Vec<Org>> {
-        let ids = self.load_ids(REG_ORGS).await?;
+    pub async fn list(&self) -> anyhow::Result<Vec<Org>> {
+        let ids = load_ids(&self.db).await?;
         let mut orgs = Vec::new();
         for id in &ids {
             if let Some(org) = self.db.get::<Org>(NS_ORG, id).await? {
@@ -118,13 +65,15 @@ impl OrgStore {
         Ok(orgs)
     }
 
-    pub async fn delete_org(&self, name_or_id: &str) -> anyhow::Result<()> {
+    pub async fn delete(&self, name_or_id: &str) -> anyhow::Result<()> {
         let org = self
-            .get_org(name_or_id)
+            .get(name_or_id)
             .await?
             .ok_or_else(|| anyhow::anyhow!("org '{name_or_id}' not found"))?;
 
-        let projects = self.list_projects(Some(&org.name)).await?;
+        // Check for child projects
+        let proj_store = crate::project::store::ProjectStore::new(self.db.clone());
+        let projects = proj_store.list(Some(&org.name)).await?;
         if !projects.is_empty() {
             anyhow::bail!(
                 "org '{}' has {} project(s). Delete them first.",
@@ -135,227 +84,26 @@ impl OrgStore {
 
         self.db.delete(NS_ORG, org.id.as_str()).await?;
         self.db.delete(NS_ORG_IDX, &org.name).await?;
-        self.remove_id(REG_ORGS, org.id.as_str()).await?;
-        Ok(())
-    }
-
-    // ═══════════════════════════════════════════════════
-    // Project
-    // ═══════════════════════════════════════════════════
-
-    pub async fn create_project(&self, name: &str, org_name: &str) -> anyhow::Result<Project> {
-        let org = self
-            .get_org(org_name)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("org '{org_name}' not found"))?;
-
-        let idx_key = format!("{}/{}", org.id.as_str(), name);
-        let existing: Option<String> = self.db.get(NS_PROJ_IDX, &idx_key).await?;
-        if existing.is_some() {
-            anyhow::bail!("project '{name}' already exists in org '{org_name}'");
-        }
-
-        let project = Project {
-            id: ProjectId::generate(),
-            name: name.to_string(),
-            org_id: org.id.clone(),
-            org_name: org.name.clone(),
-            created_at: now(),
-        };
-
-        self.db.put(NS_PROJ, project.id.as_str(), &project).await?;
-        self.db
-            .put(NS_PROJ_IDX, &idx_key, &project.id.as_str().to_string())
-            .await?;
-        self.add_id(REG_PROJECTS, project.id.as_str()).await?;
-
-        Ok(project)
-    }
-
-    pub async fn get_project(
-        &self,
-        name_or_id: &str,
-        org_name: Option<&str>,
-    ) -> anyhow::Result<Option<Project>> {
-        if ProjectId::looks_like_id(name_or_id) {
-            return self.db.get(NS_PROJ, name_or_id).await.map_err(Into::into);
-        }
-
-        let org_name =
-            org_name.ok_or_else(|| anyhow::anyhow!("--org required to resolve project by name"))?;
-        let org = self
-            .get_org(org_name)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("org '{org_name}' not found"))?;
-
-        let idx_key = format!("{}/{}", org.id.as_str(), name_or_id);
-        let id: Option<String> = self.db.get(NS_PROJ_IDX, &idx_key).await?;
-        match id {
-            Some(id) => self.db.get(NS_PROJ, &id).await.map_err(Into::into),
-            None => Ok(None),
-        }
-    }
-
-    pub async fn list_projects(&self, org_name: Option<&str>) -> anyhow::Result<Vec<Project>> {
-        let ids = self.load_ids(REG_PROJECTS).await?;
-        let mut projects = Vec::new();
-        for id in &ids {
-            if let Some(p) = self.db.get::<Project>(NS_PROJ, id).await? {
-                projects.push(p);
-            }
-        }
-
-        match org_name {
-            Some(name) => Ok(projects
-                .into_iter()
-                .filter(|p| p.org_name == name)
-                .collect()),
-            None => Ok(projects),
-        }
-    }
-
-    pub async fn delete_project(&self, name_or_id: &str, org_name: &str) -> anyhow::Result<()> {
-        let project = self
-            .get_project(name_or_id, Some(org_name))
-            .await?
-            .ok_or_else(|| {
-                anyhow::anyhow!("project '{name_or_id}' not found in org '{org_name}'")
-            })?;
-
-        let envs = self.list_envs(Some(&project.name), Some(org_name)).await?;
-        if !envs.is_empty() {
-            anyhow::bail!(
-                "project '{}' has {} environment(s). Delete them first.",
-                project.name,
-                envs.len()
-            );
-        }
-
-        let idx_key = format!("{}/{}", project.org_id.as_str(), project.name);
-        self.db.delete(NS_PROJ, project.id.as_str()).await?;
-        self.db.delete(NS_PROJ_IDX, &idx_key).await?;
-        self.remove_id(REG_PROJECTS, project.id.as_str()).await?;
-        Ok(())
-    }
-
-    // ═══════════════════════════════════════════════════
-    // Environment
-    // ═══════════════════════════════════════════════════
-
-    pub async fn create_env(
-        &self,
-        name: &str,
-        project_name: &str,
-        org_name: &str,
-    ) -> anyhow::Result<Environment> {
-        let project = self
-            .get_project(project_name, Some(org_name))
-            .await?
-            .ok_or_else(|| {
-                anyhow::anyhow!("project '{project_name}' not found in org '{org_name}'")
-            })?;
-
-        let idx_key = format!("{}/{}", project.id.as_str(), name);
-        let existing: Option<String> = self.db.get(NS_ENV_IDX, &idx_key).await?;
-        if existing.is_some() {
-            anyhow::bail!("environment '{name}' already exists in project '{project_name}'");
-        }
-
-        let env = Environment {
-            id: EnvId::generate(),
-            name: name.to_string(),
-            project_id: project.id.clone(),
-            project_name: project.name.clone(),
-            org_id: project.org_id.clone(),
-            org_name: project.org_name.clone(),
-            created_at: now(),
-        };
-
-        self.db.put(NS_ENV, env.id.as_str(), &env).await?;
-        self.db
-            .put(NS_ENV_IDX, &idx_key, &env.id.as_str().to_string())
-            .await?;
-        self.add_id(REG_ENVS, env.id.as_str()).await?;
-
-        Ok(env)
-    }
-
-    pub async fn get_env(
-        &self,
-        name_or_id: &str,
-        project_name: Option<&str>,
-        org_name: Option<&str>,
-    ) -> anyhow::Result<Option<Environment>> {
-        if EnvId::looks_like_id(name_or_id) {
-            return self.db.get(NS_ENV, name_or_id).await.map_err(Into::into);
-        }
-
-        let project_name = project_name
-            .ok_or_else(|| anyhow::anyhow!("--project required to resolve environment by name"))?;
-        let project = self
-            .get_project(project_name, org_name)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("project '{project_name}' not found"))?;
-
-        let idx_key = format!("{}/{}", project.id.as_str(), name_or_id);
-        let id: Option<String> = self.db.get(NS_ENV_IDX, &idx_key).await?;
-        match id {
-            Some(id) => self.db.get(NS_ENV, &id).await.map_err(Into::into),
-            None => Ok(None),
-        }
-    }
-
-    pub async fn list_envs(
-        &self,
-        project_name: Option<&str>,
-        org_name: Option<&str>,
-    ) -> anyhow::Result<Vec<Environment>> {
-        let ids = self.load_ids(REG_ENVS).await?;
-        let mut envs = Vec::new();
-        for id in &ids {
-            if let Some(e) = self.db.get::<Environment>(NS_ENV, id).await? {
-                envs.push(e);
-            }
-        }
-
-        match (project_name, org_name) {
-            (Some(proj), Some(org)) => Ok(envs
-                .into_iter()
-                .filter(|e| e.project_name == proj && e.org_name == org)
-                .collect()),
-            (Some(proj), None) => Ok(envs
-                .into_iter()
-                .filter(|e| e.project_name == proj)
-                .collect()),
-            (None, Some(org)) => Ok(envs.into_iter().filter(|e| e.org_name == org).collect()),
-            (None, None) => Ok(envs),
-        }
-    }
-
-    pub async fn delete_env(
-        &self,
-        name_or_id: &str,
-        project_name: &str,
-        org_name: &str,
-    ) -> anyhow::Result<()> {
-        let env = self
-            .get_env(name_or_id, Some(project_name), Some(org_name))
-            .await?
-            .ok_or_else(|| {
-                anyhow::anyhow!("environment '{name_or_id}' not found in project '{project_name}'")
-            })?;
-
-        let idx_key = format!("{}/{}", env.project_id.as_str(), env.name);
-        self.db.delete(NS_ENV, env.id.as_str()).await?;
-        self.db.delete(NS_ENV_IDX, &idx_key).await?;
-        self.remove_id(REG_ENVS, env.id.as_str()).await?;
+        remove_id(&self.db, org.id.as_str()).await?;
         Ok(())
     }
 }
 
-fn now() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs()
+async fn load_ids(db: &ClusterDb) -> anyhow::Result<Vec<String>> {
+    let ids: Option<Vec<String>> = db.get(REG_ORGS.0, REG_ORGS.1).await?;
+    Ok(ids.unwrap_or_default())
+}
+
+async fn add_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
+    let mut ids = load_ids(db).await?;
+    ids.push(id.to_string());
+    db.put(REG_ORGS.0, REG_ORGS.1, &ids).await?;
+    Ok(())
+}
+
+async fn remove_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
+    let mut ids = load_ids(db).await?;
+    ids.retain(|i| i != id);
+    db.put(REG_ORGS.0, REG_ORGS.1, &ids).await?;
+    Ok(())
 }

--- a/layers/org/src/types.rs
+++ b/layers/org/src/types.rs
@@ -1,6 +1,6 @@
-//! Org, Project, Environment data types.
+//! Org data type.
 
-use nauka_core::id::{EnvId, OrgId, ProjectId};
+use nauka_core::id::OrgId;
 use serde::{Deserialize, Serialize};
 
 /// An organization — the top-level resource.
@@ -8,27 +8,5 @@ use serde::{Deserialize, Serialize};
 pub struct Org {
     pub id: OrgId,
     pub name: String,
-    pub created_at: u64,
-}
-
-/// A project within an organization.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Project {
-    pub id: ProjectId,
-    pub name: String,
-    pub org_id: OrgId,
-    pub org_name: String,
-    pub created_at: u64,
-}
-
-/// An environment within a project.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Environment {
-    pub id: EnvId,
-    pub name: String,
-    pub project_id: ProjectId,
-    pub project_name: String,
-    pub org_id: OrgId,
-    pub org_name: String,
     pub created_at: u64,
 }


### PR DESCRIPTION
## Summary
- Restructure org layer: `project/` sub-module inside `org/`, `env/` sub-module inside `project/`
- Extend ResourceDef framework with `children` for auto-generated nested CLI
- Fix API route_gen to extract path params (org_id, project_id) into handler scope
- List filters accept both names and IDs for CLI/API compatibility
- Add MDX operator docs for org, project, and environment

## CLI hierarchy (auto-generated)
```
nauka org create/list/get/delete
nauka org project create/list/get/delete  --org <org>
nauka org project env create/list/get/delete  --org <org> --project <project>
```

## REST API (auto-generated, scoped routes)
```
POST/GET/DELETE  /admin/v1/org
POST/GET/DELETE  /admin/v1/org/{org_id}/project
POST/GET/DELETE  /admin/v1/org/{org_id}/project/{project_id}/env
```

## Test plan
- [x] `cargo build` + `cargo clippy` clean
- [x] All unit tests pass (476+)
- [x] Full CLI CRUD tested on Hetzner (49.12.233.86)
- [x] Full REST API tested with curl on Hetzner — create, list, get, delete for org/project/env
- [x] Cascade delete protection verified (CLI + API)
- [x] Leave/reinit cycle verified
- [x] TiKV max-replicas auto-adjustment on init/join/leave

🤖 Generated with [Claude Code](https://claude.com/claude-code)