### PR TITLE
fix(docs): add Organization layer to docs site

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -65,6 +65,7 @@ export default defineConfig({
 				{ label: 'Core', autogenerate: { directory: 'layers/core' } },
 				{ label: 'State', autogenerate: { directory: 'layers/state' } },
 				{ label: 'Hypervisor', autogenerate: { directory: 'layers/hypervisor' } },
+				{ label: 'Organization', autogenerate: { directory: 'layers/org' } },
 				{
 					label: 'API Reference',
 					items: [


### PR DESCRIPTION
Adds the org layer sidebar entry to `docs/astro.config.mjs`. The MDX files already exist in `layers/org/src/` and the sync script already copies them — only the sidebar config was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)