### PR TITLE
fix(core): lowercase ULID IDs

### DIFF
--- a/layers/core/src/id.rs
+++ b/layers/core/src/id.rs
@@ -50,9 +50,9 @@ pub enum IdError {
     },
 }
 
-/// Generate a ULID string (26-char Crockford base32, uppercase).
+/// Generate a ULID string (26-char Crockford base32, lowercase).
 fn generate_ulid() -> String {
-    ulid::Ulid::new().to_string()
+    ulid::Ulid::new().to_string().to_lowercase()
 }
 
 /// Extract the timestamp (milliseconds since epoch) from a ULID string.


### PR DESCRIPTION
One-line change: `ulid.to_string().to_lowercase()`

Before: `org-01KNPZ5V42DYE2ZEN44ACK6SKF`
After: `org-01knpz5v42dye2zen44ack6skf`

Matches RFC 3986 URI conventions and aligns with AWS/GCP/Stripe patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)