### PR TITLE
feat(network): add VPC, Subnet, VPC Peering layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,6 +1444,7 @@ dependencies = [
  "http 1.4.0",
  "nauka-core",
  "nauka-hypervisor",
+ "nauka-network",
  "nauka-org",
  "nauka-state",
  "openssl",
@@ -1546,6 +1547,25 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower 0.5.3",
+]
+
+[[package]]
+name = "nauka-network"
+version = "2.0.0"
+dependencies = [
+ "anyhow",
+ "ipnet",
+ "nauka-core",
+ "nauka-hypervisor",
+ "nauka-org",
+ "nauka-state",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tikv-client",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "layers/hypervisor",
     "layers/hypervisor/tests/e2e",
     "layers/org",
+    "layers/network",
     "bin/nauka",
 ]
 
@@ -32,3 +33,4 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 hyper = "1"
 openssl = { version = "0.10", features = ["vendored"] }
+ipnet = "2"

--- a/bin/nauka/Cargo.toml
+++ b/bin/nauka/Cargo.toml
@@ -19,6 +19,7 @@ nauka-core = { path = "../../layers/core" }
 nauka-state = { path = "../../layers/state" }
 nauka-hypervisor = { path = "../../layers/hypervisor" }
 nauka-org = { path = "../../layers/org" }
+nauka-network = { path = "../../layers/network" }
 clap.workspace = true
 anyhow.workspace = true
 serde_json.workspace = true

--- a/bin/nauka/src/main.rs
+++ b/bin/nauka/src/main.rs
@@ -15,6 +15,9 @@ fn build_registry() -> ResourceRegistry {
     // Org hierarchy (org → project → env)
     registry.register(nauka_org::registration());
 
+    // Network (vpc → subnet, peering)
+    registry.register(nauka_network::registration());
+
     registry
 }
 

--- a/layers/core/src/resource/cli_gen.rs
+++ b/layers/core/src/resource/cli_gen.rs
@@ -121,6 +121,7 @@ fn generate_operation(def: &ResourceDef, op: &super::operation::OperationDef) ->
         }
 
         OperationSemantics::Action => {
+            cmd = add_scope_args(cmd, def, false);
             for arg in &op.args {
                 match &arg.source {
                     super::operation::ArgSource::Custom(field) => {

--- a/layers/network/Cargo.toml
+++ b/layers/network/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "nauka-network"
+description = "Network layer — VPC, Subnet, VPC Peering"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+nauka-core = { path = "../core" }
+nauka-state = { path = "../state" }
+nauka-hypervisor = { path = "../hypervisor" }
+nauka-org = { path = "../org" }
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+anyhow.workspace = true
+thiserror.workspace = true
+tikv-client = "0.4"
+ipnet = "2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/layers/network/src/lib.rs
+++ b/layers/network/src/lib.rs
@@ -1,0 +1,57 @@
+//! Network layer — VPC, Subnet, VPC Peering.
+//!
+//! Structure mirrors the resource hierarchy:
+//! - **VPC** — virtual private cloud scoped to an Org
+//!   - **Subnet** — scoped within a VPC
+//!   - **Peering** — connection between two VPCs
+//!
+//! CLI: `nauka vpc`, `nauka vpc subnet`, `nauka vpc peering`
+
+pub mod validate;
+pub mod vpc;
+
+use nauka_core::resource::ResourceRegistration;
+use nauka_hypervisor::controlplane;
+use nauka_hypervisor::fabric;
+use nauka_state::LocalDb;
+
+/// Top-level registration: vpc with subnet and peering as children.
+pub fn registration() -> ResourceRegistration {
+    vpc::handlers::registration()
+}
+
+/// Connect to ClusterDb via PD endpoints from fabric state.
+pub(crate) async fn connect_cluster_db() -> anyhow::Result<controlplane::ClusterDb> {
+    let dir = nauka_core::process::nauka_dir();
+    let _ = std::fs::create_dir_all(&dir);
+    let db = LocalDb::open("hypervisor")?;
+
+    let state = fabric::state::FabricState::load(&db)
+        .map_err(|e| anyhow::anyhow!("{e}"))?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "cluster not initialized.\n\n\
+                 Initialize a cluster first with:\n\
+                 \x20 nauka hypervisor init"
+            )
+        })?;
+
+    let self_endpoint = format!(
+        "http://[{}]:{}",
+        state.hypervisor.mesh_ipv6,
+        controlplane::PD_CLIENT_PORT,
+    );
+    let mut endpoints = vec![self_endpoint];
+    for peer in &state.peers.peers {
+        endpoints.push(format!(
+            "http://[{}]:{}",
+            peer.mesh_ipv6,
+            controlplane::PD_CLIENT_PORT,
+        ));
+    }
+    let refs: Vec<&str> = endpoints.iter().map(|s| s.as_str()).collect();
+
+    controlplane::ClusterDb::connect(&refs)
+        .await
+        .map_err(Into::into)
+}

--- a/layers/network/src/overview.mdx
+++ b/layers/network/src/overview.mdx
@@ -1,0 +1,50 @@
+---
+title: Network Layer
+description: Virtual networking — VPCs, subnets, and peering for isolated cloud networks over the WireGuard mesh.
+sidebar:
+  order: 1
+---
+
+The network layer provides virtual networking on top of the WireGuard mesh. Every VM runs inside a VPC (Virtual Private Cloud) with its own isolated network, connected to a subnet with a private IP address.
+
+## Architecture
+
+```
+VPC (prod-net, CIDR 10.0.0.0/16, VNI 100)
+├── Subnet (web, 10.0.1.0/24, gateway 10.0.1.1)
+├── Subnet (api, 10.0.2.0/24, gateway 10.0.2.1)
+└── Peering → partner-net
+```
+
+- **VPC** — an isolated L2 network backed by a VXLAN tunnel. Each VPC gets a unique VNI (VXLAN Network Identifier). Traffic between VPCs is blocked unless peered.
+- **Subnet** — an IP allocation range within a VPC. Subnets are cross-zone (a VM in any zone can use any subnet).
+- **Peering** — connects two VPCs so their VMs can communicate. CIDRs must not overlap.
+
+## VPC scoping
+
+A VPC belongs to an organization. Optionally, it can be scoped to a project or environment:
+
+```bash
+# Shared VPC (available to all projects in the org)
+nauka vpc create shared-net --org acme --cidr 10.0.0.0/16
+
+# Dedicated to a project
+nauka vpc create backend-net --org acme --cidr 10.1.0.0/16 --project backend
+
+# Dedicated to an environment
+nauka vpc create prod-net --org acme --cidr 10.2.0.0/16 --project backend --env production
+```
+
+## Quick start
+
+```bash
+# Create a VPC
+nauka vpc create prod-net --org acme --cidr 10.0.0.0/16
+
+# Add subnets
+nauka vpc subnet create web --vpc prod-net --cidr 10.0.1.0/24
+nauka vpc subnet create api --vpc prod-net --cidr 10.0.2.0/24
+
+# Peer two VPCs
+nauka vpc peering create --vpc prod-net --peer-vpc staging-net
+```

--- a/layers/network/src/validate.rs
+++ b/layers/network/src/validate.rs
@@ -1,0 +1,107 @@
+//! Network validation — CIDR parsing, containment, overlap checks.
+
+/// Validate a CIDR is a valid private range (RFC 1918) with prefix /8-/24.
+pub fn private_cidr(cidr: &str) -> anyhow::Result<ipnet::Ipv4Net> {
+    let net: ipnet::Ipv4Net = cidr
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid CIDR '{cidr}': {e}"))?;
+
+    let prefix = net.prefix_len();
+    if !(8..=24).contains(&prefix) {
+        anyhow::bail!("CIDR prefix must be between /8 and /24, got /{prefix}");
+    }
+
+    let ip = net.network();
+    let is_private = ip.octets()[0] == 10
+        || (ip.octets()[0] == 172 && (16..=31).contains(&ip.octets()[1]))
+        || (ip.octets()[0] == 192 && ip.octets()[1] == 168);
+
+    if !is_private {
+        anyhow::bail!(
+            "CIDR must be a private range (10.0.0.0/8, 172.16.0.0/12, or 192.168.0.0/16)"
+        );
+    }
+
+    Ok(net)
+}
+
+/// Validate a subnet CIDR is within a VPC CIDR.
+pub fn subnet_within_vpc(subnet_cidr: &str, vpc_cidr: &str) -> anyhow::Result<ipnet::Ipv4Net> {
+    let subnet: ipnet::Ipv4Net = subnet_cidr
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid subnet CIDR '{subnet_cidr}': {e}"))?;
+    let vpc: ipnet::Ipv4Net = vpc_cidr
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid VPC CIDR '{vpc_cidr}': {e}"))?;
+
+    if !vpc.contains(&subnet) {
+        anyhow::bail!("subnet {subnet} is not within VPC CIDR {vpc}");
+    }
+
+    Ok(subnet)
+}
+
+/// Check that a new CIDR doesn't overlap with any existing CIDRs.
+pub fn no_overlap(new_cidr: &ipnet::Ipv4Net, existing: &[String]) -> anyhow::Result<()> {
+    for existing_str in existing {
+        if let Ok(existing_net) = existing_str.parse::<ipnet::Ipv4Net>() {
+            if new_cidr.contains(&existing_net) || existing_net.contains(new_cidr) {
+                anyhow::bail!("CIDR {new_cidr} overlaps with existing {existing_net}");
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Compute the gateway IP (first host address) from a CIDR.
+pub fn gateway(cidr: &ipnet::Ipv4Net) -> String {
+    let hosts = cidr.hosts();
+    hosts
+        .into_iter()
+        .next()
+        .map(|ip| ip.to_string())
+        .unwrap_or_else(|| cidr.network().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_private_cidrs() {
+        assert!(private_cidr("10.0.0.0/16").is_ok());
+        assert!(private_cidr("172.16.0.0/12").is_ok());
+        assert!(private_cidr("192.168.0.0/24").is_ok());
+    }
+
+    #[test]
+    fn reject_public_cidr() {
+        assert!(private_cidr("8.8.8.0/24").is_err());
+    }
+
+    #[test]
+    fn reject_bad_prefix() {
+        assert!(private_cidr("10.0.0.0/4").is_err()); // too wide
+        assert!(private_cidr("10.0.0.0/28").is_err()); // too narrow
+    }
+
+    #[test]
+    fn subnet_containment() {
+        assert!(subnet_within_vpc("10.0.1.0/24", "10.0.0.0/16").is_ok());
+        assert!(subnet_within_vpc("10.1.0.0/24", "10.0.0.0/16").is_err());
+    }
+
+    #[test]
+    fn overlap_detection() {
+        let net: ipnet::Ipv4Net = "10.0.1.0/24".parse().unwrap();
+        assert!(no_overlap(&net, &["10.0.2.0/24".to_string()]).is_ok());
+        assert!(no_overlap(&net, &["10.0.1.0/25".to_string()]).is_err());
+        assert!(no_overlap(&net, &["10.0.0.0/16".to_string()]).is_err());
+    }
+
+    #[test]
+    fn gateway_computation() {
+        let net: ipnet::Ipv4Net = "10.0.1.0/24".parse().unwrap();
+        assert_eq!(gateway(&net), "10.0.1.1");
+    }
+}

--- a/layers/network/src/vpc/handlers.rs
+++ b/layers/network/src/vpc/handlers.rs
@@ -1,0 +1,126 @@
+use std::future::Future;
+use std::pin::Pin;
+
+use nauka_core::resource::*;
+
+use super::store::VpcStore;
+
+pub fn resource_def() -> ResourceDef {
+    ResourceDef::build("vpc", "Manage virtual private clouds")
+        .plural("vpcs")
+        .parent("org", "--org", "Organization")
+        .create()
+        .op(|op| {
+            op.with_arg(OperationArg::required(
+                "cidr",
+                FieldDef::cidr("cidr", "VPC CIDR block (e.g. 10.0.0.0/16)"),
+            ))
+            .with_arg(OperationArg::optional(
+                "project",
+                FieldDef::string("project", "Scope to a project"),
+            ))
+            .with_arg(OperationArg::optional(
+                "env",
+                FieldDef::string("env", "Scope to an environment"),
+            ))
+            .with_example("nauka vpc create prod-net --org acme --cidr 10.0.0.0/16")
+        })
+        .list()
+        .get()
+        .delete()
+        .column("NAME", "name")
+        .column("CIDR", "cidr")
+        .column("ORG", "org_name")
+        .column("VNI", "vni")
+        .column("ID", "id")
+        .column_def(ColumnDef::new("CREATED", "created_at").with_format(DisplayFormat::Timestamp))
+        .empty_message(
+            "No VPCs found. Create one with: nauka vpc create <name> --org <org> --cidr <cidr>",
+        )
+        .detail_section(
+            None,
+            vec![
+                DetailField::new("Name", "name"),
+                DetailField::new("ID", "id"),
+                DetailField::new("CIDR", "cidr"),
+                DetailField::new("VNI", "vni"),
+                DetailField::new("Organization", "org_name"),
+                DetailField::new("Created", "created_at").with_format(DisplayFormat::Timestamp),
+            ],
+        )
+        .done()
+}
+
+pub fn handler() -> HandlerFn {
+    Box::new(
+        |req: OperationRequest| -> Pin<
+            Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
+        > {
+            Box::pin(async move {
+                let store = VpcStore::new(crate::connect_cluster_db().await?);
+                match req.operation.as_str() {
+                    "create" => {
+                        let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name"))?;
+                        let org = req
+                            .scope
+                            .get("org")
+                            .ok_or_else(|| anyhow::anyhow!("--org is required"))?
+                            .to_string();
+                        let cidr = req
+                            .fields
+                            .get("cidr")
+                            .ok_or_else(|| anyhow::anyhow!("--cidr is required"))?
+                            .clone();
+                        let project = req.fields.get("project").cloned();
+                        let env = req.fields.get("env").cloned();
+                        nauka_core::validate::name(&name)?;
+                        let vpc = store.create(&name, &org, &cidr, project, env).await?;
+                        Ok(OperationResponse::Resource(vpc.to_api_json()))
+                    }
+                    "list" => {
+                        let org = req.scope.get("org").map(|s| s.to_string());
+                        let vpcs = store.list(org.as_deref()).await?;
+                        let items: Vec<serde_json::Value> =
+                            vpcs.iter().map(|v| v.to_api_json()).collect();
+                        Ok(OperationResponse::ResourceList(items))
+                    }
+                    "get" => {
+                        let name = req
+                            .name
+                            .ok_or_else(|| anyhow::anyhow!("missing name or ID"))?;
+                        let org = req.scope.get("org").map(|s| s.to_string());
+                        let vpc = store
+                            .get(&name, org.as_deref())
+                            .await?
+                            .ok_or_else(|| anyhow::anyhow!("vpc '{name}' not found"))?;
+                        Ok(OperationResponse::Resource(vpc.to_api_json()))
+                    }
+                    "delete" => {
+                        let name = req
+                            .name
+                            .ok_or_else(|| anyhow::anyhow!("missing name or ID"))?;
+                        let org = req
+                            .scope
+                            .get("org")
+                            .ok_or_else(|| anyhow::anyhow!("--org is required"))?
+                            .to_string();
+                        store.delete(&name, &org).await?;
+                        Ok(OperationResponse::Message(format!("vpc '{name}' deleted.")))
+                    }
+                    other => Ok(OperationResponse::Message(format!("unknown: {other}"))),
+                }
+            })
+        },
+    )
+}
+
+pub fn registration() -> ResourceRegistration {
+    ResourceRegistration {
+        def: resource_def(),
+        handler: handler(),
+        children: vec![
+            super::subnet::handlers::registration(),
+            super::peering::handlers::registration(),
+        ],
+    }
+}

--- a/layers/network/src/vpc/mod.rs
+++ b/layers/network/src/vpc/mod.rs
@@ -1,0 +1,5 @@
+pub mod handlers;
+pub mod peering;
+pub mod store;
+pub mod subnet;
+pub mod types;

--- a/layers/network/src/vpc/overview.mdx
+++ b/layers/network/src/vpc/overview.mdx
@@ -1,0 +1,43 @@
+---
+title: VPCs
+description: Virtual Private Clouds — isolated networks with private CIDR ranges and automatic VNI assignment.
+sidebar:
+  order: 2
+---
+
+A VPC is an isolated virtual network. Each VPC gets a unique VXLAN Network Identifier (VNI) and a private CIDR block. VMs in different VPCs cannot communicate unless the VPCs are peered.
+
+## Creating a VPC
+
+```bash
+nauka vpc create prod-net --org acme --cidr 10.0.0.0/16
+```
+
+```
+  Name:            prod-net
+  ID:              vpc-01knq...
+  CIDR:            10.0.0.0/16
+  VNI:             100
+  Organization:    acme
+```
+
+The CIDR must be a private range (RFC 1918) with a prefix between /8 and /24.
+
+## Listing and inspecting
+
+```bash
+nauka vpc list --org acme
+nauka vpc get prod-net --org acme
+```
+
+## Deleting
+
+A VPC cannot be deleted while it has subnets:
+
+```
+Error: vpc 'prod-net' has 2 subnet(s). Delete them first.
+```
+
+## VNI assignment
+
+Each VPC automatically receives a unique VNI starting at 100. VNIs are never reused. The VNI maps directly to a VXLAN tunnel that isolates the VPC's traffic on the mesh.

--- a/layers/network/src/vpc/peering/handlers.rs
+++ b/layers/network/src/vpc/peering/handlers.rs
@@ -1,0 +1,106 @@
+use std::future::Future;
+use std::pin::Pin;
+
+use nauka_core::resource::*;
+
+use super::store::PeeringStore;
+
+pub fn resource_def() -> ResourceDef {
+    ResourceDef::build("peering", "Manage VPC peering connections")
+        .plural("peerings")
+        .parent("org", "--org", "Organization")
+        .parent("vpc", "--vpc", "VPC")
+        .action("create", "Create a peering connection")
+        .op(|op| {
+            op.with_arg(OperationArg::required(
+                "peer-vpc",
+                FieldDef::string("peer-vpc", "VPC to peer with"),
+            ))
+        })
+        .list()
+        .get()
+        .delete()
+        .column("NAME", "name")
+        .column("VPC", "vpc_name")
+        .column("PEER", "peer_vpc_name")
+        .column("STATE", "state")
+        .column("ID", "id")
+        .empty_message("No peerings found.")
+        .detail_section(
+            None,
+            vec![
+                DetailField::new("Name", "name"),
+                DetailField::new("ID", "id"),
+                DetailField::new("VPC", "vpc_name"),
+                DetailField::new("Peer VPC", "peer_vpc_name"),
+                DetailField::new("State", "state"),
+                DetailField::new("Created", "created_at").with_format(DisplayFormat::Timestamp),
+            ],
+        )
+        .done()
+}
+
+pub fn handler() -> HandlerFn {
+    Box::new(
+        |req: OperationRequest| -> Pin<
+            Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
+        > {
+            Box::pin(async move {
+                let store = PeeringStore::new(crate::connect_cluster_db().await?);
+                match req.operation.as_str() {
+                    "create" => {
+                        let vpc = req
+                            .scope
+                            .get("vpc")
+                            .ok_or_else(|| anyhow::anyhow!("--vpc is required"))?
+                            .to_string();
+                        let org = req.scope.get("org").map(|s| s.to_string());
+                        let peer_vpc = req
+                            .fields
+                            .get("peer-vpc")
+                            .ok_or_else(|| anyhow::anyhow!("--peer-vpc is required"))?
+                            .clone();
+                        let peering =
+                            store.create(&vpc, &peer_vpc, org.as_deref()).await?;
+                        Ok(OperationResponse::Resource(peering.to_api_json()))
+                    }
+                    "list" => {
+                        let vpc = req.scope.get("vpc").map(|s| s.to_string());
+                        let peerings = store.list(vpc.as_deref()).await?;
+                        let items: Vec<serde_json::Value> =
+                            peerings.iter().map(|p| p.to_api_json()).collect();
+                        Ok(OperationResponse::ResourceList(items))
+                    }
+                    "get" => {
+                        let name = req
+                            .name
+                            .ok_or_else(|| anyhow::anyhow!("missing peering ID"))?;
+                        let peering = store
+                            .get(&name)
+                            .await?
+                            .ok_or_else(|| anyhow::anyhow!("peering '{name}' not found"))?;
+                        Ok(OperationResponse::Resource(peering.to_api_json()))
+                    }
+                    "delete" => {
+                        let name = req
+                            .name
+                            .ok_or_else(|| anyhow::anyhow!("missing peering ID"))?;
+                        store.delete(&name).await?;
+                        Ok(OperationResponse::Message(format!(
+                            "peering '{name}' deleted."
+                        )))
+                    }
+                    other => Ok(OperationResponse::Message(format!("unknown: {other}"))),
+                }
+            })
+        },
+    )
+}
+
+pub fn registration() -> ResourceRegistration {
+    ResourceRegistration {
+        def: resource_def(),
+        handler: handler(),
+        children: vec![],
+    }
+}

--- a/layers/network/src/vpc/peering/mod.rs
+++ b/layers/network/src/vpc/peering/mod.rs
@@ -1,0 +1,3 @@
+pub mod handlers;
+pub mod store;
+pub mod types;

--- a/layers/network/src/vpc/peering/overview.mdx
+++ b/layers/network/src/vpc/peering/overview.mdx
@@ -1,0 +1,46 @@
+---
+title: VPC Peering
+description: Connect two VPCs so their VMs can communicate across network boundaries.
+sidebar:
+  order: 4
+---
+
+VPC peering connects two isolated VPCs so VMs in either network can reach each other. Traffic flows directly — no NAT, no gateway.
+
+## Creating a peering
+
+```bash
+nauka vpc peering create --vpc prod-net --peer-vpc staging-net
+```
+
+```
+  Name:            prod-net-to-staging-net
+  VPC:             prod-net
+  Peer VPC:        staging-net
+  State:           active
+```
+
+The name is auto-generated from the two VPC names.
+
+## Requirements
+
+- The two VPCs must have **non-overlapping CIDRs** (otherwise routing is ambiguous)
+- A VPC **cannot peer with itself**
+- Only **one peering** can exist between any two VPCs
+
+```bash
+# ✗ Rejected — CIDRs overlap
+nauka vpc peering create --vpc net-a --peer-vpc net-b
+# Error: VPC CIDRs overlap: 10.0.0.0/16 and 10.0.0.0/16
+
+# ✗ Rejected — already peered
+nauka vpc peering create --vpc prod-net --peer-vpc staging-net
+# Error: peering already exists between 'prod-net' and 'staging-net'
+```
+
+## Listing peerings
+
+```bash
+# All peerings for a VPC (shows both directions)
+nauka vpc peering list --vpc prod-net
+```

--- a/layers/network/src/vpc/peering/store.rs
+++ b/layers/network/src/vpc/peering/store.rs
@@ -1,0 +1,151 @@
+use nauka_core::id::PeeringId;
+use nauka_core::resource::ResourceMeta;
+use nauka_hypervisor::controlplane::ClusterDb;
+
+use super::types::{PeeringState, VpcPeering};
+
+const NS_PEER: &str = "vpcpeer";
+const NS_PEER_IDX: &str = "vpcpeer-idx";
+const REG_PEERS: (&str, &str) = ("_reg", "vpcpeer-ids");
+
+pub struct PeeringStore {
+    db: ClusterDb,
+}
+
+impl PeeringStore {
+    pub fn new(db: ClusterDb) -> Self {
+        Self { db }
+    }
+
+    pub async fn create(
+        &self,
+        vpc_name_or_id: &str,
+        peer_vpc_name_or_id: &str,
+        org_name: Option<&str>,
+    ) -> anyhow::Result<VpcPeering> {
+        let vpc_store = crate::vpc::store::VpcStore::new(self.db.clone());
+        let vpc = vpc_store
+            .get(vpc_name_or_id, org_name)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("vpc '{vpc_name_or_id}' not found"))?;
+        let peer_vpc = vpc_store
+            .get(peer_vpc_name_or_id, org_name)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("vpc '{peer_vpc_name_or_id}' not found"))?;
+
+        // Can't peer with self
+        if vpc.meta.id == peer_vpc.meta.id {
+            anyhow::bail!("cannot peer a VPC with itself");
+        }
+
+        // CIDRs must not overlap
+        if let (Ok(a), Ok(b)) = (
+            vpc.cidr.parse::<ipnet::Ipv4Net>(),
+            peer_vpc.cidr.parse::<ipnet::Ipv4Net>(),
+        ) {
+            if a.contains(&b) || b.contains(&a) {
+                anyhow::bail!("VPC CIDRs overlap: {} and {}", vpc.cidr, peer_vpc.cidr);
+            }
+        }
+
+        // Check no existing peering between these two
+        let idx_key = format!("{}/{}", vpc.meta.id, peer_vpc.meta.id);
+        let reverse_key = format!("{}/{}", peer_vpc.meta.id, vpc.meta.id);
+        let existing: Option<String> = self.db.get(NS_PEER_IDX, &idx_key).await?;
+        let existing_rev: Option<String> = self.db.get(NS_PEER_IDX, &reverse_key).await?;
+        if existing.is_some() || existing_rev.is_some() {
+            anyhow::bail!(
+                "peering already exists between '{}' and '{}'",
+                vpc.meta.name,
+                peer_vpc.meta.name
+            );
+        }
+
+        let auto_name = format!("{}-to-{}", vpc.meta.name, peer_vpc.meta.name);
+        let peering = VpcPeering {
+            meta: ResourceMeta::new(PeeringId::generate().to_string(), &auto_name),
+            vpc_id: vpc.meta.id.clone().into(),
+            vpc_name: vpc.meta.name.clone(),
+            peer_vpc_id: peer_vpc.meta.id.clone().into(),
+            peer_vpc_name: peer_vpc.meta.name.clone(),
+            state: PeeringState::Active,
+        };
+
+        self.db.put(NS_PEER, &peering.meta.id, &peering).await?;
+        self.db.put(NS_PEER_IDX, &idx_key, &peering.meta.id).await?;
+        self.db
+            .put(NS_PEER_IDX, &reverse_key, &peering.meta.id)
+            .await?;
+        add_id(&self.db, &peering.meta.id).await?;
+
+        Ok(peering)
+    }
+
+    pub async fn get(&self, name_or_id: &str) -> anyhow::Result<Option<VpcPeering>> {
+        // Peerings are always looked up by ID (names are auto-generated)
+        self.db.get(NS_PEER, name_or_id).await.map_err(Into::into)
+    }
+
+    pub async fn list(&self, vpc_name: Option<&str>) -> anyhow::Result<Vec<VpcPeering>> {
+        let ids = load_ids(&self.db).await?;
+        let mut peers = Vec::new();
+        for id in &ids {
+            if let Some(p) = self.db.get::<VpcPeering>(NS_PEER, id).await? {
+                peers.push(p);
+            }
+        }
+        match vpc_name {
+            Some(name) => Ok(peers
+                .into_iter()
+                .filter(|p| {
+                    p.vpc_name == name
+                        || p.vpc_id.as_str() == name
+                        || p.peer_vpc_name == name
+                        || p.peer_vpc_id.as_str() == name
+                })
+                .collect()),
+            None => Ok(peers),
+        }
+    }
+
+    pub async fn delete(&self, name_or_id: &str) -> anyhow::Result<()> {
+        let peering = self
+            .get(name_or_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("peering '{name_or_id}' not found"))?;
+        let idx_key = format!(
+            "{}/{}",
+            peering.vpc_id.as_str(),
+            peering.peer_vpc_id.as_str()
+        );
+        let reverse_key = format!(
+            "{}/{}",
+            peering.peer_vpc_id.as_str(),
+            peering.vpc_id.as_str()
+        );
+        self.db.delete(NS_PEER, &peering.meta.id).await?;
+        self.db.delete(NS_PEER_IDX, &idx_key).await?;
+        self.db.delete(NS_PEER_IDX, &reverse_key).await?;
+        remove_id(&self.db, &peering.meta.id).await?;
+        Ok(())
+    }
+}
+
+async fn load_ids(db: &ClusterDb) -> anyhow::Result<Vec<String>> {
+    let ids: Option<Vec<String>> = db.get(REG_PEERS.0, REG_PEERS.1).await?;
+    Ok(ids.unwrap_or_default())
+}
+
+async fn add_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
+    let mut ids = load_ids(db).await?;
+    ids.push(id.to_string());
+    db.put(REG_PEERS.0, REG_PEERS.1, &ids).await?;
+    Ok(())
+}
+
+async fn remove_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
+    let mut ids = load_ids(db).await?;
+    ids.retain(|i| i != id);
+    db.put(REG_PEERS.0, REG_PEERS.1, &ids).await?;
+    Ok(())
+}

--- a/layers/network/src/vpc/peering/types.rs
+++ b/layers/network/src/vpc/peering/types.rs
@@ -1,0 +1,37 @@
+use nauka_core::id::VpcId;
+use nauka_core::resource::{ApiResource, ResourceMeta};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum PeeringState {
+    #[serde(rename = "active")]
+    Active,
+    #[serde(rename = "pending")]
+    Pending,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VpcPeering {
+    #[serde(flatten)]
+    pub meta: ResourceMeta,
+    pub vpc_id: VpcId,
+    pub vpc_name: String,
+    pub peer_vpc_id: VpcId,
+    pub peer_vpc_name: String,
+    pub state: PeeringState,
+}
+
+impl ApiResource for VpcPeering {
+    fn meta(&self) -> &ResourceMeta {
+        &self.meta
+    }
+    fn resource_fields(&self) -> serde_json::Value {
+        serde_json::json!({
+            "vpc_id": self.vpc_id.as_str(),
+            "vpc_name": self.vpc_name,
+            "peer_vpc_id": self.peer_vpc_id.as_str(),
+            "peer_vpc_name": self.peer_vpc_name,
+            "state": self.state,
+        })
+    }
+}

--- a/layers/network/src/vpc/store.rs
+++ b/layers/network/src/vpc/store.rs
@@ -1,0 +1,157 @@
+use nauka_core::id::VpcId;
+use nauka_core::resource::ResourceMeta;
+use nauka_hypervisor::controlplane::ClusterDb;
+
+use super::types::Vpc;
+
+const NS_VPC: &str = "vpc";
+const NS_VPC_IDX: &str = "vpc-idx";
+const REG_VPCS: (&str, &str) = ("_reg", "vpc-ids");
+const VNI_COUNTER: (&str, &str) = ("_reg", "vni-counter");
+const VNI_START: u32 = 100;
+
+pub struct VpcStore {
+    db: ClusterDb,
+}
+
+impl VpcStore {
+    pub fn new(db: ClusterDb) -> Self {
+        Self { db }
+    }
+
+    async fn next_vni(&self) -> anyhow::Result<u32> {
+        let current: Option<u32> = self.db.get(VNI_COUNTER.0, VNI_COUNTER.1).await?;
+        let vni = current.unwrap_or(VNI_START);
+        self.db
+            .put(VNI_COUNTER.0, VNI_COUNTER.1, &(vni + 1))
+            .await?;
+        Ok(vni)
+    }
+
+    pub async fn create(
+        &self,
+        name: &str,
+        org_name: &str,
+        cidr: &str,
+        project_id: Option<String>,
+        env_id: Option<String>,
+    ) -> anyhow::Result<Vpc> {
+        // Resolve org
+        let org_store = nauka_org::store::OrgStore::new(self.db.clone());
+        let org = org_store
+            .get(org_name)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("org '{org_name}' not found"))?;
+
+        // Validate CIDR
+        crate::validate::private_cidr(cidr)?;
+
+        // Check uniqueness within org
+        let idx_key = format!("{}/{}", org.meta.id, name);
+        let existing: Option<String> = self.db.get(NS_VPC_IDX, &idx_key).await?;
+        if existing.is_some() {
+            anyhow::bail!("vpc '{name}' already exists in org '{org_name}'");
+        }
+
+        let vni = self.next_vni().await?;
+
+        let vpc = Vpc {
+            meta: ResourceMeta::new(VpcId::generate().to_string(), name),
+            cidr: cidr.to_string(),
+            org_id: org.meta.id.clone().into(),
+            org_name: org.meta.name.clone(),
+            vni,
+            project_id: project_id.map(|s| s.into()),
+            env_id: env_id.map(|s| s.into()),
+        };
+
+        self.db.put(NS_VPC, &vpc.meta.id, &vpc).await?;
+        self.db.put(NS_VPC_IDX, &idx_key, &vpc.meta.id).await?;
+        add_id(&self.db, &vpc.meta.id).await?;
+
+        Ok(vpc)
+    }
+
+    pub async fn get(
+        &self,
+        name_or_id: &str,
+        org_name: Option<&str>,
+    ) -> anyhow::Result<Option<Vpc>> {
+        if VpcId::looks_like_id(name_or_id) {
+            return self.db.get(NS_VPC, name_or_id).await.map_err(Into::into);
+        }
+        let org_name =
+            org_name.ok_or_else(|| anyhow::anyhow!("--org required to resolve VPC by name"))?;
+        let org_store = nauka_org::store::OrgStore::new(self.db.clone());
+        let org = org_store
+            .get(org_name)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("org '{org_name}' not found"))?;
+        let idx_key = format!("{}/{}", org.meta.id, name_or_id);
+        let id: Option<String> = self.db.get(NS_VPC_IDX, &idx_key).await?;
+        match id {
+            Some(id) => self.db.get(NS_VPC, &id).await.map_err(Into::into),
+            None => Ok(None),
+        }
+    }
+
+    pub async fn list(&self, org_name: Option<&str>) -> anyhow::Result<Vec<Vpc>> {
+        let ids = load_ids(&self.db).await?;
+        let mut vpcs = Vec::new();
+        for id in &ids {
+            if let Some(v) = self.db.get::<Vpc>(NS_VPC, id).await? {
+                vpcs.push(v);
+            }
+        }
+        match org_name {
+            Some(name) => Ok(vpcs
+                .into_iter()
+                .filter(|v| v.org_name == name || v.org_id.as_str() == name)
+                .collect()),
+            None => Ok(vpcs),
+        }
+    }
+
+    pub async fn delete(&self, name_or_id: &str, org_name: &str) -> anyhow::Result<()> {
+        let vpc = self
+            .get(name_or_id, Some(org_name))
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("vpc '{name_or_id}' not found in org '{org_name}'"))?;
+
+        // Check for child subnets
+        let sub_store = super::subnet::store::SubnetStore::new(self.db.clone());
+        let subs = sub_store.list(Some(&vpc.meta.name), Some(org_name)).await?;
+        if !subs.is_empty() {
+            anyhow::bail!(
+                "vpc '{}' has {} subnet(s). Delete them first.",
+                vpc.meta.name,
+                subs.len()
+            );
+        }
+
+        let idx_key = format!("{}/{}", vpc.org_id.as_str(), vpc.meta.name);
+        self.db.delete(NS_VPC, &vpc.meta.id).await?;
+        self.db.delete(NS_VPC_IDX, &idx_key).await?;
+        remove_id(&self.db, &vpc.meta.id).await?;
+        Ok(())
+    }
+}
+
+async fn load_ids(db: &ClusterDb) -> anyhow::Result<Vec<String>> {
+    let ids: Option<Vec<String>> = db.get(REG_VPCS.0, REG_VPCS.1).await?;
+    Ok(ids.unwrap_or_default())
+}
+
+async fn add_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
+    let mut ids = load_ids(db).await?;
+    ids.push(id.to_string());
+    db.put(REG_VPCS.0, REG_VPCS.1, &ids).await?;
+    Ok(())
+}
+
+async fn remove_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
+    let mut ids = load_ids(db).await?;
+    ids.retain(|i| i != id);
+    db.put(REG_VPCS.0, REG_VPCS.1, &ids).await?;
+    Ok(())
+}

--- a/layers/network/src/vpc/subnet/handlers.rs
+++ b/layers/network/src/vpc/subnet/handlers.rs
@@ -1,0 +1,121 @@
+use std::future::Future;
+use std::pin::Pin;
+
+use nauka_core::resource::*;
+
+use super::store::SubnetStore;
+
+pub fn resource_def() -> ResourceDef {
+    ResourceDef::build("subnet", "Manage subnets within a VPC")
+        .plural("subnets")
+        .parent("org", "--org", "Organization")
+        .parent("vpc", "--vpc", "VPC")
+        .create()
+        .op(|op| {
+            op.with_arg(OperationArg::required(
+                "cidr",
+                FieldDef::cidr("cidr", "Subnet CIDR block (e.g. 10.0.1.0/24)"),
+            ))
+            .with_example("nauka vpc subnet create web --vpc prod-net --cidr 10.0.1.0/24")
+        })
+        .list()
+        .get()
+        .delete()
+        .column("NAME", "name")
+        .column("CIDR", "cidr")
+        .column("GATEWAY", "gateway")
+        .column("VPC", "vpc_name")
+        .column("ID", "id")
+        .column_def(ColumnDef::new("CREATED", "created_at").with_format(DisplayFormat::Timestamp))
+        .empty_message(
+            "No subnets found. Create one with: nauka vpc subnet create <name> --vpc <vpc> --cidr <cidr>",
+        )
+        .detail_section(
+            None,
+            vec![
+                DetailField::new("Name", "name"),
+                DetailField::new("ID", "id"),
+                DetailField::new("CIDR", "cidr"),
+                DetailField::new("Gateway", "gateway"),
+                DetailField::new("VPC", "vpc_name"),
+                DetailField::new("Created", "created_at").with_format(DisplayFormat::Timestamp),
+            ],
+        )
+        .done()
+}
+
+pub fn handler() -> HandlerFn {
+    Box::new(
+        |req: OperationRequest| -> Pin<
+            Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
+        > {
+            Box::pin(async move {
+                let store = SubnetStore::new(crate::connect_cluster_db().await?);
+                match req.operation.as_str() {
+                    "create" => {
+                        let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name"))?;
+                        let vpc = req
+                            .scope
+                            .get("vpc")
+                            .ok_or_else(|| anyhow::anyhow!("--vpc is required"))?
+                            .to_string();
+                        let org = req.scope.get("org").map(|s| s.to_string());
+                        let cidr = req
+                            .fields
+                            .get("cidr")
+                            .ok_or_else(|| anyhow::anyhow!("--cidr is required"))?
+                            .clone();
+                        nauka_core::validate::name(&name)?;
+                        let subnet =
+                            store.create(&name, &vpc, org.as_deref(), &cidr).await?;
+                        Ok(OperationResponse::Resource(subnet.to_api_json()))
+                    }
+                    "list" => {
+                        let vpc = req.scope.get("vpc").map(|s| s.to_string());
+                        let org = req.scope.get("org").map(|s| s.to_string());
+                        let subs = store.list(vpc.as_deref(), org.as_deref()).await?;
+                        let items: Vec<serde_json::Value> =
+                            subs.iter().map(|s| s.to_api_json()).collect();
+                        Ok(OperationResponse::ResourceList(items))
+                    }
+                    "get" => {
+                        let name = req
+                            .name
+                            .ok_or_else(|| anyhow::anyhow!("missing name or ID"))?;
+                        let vpc = req.scope.get("vpc").map(|s| s.to_string());
+                        let org = req.scope.get("org").map(|s| s.to_string());
+                        let subnet = store
+                            .get(&name, vpc.as_deref(), org.as_deref())
+                            .await?
+                            .ok_or_else(|| anyhow::anyhow!("subnet '{name}' not found"))?;
+                        Ok(OperationResponse::Resource(subnet.to_api_json()))
+                    }
+                    "delete" => {
+                        let name = req
+                            .name
+                            .ok_or_else(|| anyhow::anyhow!("missing name or ID"))?;
+                        let vpc = req
+                            .scope
+                            .get("vpc")
+                            .ok_or_else(|| anyhow::anyhow!("--vpc is required"))?
+                            .to_string();
+                        let org = req.scope.get("org").map(|s| s.to_string());
+                        store.delete(&name, &vpc, org.as_deref()).await?;
+                        Ok(OperationResponse::Message(format!(
+                            "subnet '{name}' deleted."
+                        )))
+                    }
+                    other => Ok(OperationResponse::Message(format!("unknown: {other}"))),
+                }
+            })
+        },
+    )
+}
+
+pub fn registration() -> ResourceRegistration {
+    ResourceRegistration {
+        def: resource_def(),
+        handler: handler(),
+        children: vec![],
+    }
+}

--- a/layers/network/src/vpc/subnet/mod.rs
+++ b/layers/network/src/vpc/subnet/mod.rs
@@ -1,0 +1,3 @@
+pub mod handlers;
+pub mod store;
+pub mod types;

--- a/layers/network/src/vpc/subnet/overview.mdx
+++ b/layers/network/src/vpc/subnet/overview.mdx
@@ -1,0 +1,42 @@
+---
+title: Subnets
+description: IP address ranges within a VPC for VM placement.
+sidebar:
+  order: 3
+---
+
+A subnet is an IP range within a VPC. When a VM is created, it gets an IP from its subnet. Subnets are cross-zone — a VM in any availability zone can use any subnet.
+
+## Creating a subnet
+
+```bash
+nauka vpc subnet create web --vpc prod-net --cidr 10.0.1.0/24
+```
+
+```
+  Name:            web
+  ID:              sub-01knq...
+  CIDR:            10.0.1.0/24
+  Gateway:         10.0.1.1
+  VPC:             prod-net
+```
+
+The gateway is automatically set to the first usable IP in the range.
+
+## Validation
+
+- The subnet CIDR must be within the parent VPC's CIDR
+- Subnets in the same VPC must not overlap
+
+```bash
+# ✓ Valid — 10.0.1.0/24 is within 10.0.0.0/16
+nauka vpc subnet create web --vpc prod-net --cidr 10.0.1.0/24
+
+# ✗ Rejected — overlaps with the 'web' subnet
+nauka vpc subnet create api --vpc prod-net --cidr 10.0.1.0/25
+# Error: CIDR 10.0.1.0/25 overlaps with existing 10.0.1.0/24
+
+# ✗ Rejected — outside VPC CIDR
+nauka vpc subnet create ext --vpc prod-net --cidr 192.168.0.0/24
+# Error: subnet 192.168.0.0/24 is not within VPC CIDR 10.0.0.0/16
+```

--- a/layers/network/src/vpc/subnet/store.rs
+++ b/layers/network/src/vpc/subnet/store.rs
@@ -1,0 +1,147 @@
+use nauka_core::id::SubnetId;
+use nauka_core::resource::ResourceMeta;
+use nauka_hypervisor::controlplane::ClusterDb;
+
+use super::types::Subnet;
+
+const NS_SUB: &str = "sub";
+const NS_SUB_IDX: &str = "sub-idx";
+const REG_SUBS: (&str, &str) = ("_reg", "sub-ids");
+
+pub struct SubnetStore {
+    db: ClusterDb,
+}
+
+impl SubnetStore {
+    pub fn new(db: ClusterDb) -> Self {
+        Self { db }
+    }
+
+    pub async fn create(
+        &self,
+        name: &str,
+        vpc_name_or_id: &str,
+        org_name: Option<&str>,
+        cidr: &str,
+    ) -> anyhow::Result<Subnet> {
+        let vpc_store = crate::vpc::store::VpcStore::new(self.db.clone());
+        let vpc = vpc_store
+            .get(vpc_name_or_id, org_name)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("vpc '{vpc_name_or_id}' not found"))?;
+
+        // Validate subnet is within VPC
+        let subnet_net = crate::validate::subnet_within_vpc(cidr, &vpc.cidr)?;
+
+        // Check overlap with existing subnets
+        let existing_subs = self.list(Some(&vpc.meta.name), None).await?;
+        let existing_cidrs: Vec<String> = existing_subs.iter().map(|s| s.cidr.clone()).collect();
+        crate::validate::no_overlap(&subnet_net, &existing_cidrs)?;
+
+        // Check uniqueness within VPC
+        let idx_key = format!("{}/{}", vpc.meta.id, name);
+        let existing: Option<String> = self.db.get(NS_SUB_IDX, &idx_key).await?;
+        if existing.is_some() {
+            anyhow::bail!("subnet '{name}' already exists in vpc '{}'", vpc.meta.name);
+        }
+
+        let gw = crate::validate::gateway(&subnet_net);
+
+        let subnet = Subnet {
+            meta: ResourceMeta::new(SubnetId::generate().to_string(), name),
+            vpc_id: vpc.meta.id.clone().into(),
+            vpc_name: vpc.meta.name.clone(),
+            cidr: cidr.to_string(),
+            gateway: gw,
+        };
+
+        self.db.put(NS_SUB, &subnet.meta.id, &subnet).await?;
+        self.db.put(NS_SUB_IDX, &idx_key, &subnet.meta.id).await?;
+        add_id(&self.db, &subnet.meta.id).await?;
+
+        Ok(subnet)
+    }
+
+    pub async fn get(
+        &self,
+        name_or_id: &str,
+        vpc_name_or_id: Option<&str>,
+        org_name: Option<&str>,
+    ) -> anyhow::Result<Option<Subnet>> {
+        if SubnetId::looks_like_id(name_or_id) {
+            return self.db.get(NS_SUB, name_or_id).await.map_err(Into::into);
+        }
+        let vpc_name = vpc_name_or_id
+            .ok_or_else(|| anyhow::anyhow!("--vpc required to resolve subnet by name"))?;
+        let vpc_store = crate::vpc::store::VpcStore::new(self.db.clone());
+        let vpc = vpc_store
+            .get(vpc_name, org_name)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("vpc '{vpc_name}' not found"))?;
+        let idx_key = format!("{}/{}", vpc.meta.id, name_or_id);
+        let id: Option<String> = self.db.get(NS_SUB_IDX, &idx_key).await?;
+        match id {
+            Some(id) => self.db.get(NS_SUB, &id).await.map_err(Into::into),
+            None => Ok(None),
+        }
+    }
+
+    pub async fn list(
+        &self,
+        vpc_name: Option<&str>,
+        _org_name: Option<&str>,
+    ) -> anyhow::Result<Vec<Subnet>> {
+        let ids = load_ids(&self.db).await?;
+        let mut subs = Vec::new();
+        for id in &ids {
+            if let Some(s) = self.db.get::<Subnet>(NS_SUB, id).await? {
+                subs.push(s);
+            }
+        }
+        match vpc_name {
+            Some(name) => Ok(subs
+                .into_iter()
+                .filter(|s| s.vpc_name == name || s.vpc_id.as_str() == name)
+                .collect()),
+            None => Ok(subs),
+        }
+    }
+
+    pub async fn delete(
+        &self,
+        name_or_id: &str,
+        vpc_name: &str,
+        org_name: Option<&str>,
+    ) -> anyhow::Result<()> {
+        let subnet = self
+            .get(name_or_id, Some(vpc_name), org_name)
+            .await?
+            .ok_or_else(|| {
+                anyhow::anyhow!("subnet '{name_or_id}' not found in vpc '{vpc_name}'")
+            })?;
+        let idx_key = format!("{}/{}", subnet.vpc_id.as_str(), subnet.meta.name);
+        self.db.delete(NS_SUB, &subnet.meta.id).await?;
+        self.db.delete(NS_SUB_IDX, &idx_key).await?;
+        remove_id(&self.db, &subnet.meta.id).await?;
+        Ok(())
+    }
+}
+
+async fn load_ids(db: &ClusterDb) -> anyhow::Result<Vec<String>> {
+    let ids: Option<Vec<String>> = db.get(REG_SUBS.0, REG_SUBS.1).await?;
+    Ok(ids.unwrap_or_default())
+}
+
+async fn add_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
+    let mut ids = load_ids(db).await?;
+    ids.push(id.to_string());
+    db.put(REG_SUBS.0, REG_SUBS.1, &ids).await?;
+    Ok(())
+}
+
+async fn remove_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
+    let mut ids = load_ids(db).await?;
+    ids.retain(|i| i != id);
+    db.put(REG_SUBS.0, REG_SUBS.1, &ids).await?;
+    Ok(())
+}

--- a/layers/network/src/vpc/subnet/types.rs
+++ b/layers/network/src/vpc/subnet/types.rs
@@ -1,0 +1,27 @@
+use nauka_core::id::VpcId;
+use nauka_core::resource::{ApiResource, ResourceMeta};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Subnet {
+    #[serde(flatten)]
+    pub meta: ResourceMeta,
+    pub vpc_id: VpcId,
+    pub vpc_name: String,
+    pub cidr: String,
+    pub gateway: String,
+}
+
+impl ApiResource for Subnet {
+    fn meta(&self) -> &ResourceMeta {
+        &self.meta
+    }
+    fn resource_fields(&self) -> serde_json::Value {
+        serde_json::json!({
+            "vpc_id": self.vpc_id.as_str(),
+            "vpc_name": self.vpc_name,
+            "cidr": self.cidr,
+            "gateway": self.gateway,
+        })
+    }
+}

--- a/layers/network/src/vpc/types.rs
+++ b/layers/network/src/vpc/types.rs
@@ -1,0 +1,38 @@
+use nauka_core::id::{EnvId, OrgId, ProjectId};
+use nauka_core::resource::{ApiResource, ResourceMeta};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Vpc {
+    #[serde(flatten)]
+    pub meta: ResourceMeta,
+    pub cidr: String,
+    pub org_id: OrgId,
+    pub org_name: String,
+    pub vni: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<ProjectId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env_id: Option<EnvId>,
+}
+
+impl ApiResource for Vpc {
+    fn meta(&self) -> &ResourceMeta {
+        &self.meta
+    }
+    fn resource_fields(&self) -> serde_json::Value {
+        let mut fields = serde_json::json!({
+            "cidr": self.cidr,
+            "org_id": self.org_id.as_str(),
+            "org_name": self.org_name,
+            "vni": self.vni,
+        });
+        if let Some(ref pid) = self.project_id {
+            fields["project_id"] = serde_json::json!(pid.as_str());
+        }
+        if let Some(ref eid) = self.env_id {
+            fields["env_id"] = serde_json::json!(eid.as_str());
+        }
+        fields
+    }
+}


### PR DESCRIPTION
## Summary
New `layers/network` crate with CRUD for virtual networking:

- **VPC**: isolated L2 network with auto-assigned VNI, private CIDR (RFC 1918), optional project/env scoping, cascade delete protection
- **Subnet**: IP range within a VPC with CIDR containment + overlap validation, auto-computed gateway
- **VPC Peering**: bidirectional connection between VPCs with self-peer and CIDR overlap guards

## CLI
```
nauka vpc create prod-net --org acme --cidr 10.0.0.0/16
nauka vpc subnet create web --vpc prod-net --cidr 10.0.1.0/24
nauka vpc peering create --vpc prod-net --peer-vpc staging-net
```

## Validation
- CIDR must be private (RFC 1918) with prefix /8-/24
- Subnets must be within VPC CIDR and not overlap
- Peering rejects self-peer, duplicate, and overlapping CIDRs
- VPC can't be deleted while subnets exist

## Test plan
- [x] `cargo build` + `cargo clippy` clean
- [x] 6 CIDR validation unit tests
- [x] Full CLI CRUD on Hetzner: VPC create/list/get/delete
- [x] Subnet create with overlap/containment validation
- [x] VPC Peering with self-peer/duplicate guards
- [x] Cascade delete protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)