### PR TITLE
feat(compute): add VM lifecycle layer (CRUD + start/stop)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1442,6 +1442,7 @@ dependencies = [
  "clap",
  "flate2",
  "http 1.4.0",
+ "nauka-compute",
  "nauka-core",
  "nauka-hypervisor",
  "nauka-network",
@@ -1458,6 +1459,25 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "nauka-compute"
+version = "2.0.0"
+dependencies = [
+ "anyhow",
+ "nauka-core",
+ "nauka-hypervisor",
+ "nauka-network",
+ "nauka-org",
+ "nauka-state",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tikv-client",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "layers/hypervisor/tests/e2e",
     "layers/org",
     "layers/network",
+    "layers/compute",
     "bin/nauka",
 ]
 

--- a/bin/nauka/Cargo.toml
+++ b/bin/nauka/Cargo.toml
@@ -20,6 +20,7 @@ nauka-state = { path = "../../layers/state" }
 nauka-hypervisor = { path = "../../layers/hypervisor" }
 nauka-org = { path = "../../layers/org" }
 nauka-network = { path = "../../layers/network" }
+nauka-compute = { path = "../../layers/compute" }
 clap.workspace = true
 anyhow.workspace = true
 serde_json.workspace = true

--- a/bin/nauka/src/main.rs
+++ b/bin/nauka/src/main.rs
@@ -18,6 +18,9 @@ fn build_registry() -> ResourceRegistry {
     // Network (vpc → subnet, peering)
     registry.register(nauka_network::registration());
 
+    // Compute (vm)
+    registry.register(nauka_compute::registration());
+
     registry
 }
 

--- a/layers/compute/Cargo.toml
+++ b/layers/compute/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "nauka-compute"
+description = "Compute layer — virtual machine lifecycle"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+nauka-core = { path = "../core" }
+nauka-state = { path = "../state" }
+nauka-hypervisor = { path = "../hypervisor" }
+nauka-org = { path = "../org" }
+nauka-network = { path = "../network" }
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+anyhow.workspace = true
+thiserror.workspace = true
+tikv-client = "0.4"
+
+[dev-dependencies]
+tempfile = "3"

--- a/layers/compute/src/lib.rs
+++ b/layers/compute/src/lib.rs
@@ -1,0 +1,54 @@
+//! Compute layer — virtual machine lifecycle.
+//!
+//! Structure:
+//! - **VM** — virtual machine scoped to an Org/Project/Env, placed on a subnet
+//!
+//! CLI: `nauka vm`
+
+pub mod vm;
+
+use nauka_core::resource::ResourceRegistration;
+use nauka_hypervisor::controlplane;
+use nauka_hypervisor::fabric;
+use nauka_state::LocalDb;
+
+/// Top-level registration: vm resource.
+pub fn registration() -> ResourceRegistration {
+    vm::handlers::registration()
+}
+
+/// Connect to ClusterDb via PD endpoints from fabric state.
+pub(crate) async fn connect_cluster_db() -> anyhow::Result<controlplane::ClusterDb> {
+    let dir = nauka_core::process::nauka_dir();
+    let _ = std::fs::create_dir_all(&dir);
+    let db = LocalDb::open("hypervisor")?;
+
+    let state = fabric::state::FabricState::load(&db)
+        .map_err(|e| anyhow::anyhow!("{e}"))?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "cluster not initialized.\n\n\
+                 Initialize a cluster first with:\n\
+                 \x20 nauka hypervisor init"
+            )
+        })?;
+
+    let self_endpoint = format!(
+        "http://[{}]:{}",
+        state.hypervisor.mesh_ipv6,
+        controlplane::PD_CLIENT_PORT,
+    );
+    let mut endpoints = vec![self_endpoint];
+    for peer in &state.peers.peers {
+        endpoints.push(format!(
+            "http://[{}]:{}",
+            peer.mesh_ipv6,
+            controlplane::PD_CLIENT_PORT,
+        ));
+    }
+    let refs: Vec<&str> = endpoints.iter().map(|s| s.as_str()).collect();
+
+    controlplane::ClusterDb::connect(&refs)
+        .await
+        .map_err(Into::into)
+}

--- a/layers/compute/src/overview.mdx
+++ b/layers/compute/src/overview.mdx
@@ -1,0 +1,40 @@
+---
+title: Compute Layer
+description: Virtual machine lifecycle — create, start, stop, and delete VMs on the Nauka mesh.
+sidebar:
+  order: 1
+---
+
+The compute layer manages virtual machines across hypervisor nodes. A VM is placed in an organization's project and environment, connected to a VPC subnet.
+
+## Creating a VM
+
+```bash
+nauka vm create web-1 \
+  --org acme --project backend --env production \
+  --vpc prod-net --subnet web \
+  --cpu 2 --memory 4096 --disk 40 --image ubuntu-24.04
+```
+
+The VM is created in `pending` state. The Forge reconciler (future) will schedule it on a hypervisor and transition it to `running`.
+
+## Lifecycle
+
+```
+pending → running → stopped → deleted
+                  ↘ deleted
+```
+
+- `nauka vm start <name>` — transitions from stopped/pending to running
+- `nauka vm stop <name>` — transitions from running to stopped
+- `nauka vm delete <name>` — only from stopped or pending
+
+## Listing VMs
+
+```bash
+# All VMs
+nauka vm list
+
+# Filter by scope
+nauka vm list --org acme --project backend --env production
+```

--- a/layers/compute/src/vm/handlers.rs
+++ b/layers/compute/src/vm/handlers.rs
@@ -1,0 +1,261 @@
+use std::future::Future;
+use std::pin::Pin;
+
+use nauka_core::resource::*;
+
+use super::store::VmStore;
+use super::types::VmState;
+
+pub fn resource_def() -> ResourceDef {
+    ResourceDef::build("vm", "Manage virtual machines")
+        .plural("vms")
+        .parent("org", "--org", "Organization")
+        .create()
+        .op(|op| {
+            op.with_arg(OperationArg::required(
+                "project",
+                FieldDef::string("project", "Project"),
+            ))
+            .with_arg(OperationArg::required(
+                "env",
+                FieldDef::string("env", "Environment"),
+            ))
+            .with_arg(OperationArg::required(
+                "vpc",
+                FieldDef::string("vpc", "VPC"),
+            ))
+            .with_arg(OperationArg::required(
+                "subnet",
+                FieldDef::string("subnet", "Subnet"),
+            ))
+            .with_arg(OperationArg::required(
+                "cpu",
+                FieldDef::integer("cpu", "Number of vCPUs"),
+            ))
+            .with_arg(OperationArg::required(
+                "memory",
+                FieldDef::integer("memory", "Memory in MB"),
+            ))
+            .with_arg(OperationArg::required(
+                "disk",
+                FieldDef::integer("disk", "Disk size in GB"),
+            ))
+            .with_arg(OperationArg::required(
+                "image",
+                FieldDef::string("image", "OS image (e.g. ubuntu-24.04)"),
+            ))
+            .with_arg(OperationArg::optional(
+                "region",
+                FieldDef::string("region", "Region").with_default("default"),
+            ))
+            .with_arg(OperationArg::optional(
+                "zone",
+                FieldDef::string("zone", "Zone").with_default("default"),
+            ))
+            .with_example(
+                "nauka vm create web-1 --org acme --project backend --env production --vpc prod-net --subnet web --cpu 2 --memory 4096 --disk 40 --image ubuntu-24.04",
+            )
+        })
+        .list()
+        .op(|op| {
+            op.with_arg(OperationArg::optional(
+                "project",
+                FieldDef::string("project", "Filter by project"),
+            ))
+            .with_arg(OperationArg::optional(
+                "env",
+                FieldDef::string("env", "Filter by environment"),
+            ))
+        })
+        .get()
+        .delete()
+        .action("start", "Start a stopped VM")
+        .op(|op| {
+            op.with_arg(OperationArg::required(
+                "name",
+                FieldDef::string("name", "VM name or ID"),
+            ))
+        })
+        .action("stop", "Stop a running VM")
+        .op(|op| {
+            op.with_arg(OperationArg::required(
+                "name",
+                FieldDef::string("name", "VM name or ID"),
+            ))
+        })
+        .column("NAME", "name")
+        .column_def(ColumnDef::new("STATE", "state").with_format(DisplayFormat::Status))
+        .column("CPU", "vcpus")
+        .column("MEM", "memory_mb")
+        .column("IMAGE", "image")
+        .column("ENV", "env_name")
+        .column("ID", "id")
+        .empty_message("No VMs found. Create one with: nauka vm create <name> --org <org> --project <project> --env <env> --vpc <vpc> --subnet <subnet> --cpu <n> --memory <mb> --disk <gb> --image <image>")
+        .detail_section(None, vec![
+            DetailField::new("Name", "name"),
+            DetailField::new("ID", "id"),
+            DetailField::new("State", "state").with_format(DisplayFormat::Status),
+            DetailField::new("Image", "image"),
+            DetailField::new("vCPUs", "vcpus"),
+            DetailField::new("Memory", "memory_mb"),
+            DetailField::new("Disk", "disk_gb"),
+            DetailField::new("VPC", "vpc_name"),
+            DetailField::new("Subnet", "subnet_name"),
+            DetailField::new("Private IP", "private_ip"),
+            DetailField::new("Organization", "org_name"),
+            DetailField::new("Project", "project_name"),
+            DetailField::new("Environment", "env_name"),
+            DetailField::new("Region", "region"),
+            DetailField::new("Zone", "zone"),
+            DetailField::new("Hypervisor", "hypervisor_id"),
+            DetailField::new("Created", "created_at").with_format(DisplayFormat::Timestamp),
+        ])
+        .done()
+}
+
+pub fn handler() -> HandlerFn {
+    Box::new(
+        |req: OperationRequest| -> Pin<
+            Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
+        > {
+            Box::pin(async move {
+                let store = VmStore::new(crate::connect_cluster_db().await?);
+                match req.operation.as_str() {
+                    "create" => {
+                        let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name"))?;
+                        let org = req
+                            .scope
+                            .get("org")
+                            .ok_or_else(|| anyhow::anyhow!("--org is required"))?
+                            .to_string();
+                        let project = req
+                            .fields
+                            .get("project")
+                            .ok_or_else(|| anyhow::anyhow!("--project is required"))?
+                            .clone();
+                        let env = req
+                            .fields
+                            .get("env")
+                            .ok_or_else(|| anyhow::anyhow!("--env is required"))?
+                            .clone();
+                        let vpc = req
+                            .fields
+                            .get("vpc")
+                            .ok_or_else(|| anyhow::anyhow!("--vpc is required"))?
+                            .clone();
+                        let subnet = req
+                            .fields
+                            .get("subnet")
+                            .ok_or_else(|| anyhow::anyhow!("--subnet is required"))?
+                            .clone();
+                        let cpu: u32 = req
+                            .fields
+                            .get("cpu")
+                            .ok_or_else(|| anyhow::anyhow!("--cpu is required"))?
+                            .parse()
+                            .map_err(|_| anyhow::anyhow!("--cpu must be a number"))?;
+                        let memory: u32 = req
+                            .fields
+                            .get("memory")
+                            .ok_or_else(|| anyhow::anyhow!("--memory is required"))?
+                            .parse()
+                            .map_err(|_| anyhow::anyhow!("--memory must be a number"))?;
+                        let disk: u32 = req
+                            .fields
+                            .get("disk")
+                            .ok_or_else(|| anyhow::anyhow!("--disk is required"))?
+                            .parse()
+                            .map_err(|_| anyhow::anyhow!("--disk must be a number"))?;
+                        let image = req
+                            .fields
+                            .get("image")
+                            .ok_or_else(|| anyhow::anyhow!("--image is required"))?
+                            .clone();
+                        let region = req
+                            .fields
+                            .get("region")
+                            .cloned()
+                            .unwrap_or_else(|| "default".to_string());
+                        let zone = req
+                            .fields
+                            .get("zone")
+                            .cloned()
+                            .unwrap_or_else(|| "default".to_string());
+
+                        nauka_core::validate::name(&name)?;
+                        let vm = store
+                            .create(
+                                &name, &org, &project, &env, &vpc, &subnet, cpu, memory, disk,
+                                &image, &region, &zone,
+                            )
+                            .await?;
+                        Ok(OperationResponse::Resource(vm.to_api_json()))
+                    }
+                    "list" => {
+                        let org = req.scope.get("org").map(|s| s.to_string());
+                        let project = req.fields.get("project").cloned();
+                        let env = req.fields.get("env").cloned();
+                        let vms = store
+                            .list(org.as_deref(), project.as_deref(), env.as_deref())
+                            .await?;
+                        let items: Vec<serde_json::Value> =
+                            vms.iter().map(|v| v.to_api_json()).collect();
+                        Ok(OperationResponse::ResourceList(items))
+                    }
+                    "get" => {
+                        let name = req
+                            .name
+                            .ok_or_else(|| anyhow::anyhow!("missing name or ID"))?;
+                        let org = req.scope.get("org").map(|s| s.to_string());
+                        let vm = store
+                            .get(&name, org.as_deref(), None, None)
+                            .await?
+                            .ok_or_else(|| anyhow::anyhow!("vm '{name}' not found"))?;
+                        Ok(OperationResponse::Resource(vm.to_api_json()))
+                    }
+                    "delete" => {
+                        let name = req
+                            .name
+                            .ok_or_else(|| anyhow::anyhow!("missing name or ID"))?;
+                        let org = req.scope.get("org").map(|s| s.to_string());
+                        store.delete(&name, org.as_deref(), None, None).await?;
+                        Ok(OperationResponse::Message(format!("vm '{name}' deleted.")))
+                    }
+                    "start" => {
+                        let name = req
+                            .fields
+                            .get("name")
+                            .ok_or_else(|| anyhow::anyhow!("missing VM name or ID"))?
+                            .clone();
+                        let org = req.scope.get("org").map(|s| s.to_string());
+                        let vm = store
+                            .update_state(&name, VmState::Running, org.as_deref(), None, None)
+                            .await?;
+                        Ok(OperationResponse::Resource(vm.to_api_json()))
+                    }
+                    "stop" => {
+                        let name = req
+                            .fields
+                            .get("name")
+                            .ok_or_else(|| anyhow::anyhow!("missing VM name or ID"))?
+                            .clone();
+                        let org = req.scope.get("org").map(|s| s.to_string());
+                        let vm = store
+                            .update_state(&name, VmState::Stopped, org.as_deref(), None, None)
+                            .await?;
+                        Ok(OperationResponse::Resource(vm.to_api_json()))
+                    }
+                    other => Ok(OperationResponse::Message(format!("unknown: {other}"))),
+                }
+            })
+        },
+    )
+}
+
+pub fn registration() -> ResourceRegistration {
+    ResourceRegistration {
+        def: resource_def(),
+        handler: handler(),
+        children: vec![],
+    }
+}

--- a/layers/compute/src/vm/mod.rs
+++ b/layers/compute/src/vm/mod.rs
@@ -1,0 +1,3 @@
+pub mod handlers;
+pub mod store;
+pub mod types;

--- a/layers/compute/src/vm/store.rs
+++ b/layers/compute/src/vm/store.rs
@@ -1,0 +1,249 @@
+use nauka_core::id::VmId;
+use nauka_core::resource::ResourceMeta;
+use nauka_hypervisor::controlplane::ClusterDb;
+
+use super::types::{Vm, VmState};
+
+const NS_VM: &str = "vm";
+const NS_VM_IDX: &str = "vm-idx";
+const REG_VMS: (&str, &str) = ("_reg", "vm-ids");
+
+pub struct VmStore {
+    db: ClusterDb,
+}
+
+impl VmStore {
+    pub fn new(db: ClusterDb) -> Self {
+        Self { db }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn create(
+        &self,
+        name: &str,
+        org_name: &str,
+        project_name: &str,
+        env_name: &str,
+        vpc_name: &str,
+        subnet_name: &str,
+        vcpus: u32,
+        memory_mb: u32,
+        disk_gb: u32,
+        image: &str,
+        region: &str,
+        zone: &str,
+    ) -> anyhow::Result<Vm> {
+        // Resolve org -> project -> env
+        let org_store = nauka_org::store::OrgStore::new(self.db.clone());
+        let org = org_store
+            .get(org_name)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("org '{org_name}' not found"))?;
+
+        let proj_store = nauka_org::project::store::ProjectStore::new(self.db.clone());
+        let project = proj_store
+            .get(project_name, Some(org_name))
+            .await?
+            .ok_or_else(|| {
+                anyhow::anyhow!("project '{project_name}' not found in org '{org_name}'")
+            })?;
+
+        let env_store = nauka_org::project::env::store::EnvStore::new(self.db.clone());
+        let env = env_store
+            .get(env_name, Some(project_name), Some(org_name))
+            .await?
+            .ok_or_else(|| {
+                anyhow::anyhow!("environment '{env_name}' not found in project '{project_name}'")
+            })?;
+
+        // Resolve vpc -> subnet
+        let vpc_store = nauka_network::vpc::store::VpcStore::new(self.db.clone());
+        let vpc = vpc_store
+            .get(vpc_name, Some(org_name))
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("vpc '{vpc_name}' not found"))?;
+
+        let sub_store = nauka_network::vpc::subnet::store::SubnetStore::new(self.db.clone());
+        let subnet = sub_store
+            .get(subnet_name, Some(vpc_name), Some(org_name))
+            .await?
+            .ok_or_else(|| {
+                anyhow::anyhow!("subnet '{subnet_name}' not found in vpc '{vpc_name}'")
+            })?;
+
+        // Check uniqueness within env
+        let idx_key = format!("{}/{}", env.meta.id, name);
+        let existing: Option<String> = self.db.get(NS_VM_IDX, &idx_key).await?;
+        if existing.is_some() {
+            anyhow::bail!("vm '{name}' already exists in environment '{env_name}'");
+        }
+
+        let vm = Vm {
+            meta: ResourceMeta::new(VmId::generate().to_string(), name),
+            org_id: org.meta.id.clone().into(),
+            org_name: org.meta.name.clone(),
+            project_id: project.meta.id.clone().into(),
+            project_name: project.meta.name.clone(),
+            env_id: env.meta.id.clone().into(),
+            env_name: env.meta.name.clone(),
+            vpc_id: vpc.meta.id.clone().into(),
+            vpc_name: vpc.meta.name.clone(),
+            subnet_id: subnet.meta.id.clone().into(),
+            subnet_name: subnet.meta.name.clone(),
+            vcpus,
+            memory_mb,
+            disk_gb,
+            image: image.to_string(),
+            region: region.to_string(),
+            zone: zone.to_string(),
+            private_ip: None,
+            hypervisor_id: None,
+            state: VmState::Pending,
+        };
+
+        self.db.put(NS_VM, &vm.meta.id, &vm).await?;
+        self.db.put(NS_VM_IDX, &idx_key, &vm.meta.id).await?;
+        add_id(&self.db, &vm.meta.id).await?;
+
+        Ok(vm)
+    }
+
+    pub async fn get(
+        &self,
+        name_or_id: &str,
+        org_name: Option<&str>,
+        project_name: Option<&str>,
+        env_name: Option<&str>,
+    ) -> anyhow::Result<Option<Vm>> {
+        if VmId::looks_like_id(name_or_id) {
+            return self.db.get(NS_VM, name_or_id).await.map_err(Into::into);
+        }
+
+        // Need full scope to resolve by name
+        let org_name =
+            org_name.ok_or_else(|| anyhow::anyhow!("--org required to resolve VM by name"))?;
+        let project_name = project_name
+            .ok_or_else(|| anyhow::anyhow!("--project required to resolve VM by name"))?;
+        let env_name =
+            env_name.ok_or_else(|| anyhow::anyhow!("--env required to resolve VM by name"))?;
+
+        let env_store = nauka_org::project::env::store::EnvStore::new(self.db.clone());
+        let env = env_store
+            .get(env_name, Some(project_name), Some(org_name))
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("environment '{env_name}' not found"))?;
+
+        let idx_key = format!("{}/{}", env.meta.id, name_or_id);
+        let id: Option<String> = self.db.get(NS_VM_IDX, &idx_key).await?;
+        match id {
+            Some(id) => self.db.get(NS_VM, &id).await.map_err(Into::into),
+            None => Ok(None),
+        }
+    }
+
+    pub async fn list(
+        &self,
+        org_name: Option<&str>,
+        project_name: Option<&str>,
+        env_name: Option<&str>,
+    ) -> anyhow::Result<Vec<Vm>> {
+        let ids = load_ids(&self.db).await?;
+        let mut vms = Vec::new();
+        for id in &ids {
+            if let Some(vm) = self.db.get::<Vm>(NS_VM, id).await? {
+                vms.push(vm);
+            }
+        }
+
+        // Progressive filtering
+        if let Some(org) = org_name {
+            vms.retain(|v| v.org_name == org || v.org_id.as_str() == org);
+        }
+        if let Some(proj) = project_name {
+            vms.retain(|v| v.project_name == proj || v.project_id.as_str() == proj);
+        }
+        if let Some(env) = env_name {
+            vms.retain(|v| v.env_name == env || v.env_id.as_str() == env);
+        }
+
+        Ok(vms)
+    }
+
+    pub async fn update_state(
+        &self,
+        name_or_id: &str,
+        new_state: VmState,
+        org_name: Option<&str>,
+        project_name: Option<&str>,
+        env_name: Option<&str>,
+    ) -> anyhow::Result<Vm> {
+        let mut vm = self
+            .get(name_or_id, org_name, project_name, env_name)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("vm '{name_or_id}' not found"))?;
+
+        // Validate state transition
+        match (&vm.state, &new_state) {
+            (VmState::Pending, VmState::Running) => {}
+            (VmState::Stopped, VmState::Running) => {}
+            (VmState::Running, VmState::Stopped) => {}
+            (VmState::Pending, VmState::Deleted) => {}
+            (VmState::Stopped, VmState::Deleted) => {}
+            (from, to) => anyhow::bail!("invalid state transition: {from} -> {to}"),
+        }
+
+        vm.state = new_state;
+        vm.meta.updated_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        self.db.put(NS_VM, &vm.meta.id, &vm).await?;
+        Ok(vm)
+    }
+
+    pub async fn delete(
+        &self,
+        name_or_id: &str,
+        org_name: Option<&str>,
+        project_name: Option<&str>,
+        env_name: Option<&str>,
+    ) -> anyhow::Result<()> {
+        let vm = self
+            .get(name_or_id, org_name, project_name, env_name)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("vm '{name_or_id}' not found"))?;
+
+        if vm.state != VmState::Stopped && vm.state != VmState::Pending {
+            anyhow::bail!(
+                "vm must be stopped or pending to delete (current state: {})",
+                vm.state
+            );
+        }
+
+        let idx_key = format!("{}/{}", vm.env_id.as_str(), vm.meta.name);
+        self.db.delete(NS_VM, &vm.meta.id).await?;
+        self.db.delete(NS_VM_IDX, &idx_key).await?;
+        remove_id(&self.db, &vm.meta.id).await?;
+        Ok(())
+    }
+}
+
+async fn load_ids(db: &ClusterDb) -> anyhow::Result<Vec<String>> {
+    let ids: Option<Vec<String>> = db.get(REG_VMS.0, REG_VMS.1).await?;
+    Ok(ids.unwrap_or_default())
+}
+
+async fn add_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
+    let mut ids = load_ids(db).await?;
+    ids.push(id.to_string());
+    db.put(REG_VMS.0, REG_VMS.1, &ids).await?;
+    Ok(())
+}
+
+async fn remove_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
+    let mut ids = load_ids(db).await?;
+    ids.retain(|i| i != id);
+    db.put(REG_VMS.0, REG_VMS.1, &ids).await?;
+    Ok(())
+}

--- a/layers/compute/src/vm/types.rs
+++ b/layers/compute/src/vm/types.rs
@@ -1,0 +1,96 @@
+use std::fmt;
+
+use nauka_core::id::{EnvId, OrgId, ProjectId, SubnetId, VpcId};
+use nauka_core::resource::{ApiResource, ResourceMeta};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum VmState {
+    #[default]
+    Pending,
+    Creating,
+    Running,
+    Stopped,
+    Deleting,
+    Deleted,
+}
+
+impl fmt::Display for VmState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            VmState::Pending => write!(f, "pending"),
+            VmState::Creating => write!(f, "creating"),
+            VmState::Running => write!(f, "running"),
+            VmState::Stopped => write!(f, "stopped"),
+            VmState::Deleting => write!(f, "deleting"),
+            VmState::Deleted => write!(f, "deleted"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Vm {
+    #[serde(flatten)]
+    pub meta: ResourceMeta,
+    // Scope
+    pub org_id: OrgId,
+    pub org_name: String,
+    pub project_id: ProjectId,
+    pub project_name: String,
+    pub env_id: EnvId,
+    pub env_name: String,
+    // Network
+    pub vpc_id: VpcId,
+    pub vpc_name: String,
+    pub subnet_id: SubnetId,
+    pub subnet_name: String,
+    // Specs
+    pub vcpus: u32,
+    pub memory_mb: u32,
+    pub disk_gb: u32,
+    pub image: String,
+    // Placement
+    pub region: String,
+    pub zone: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub private_ip: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hypervisor_id: Option<String>,
+    // Lifecycle
+    pub state: VmState,
+}
+
+impl ApiResource for Vm {
+    fn meta(&self) -> &ResourceMeta {
+        &self.meta
+    }
+    fn resource_fields(&self) -> serde_json::Value {
+        let mut fields = serde_json::json!({
+            "org_id": self.org_id.as_str(),
+            "org_name": self.org_name,
+            "project_id": self.project_id.as_str(),
+            "project_name": self.project_name,
+            "env_id": self.env_id.as_str(),
+            "env_name": self.env_name,
+            "vpc_id": self.vpc_id.as_str(),
+            "vpc_name": self.vpc_name,
+            "subnet_id": self.subnet_id.as_str(),
+            "subnet_name": self.subnet_name,
+            "vcpus": self.vcpus,
+            "memory_mb": self.memory_mb,
+            "disk_gb": self.disk_gb,
+            "image": self.image,
+            "region": self.region,
+            "zone": self.zone,
+            "state": self.state.to_string(),
+        });
+        if let Some(ref ip) = self.private_ip {
+            fields["private_ip"] = serde_json::json!(ip);
+        }
+        if let Some(ref hv) = self.hypervisor_id {
+            fields["hypervisor_id"] = serde_json::json!(hv);
+        }
+        fields
+    }
+}


### PR DESCRIPTION
## Summary
New `layers/compute` crate with VM lifecycle management:

- **Create**: full scope (org/project/env) + network (vpc/subnet) + specs (cpu/memory/disk/image)
- **State machine**: pending → running → stopped → deleted with validated transitions
- **start/stop**: actions update VM state
- **delete**: only from stopped/pending

## CLI
```bash
nauka vm create web-1 --org acme --project backend --env production \
  --vpc prod-net --subnet web --cpu 2 --memory 4096 --disk 40 --image ubuntu-24.04

nauka vm list
nauka vm get <id>
nauka vm start --name <id>
nauka vm stop --name <id>
nauka vm delete <id>
```

## Test plan
- [x] `cargo build` + `cargo clippy` clean
- [x] All tests pass
- [x] VM create with 5 cross-layer reference resolution (org→project→env, vpc→subnet)
- [x] VM start/stop state transitions tested on Hetzner
- [x] Cascade guards: can't delete running VM
- [x] Duplicate name rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)