### PR TITLE
refactor: deduplicate connect_cluster_db into controlplane::connect()

### DIFF
--- a/layers/compute/src/lib.rs
+++ b/layers/compute/src/lib.rs
@@ -8,47 +8,8 @@
 pub mod vm;
 
 use nauka_core::resource::ResourceRegistration;
-use nauka_hypervisor::controlplane;
-use nauka_hypervisor::fabric;
-use nauka_state::LocalDb;
 
 /// Top-level registration: vm resource.
 pub fn registration() -> ResourceRegistration {
     vm::handlers::registration()
-}
-
-/// Connect to ClusterDb via PD endpoints from fabric state.
-pub(crate) async fn connect_cluster_db() -> anyhow::Result<controlplane::ClusterDb> {
-    let dir = nauka_core::process::nauka_dir();
-    let _ = std::fs::create_dir_all(&dir);
-    let db = LocalDb::open("hypervisor")?;
-
-    let state = fabric::state::FabricState::load(&db)
-        .map_err(|e| anyhow::anyhow!("{e}"))?
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "cluster not initialized.\n\n\
-                 Initialize a cluster first with:\n\
-                 \x20 nauka hypervisor init"
-            )
-        })?;
-
-    let self_endpoint = format!(
-        "http://[{}]:{}",
-        state.hypervisor.mesh_ipv6,
-        controlplane::PD_CLIENT_PORT,
-    );
-    let mut endpoints = vec![self_endpoint];
-    for peer in &state.peers.peers {
-        endpoints.push(format!(
-            "http://[{}]:{}",
-            peer.mesh_ipv6,
-            controlplane::PD_CLIENT_PORT,
-        ));
-    }
-    let refs: Vec<&str> = endpoints.iter().map(|s| s.as_str()).collect();
-
-    controlplane::ClusterDb::connect(&refs)
-        .await
-        .map_err(Into::into)
 }

--- a/layers/compute/src/vm/handlers.rs
+++ b/layers/compute/src/vm/handlers.rs
@@ -119,7 +119,7 @@ pub fn handler() -> HandlerFn {
             Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
         > {
             Box::pin(async move {
-                let store = VmStore::new(crate::connect_cluster_db().await?);
+                let store = VmStore::new(nauka_hypervisor::controlplane::connect().await?);
                 match req.operation.as_str() {
                     "create" => {
                         let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name"))?;

--- a/layers/hypervisor/src/controlplane/mod.rs
+++ b/layers/hypervisor/src/controlplane/mod.rs
@@ -20,3 +20,32 @@ pub const PD_PEER_PORT: u16 = 2380;
 pub const TIKV_PORT: u16 = 20160;
 
 pub use store::ClusterDb;
+
+/// Connect to the TiKV cluster using PD endpoints from local fabric state.
+///
+/// This is the standard way for any layer to get a ClusterDb connection.
+/// Reads the local hypervisor state to discover PD endpoints on the mesh.
+pub async fn connect() -> anyhow::Result<ClusterDb> {
+    let dir = nauka_core::process::nauka_dir();
+    let _ = std::fs::create_dir_all(&dir);
+    let db = nauka_state::LocalDb::open("hypervisor")?;
+
+    let state = crate::fabric::state::FabricState::load(&db)
+        .map_err(|e| anyhow::anyhow!("{e}"))?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "cluster not initialized.\n\n\
+                 Initialize a cluster first with:\n\
+                 \x20 nauka hypervisor init"
+            )
+        })?;
+
+    let self_endpoint = format!("http://[{}]:{}", state.hypervisor.mesh_ipv6, PD_CLIENT_PORT,);
+    let mut endpoints = vec![self_endpoint];
+    for peer in &state.peers.peers {
+        endpoints.push(format!("http://[{}]:{}", peer.mesh_ipv6, PD_CLIENT_PORT,));
+    }
+    let refs: Vec<&str> = endpoints.iter().map(|s| s.as_str()).collect();
+
+    ClusterDb::connect(&refs).await.map_err(Into::into)
+}

--- a/layers/network/src/lib.rs
+++ b/layers/network/src/lib.rs
@@ -11,47 +11,8 @@ pub mod validate;
 pub mod vpc;
 
 use nauka_core::resource::ResourceRegistration;
-use nauka_hypervisor::controlplane;
-use nauka_hypervisor::fabric;
-use nauka_state::LocalDb;
 
 /// Top-level registration: vpc with subnet and peering as children.
 pub fn registration() -> ResourceRegistration {
     vpc::handlers::registration()
-}
-
-/// Connect to ClusterDb via PD endpoints from fabric state.
-pub(crate) async fn connect_cluster_db() -> anyhow::Result<controlplane::ClusterDb> {
-    let dir = nauka_core::process::nauka_dir();
-    let _ = std::fs::create_dir_all(&dir);
-    let db = LocalDb::open("hypervisor")?;
-
-    let state = fabric::state::FabricState::load(&db)
-        .map_err(|e| anyhow::anyhow!("{e}"))?
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "cluster not initialized.\n\n\
-                 Initialize a cluster first with:\n\
-                 \x20 nauka hypervisor init"
-            )
-        })?;
-
-    let self_endpoint = format!(
-        "http://[{}]:{}",
-        state.hypervisor.mesh_ipv6,
-        controlplane::PD_CLIENT_PORT,
-    );
-    let mut endpoints = vec![self_endpoint];
-    for peer in &state.peers.peers {
-        endpoints.push(format!(
-            "http://[{}]:{}",
-            peer.mesh_ipv6,
-            controlplane::PD_CLIENT_PORT,
-        ));
-    }
-    let refs: Vec<&str> = endpoints.iter().map(|s| s.as_str()).collect();
-
-    controlplane::ClusterDb::connect(&refs)
-        .await
-        .map_err(Into::into)
 }

--- a/layers/network/src/vpc/handlers.rs
+++ b/layers/network/src/vpc/handlers.rs
@@ -57,7 +57,7 @@ pub fn handler() -> HandlerFn {
             Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
         > {
             Box::pin(async move {
-                let store = VpcStore::new(crate::connect_cluster_db().await?);
+                let store = VpcStore::new(nauka_hypervisor::controlplane::connect().await?);
                 match req.operation.as_str() {
                     "create" => {
                         let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name"))?;

--- a/layers/network/src/vpc/peering/handlers.rs
+++ b/layers/network/src/vpc/peering/handlers.rs
@@ -46,7 +46,7 @@ pub fn handler() -> HandlerFn {
             Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
         > {
             Box::pin(async move {
-                let store = PeeringStore::new(crate::connect_cluster_db().await?);
+                let store = PeeringStore::new(nauka_hypervisor::controlplane::connect().await?);
                 match req.operation.as_str() {
                     "create" => {
                         let vpc = req

--- a/layers/network/src/vpc/subnet/handlers.rs
+++ b/layers/network/src/vpc/subnet/handlers.rs
@@ -50,7 +50,7 @@ pub fn handler() -> HandlerFn {
             Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
         > {
             Box::pin(async move {
-                let store = SubnetStore::new(crate::connect_cluster_db().await?);
+                let store = SubnetStore::new(nauka_hypervisor::controlplane::connect().await?);
                 match req.operation.as_str() {
                     "create" => {
                         let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name"))?;

--- a/layers/org/src/handlers.rs
+++ b/layers/org/src/handlers.rs
@@ -34,7 +34,7 @@ pub fn handler() -> HandlerFn {
             Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
         > {
             Box::pin(async move {
-                let store = OrgStore::new(crate::connect_cluster_db().await?);
+                let store = OrgStore::new(nauka_hypervisor::controlplane::connect().await?);
                 match req.operation.as_str() {
                     "create" => {
                         let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name"))?;

--- a/layers/org/src/lib.rs
+++ b/layers/org/src/lib.rs
@@ -13,9 +13,6 @@ pub mod store;
 pub mod types;
 
 use nauka_core::resource::ResourceRegistration;
-use nauka_hypervisor::controlplane;
-use nauka_hypervisor::fabric;
-use nauka_state::LocalDb;
 
 /// Top-level registration: org with project (with env) as children.
 pub fn registration() -> ResourceRegistration {
@@ -24,40 +21,4 @@ pub fn registration() -> ResourceRegistration {
         handler: handlers::handler(),
         children: vec![project::handlers::registration()],
     }
-}
-
-/// Connect to ClusterDb via PD endpoints from fabric state.
-pub(crate) async fn connect_cluster_db() -> anyhow::Result<controlplane::ClusterDb> {
-    let dir = nauka_core::process::nauka_dir();
-    let _ = std::fs::create_dir_all(&dir);
-    let db = LocalDb::open("hypervisor")?;
-
-    let state = fabric::state::FabricState::load(&db)
-        .map_err(|e| anyhow::anyhow!("{e}"))?
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "cluster not initialized.\n\n\
-                 Initialize a cluster first with:\n\
-                 \x20 nauka hypervisor init"
-            )
-        })?;
-
-    let self_endpoint = format!(
-        "http://[{}]:{}",
-        state.hypervisor.mesh_ipv6,
-        controlplane::PD_CLIENT_PORT,
-    );
-    let mut endpoints = vec![self_endpoint];
-    for peer in &state.peers.peers {
-        endpoints.push(format!(
-            "http://[{}]:{}",
-            peer.mesh_ipv6,
-            controlplane::PD_CLIENT_PORT,
-        ));
-    }
-    let refs: Vec<&str> = endpoints.iter().map(|s| s.as_str()).collect();
-
-    controlplane::ClusterDb::connect(&refs)
-        .await
-        .map_err(Into::into)
 }

--- a/layers/org/src/project/env/handlers.rs
+++ b/layers/org/src/project/env/handlers.rs
@@ -41,7 +41,7 @@ pub fn handler() -> HandlerFn {
             Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
         > {
             Box::pin(async move {
-                let store = EnvStore::new(crate::connect_cluster_db().await?);
+                let store = EnvStore::new(nauka_hypervisor::controlplane::connect().await?);
                 match req.operation.as_str() {
                     "create" => {
                         let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name"))?;

--- a/layers/org/src/project/handlers.rs
+++ b/layers/org/src/project/handlers.rs
@@ -37,7 +37,7 @@ pub fn handler() -> HandlerFn {
             Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
         > {
             Box::pin(async move {
-                let store = ProjectStore::new(crate::connect_cluster_db().await?);
+                let store = ProjectStore::new(nauka_hypervisor::controlplane::connect().await?);
                 match req.operation.as_str() {
                     "create" => {
                         let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name"))?;


### PR DESCRIPTION
Moves the TiKV connection logic from 3 identical copies (org, network, compute lib.rs) into a single `nauka_hypervisor::controlplane::connect()` function.

**Before**: 3 copies of the same 30-line function
**After**: 1 function, 7 call sites use `nauka_hypervisor::controlplane::connect()`

-124 lines, +36 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)