### PR TITLE
docs: add missing MDX for VM, scheduler, and reconcilers

### DIFF
--- a/layers/compute/src/scheduler.mdx
+++ b/layers/compute/src/scheduler.mdx
@@ -1,0 +1,42 @@
+---
+title: Scheduler
+description: Automatic VM placement — assigns VMs to hypervisors based on zone and availability.
+sidebar:
+  order: 3
+---
+
+When a VM is created, the scheduler automatically assigns it to a hypervisor. The user specifies **where** (zone), the scheduler decides **on which machine**.
+
+## How it works
+
+1. Read the fabric state to list all hypervisor nodes (self + peers)
+2. Filter by zone (if `--zone` is specified)
+3. Filter by region (if `--region` is specified)
+4. Pick the first available match
+
+```bash
+# No zone → scheduler picks any node (defaults to self)
+nauka vm create web-1 ... 
+
+# Specific zone → scheduler filters to nodes in that zone
+nauka vm create web-1 ... --zone fsn1
+```
+
+## Current limitations
+
+The scheduler is minimal in v1:
+
+- **No capacity check** — doesn't verify if the hypervisor has enough CPU/memory
+- **No load balancing** — picks the first match, not the least loaded
+- **No anti-affinity** — two VMs with the same name in different envs could land on the same node
+
+These will be addressed when the Forge reports node capacity via the health system.
+
+## What happens if no node matches
+
+```bash
+nauka vm create web-1 ... --zone nonexistent
+# Error: no hypervisor available in zone 'nonexistent'
+```
+
+The VM is not created. The user must specify a zone where at least one active hypervisor exists.

--- a/layers/compute/src/vm/overview.mdx
+++ b/layers/compute/src/vm/overview.mdx
@@ -1,0 +1,70 @@
+---
+title: Virtual Machines
+description: Create, manage, and control VMs across hypervisor nodes with automatic placement.
+sidebar:
+  order: 2
+---
+
+A virtual machine runs on a hypervisor node, connected to a VPC subnet. When you create a VM, the scheduler automatically picks a hypervisor based on the requested zone.
+
+## Creating a VM
+
+```bash
+nauka vm create web-1 \
+  --org acme --project backend --env production \
+  --vpc prod-net --subnet web \
+  --cpu 2 --memory 4096 --disk 40 --image ubuntu-24.04
+```
+
+```
+  Name:            web-1
+  ID:              vm-01knqgxff8...
+  State:           pending
+  Image:           ubuntu-24.04
+  vCPUs:           2
+  Memory:          4096
+  Disk:            40
+  VPC:             prod-net
+  Subnet:          web
+  Hypervisor:      hv-01knqgx8jm...
+  Created:         2026-04-08T21:45:30Z
+```
+
+The VM is created in `pending` state with a hypervisor automatically assigned. The Forge reconciler handles the actual provisioning.
+
+## Lifecycle
+
+```
+pending → running ⇄ stopped → deleted
+```
+
+```bash
+nauka vm start --name web-1 --org acme    # pending/stopped → running
+nauka vm stop --name web-1 --org acme     # running → stopped
+nauka vm delete web-1 --yes               # stopped/pending → deleted
+```
+
+A running VM cannot be deleted — stop it first.
+
+## Listing and filtering
+
+```bash
+# All VMs
+nauka vm list
+
+# Filter by scope
+nauka vm list --org acme --project backend --env production
+```
+
+## Zone placement
+
+VMs are placed on a hypervisor in the requested zone. If no zone is specified, the scheduler picks any available node.
+
+```bash
+# Place in a specific zone
+nauka vm create web-1 ... --zone fsn1
+
+# No hypervisor in that zone → error
+nauka vm create web-1 ... --zone nonexistent
+# Error: no hypervisor available in zone 'nonexistent'
+```

--- a/layers/forge/src/reconciler/overview.mdx
+++ b/layers/forge/src/reconciler/overview.mdx
@@ -1,0 +1,60 @@
+---
+title: Reconcilers
+description: How the Forge converges desired state to actual state for each resource type.
+sidebar:
+  order: 2
+---
+
+The Forge runs **reconcilers** — one per resource type — in dependency order. Each reconciler reads desired state from TiKV, compares with actual system state, and applies the delta.
+
+## Reconciliation order
+
+1. **VPC reconciler** — creates VXLAN bridges for VPCs that have VMs on this node
+2. **VM reconciler** — starts/stops VM processes to match desired state
+
+Order matters: the VPC bridge must exist before a VM can attach its network interface.
+
+## The reconciliation loop
+
+```
+Every 30 seconds:
+  1. Connect to TiKV
+  2. For each reconciler (VPC, VM):
+     a. Read desired state from TiKV
+     b. Read actual state from the kernel
+     c. Diff: what's missing? what's orphaned?
+     d. Apply: create missing, delete orphaned
+     e. Log results
+```
+
+## Reconciler trait
+
+Each resource type implements a simple contract:
+
+```
+trait Reconciler {
+    fn name(&self) → "vpc" | "vm" | ...
+    fn reconcile(ctx) → ReconcileResult
+}
+```
+
+The `ReconcileResult` reports what happened:
+
+```
+vpc: 2 desired, 1 actual — created:1 deleted:0 updated:0 failed:0
+vm: 3 desired, 3 actual — in sync
+```
+
+## Resource ownership
+
+- **VMs** belong to this node if `vm.hypervisor_id == this_node_id`
+- **VPCs** belong to this node if any local VM uses that VPC
+
+A VPC with no local VMs has its bridge removed (cleanup reconciliation).
+
+## Manual trigger
+
+```bash
+# Run one cycle manually (for debugging)
+nauka forge reconcile
+```


### PR DESCRIPTION
Adds 3 missing operator docs:
- `layers/compute/src/vm/overview.mdx` — VM lifecycle, create, start/stop
- `layers/compute/src/scheduler.mdx` — auto-placement, zone filtering
- `layers/forge/src/reconciler/overview.mdx` — reconciliation loop, trait, ownership

🤖 Generated with [Claude Code](https://claude.com/claude-code)