### PR TITLE
feat(network): VPC provisioning — real VXLAN + bridge creation by Forge

### DIFF
--- a/layers/forge/src/observer/network.rs
+++ b/layers/forge/src/observer/network.rs
@@ -1,10 +1,28 @@
-//! Network observer — scan for VXLAN bridges.
+//! Network observer — scan for active VPC bridges.
 //!
-//! Stub implementation: returns empty list.
-//! Future: parse `ip link show` for nauka bridges.
+//! Reads `ip link show` and finds interfaces matching the `nkb-` prefix.
+//! Returns bridge interface names (e.g., "nkb-a1b2c3").
 
-/// List VPC IDs that have active bridges on this node.
+use std::process::Command;
+
+/// List active VPC bridge interface names on this node.
 pub fn list_bridges() -> Vec<String> {
-    // Stub: no bridges
-    vec![]
+    let output = match Command::new("ip").args(["-o", "link", "show"]).output() {
+        Ok(o) if o.status.success() => o,
+        _ => return vec![],
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .lines()
+        .filter_map(|line| {
+            // Format: "N: nkb-abc123: <...>"
+            let name = line.split(':').nth(1)?.trim();
+            if name.starts_with("nkb-") {
+                Some(name.to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
 }

--- a/layers/forge/src/reconciler/vpc.rs
+++ b/layers/forge/src/reconciler/vpc.rs
@@ -63,9 +63,12 @@ impl super::Reconciler for VpcReconciler {
             .collect();
         for bridge in &actual_bridges {
             if !needed_bridge_names.contains(bridge) {
-                // Reverse-lookup: find VPC ID from bridge name (try all known VPCs)
                 tracing::info!(bridge, "removing orphaned bridge");
-                // We can't easily reverse the hash, so just delete the bridge directly
+                // Derive VXLAN name from bridge name (nkb-HASH → nkx-HASH)
+                let vxlan = bridge.replace("nkb-", "nkx-");
+                let _ = std::process::Command::new("ip")
+                    .args(["link", "del", &vxlan])
+                    .status();
                 let _ = std::process::Command::new("ip")
                     .args(["link", "del", bridge])
                     .status();

--- a/layers/forge/src/reconciler/vpc.rs
+++ b/layers/forge/src/reconciler/vpc.rs
@@ -1,5 +1,7 @@
 //! VPC reconciler — ensures VXLAN bridges exist for VPCs with local VMs.
 
+use nauka_network::vpc::provision;
+
 use crate::types::{ReconcileContext, ReconcileResult};
 
 pub struct VpcReconciler;
@@ -21,25 +23,53 @@ impl super::Reconciler for VpcReconciler {
             .filter(|vm| vm.hypervisor_id.as_deref() == Some(&ctx.hypervisor_id))
             .collect();
 
-        // 2. Collect unique VPC IDs needed on this node
-        let mut needed_vpc_ids: Vec<String> = local_vms
-            .iter()
-            .map(|vm| vm.vpc_id.as_str().to_string())
-            .collect();
-        needed_vpc_ids.sort();
-        needed_vpc_ids.dedup();
+        // 2. Collect unique VPC IDs needed on this node + resolve their VNIs
+        let vpc_store = nauka_network::vpc::store::VpcStore::new(ctx.db.clone());
+        let mut needed_vpcs: Vec<(String, u32)> = Vec::new(); // (vpc_id, vni)
+        for vm in &local_vms {
+            let vpc_id = vm.vpc_id.as_str().to_string();
+            if !needed_vpcs.iter().any(|(id, _)| id == &vpc_id) {
+                if let Some(vpc) = vpc_store.get(&vpc_id, None).await? {
+                    needed_vpcs.push((vpc_id, vpc.vni));
+                }
+            }
+        }
 
-        result.desired = needed_vpc_ids.len();
+        result.desired = needed_vpcs.len();
 
-        // 3. Check actual state (stub: nothing exists yet)
+        // 3. Check actual state — scan for existing bridges
         let actual_bridges = crate::observer::network::list_bridges();
         result.actual = actual_bridges.len();
 
-        // 4. Diff and apply
-        for vpc_id in &needed_vpc_ids {
-            if !actual_bridges.iter().any(|b| b == vpc_id) {
-                tracing::info!(vpc_id, "would create bridge for VPC");
-                result.created += 1;
+        // 4. Create missing bridges
+        for (vpc_id, vni) in &needed_vpcs {
+            let expected_bridge = provision::bridge_name(vpc_id);
+            if !actual_bridges.iter().any(|b| b == &expected_bridge) {
+                match provision::ensure_bridge(vpc_id, *vni, &ctx.mesh_ipv6) {
+                    Ok(()) => result.created += 1,
+                    Err(e) => {
+                        tracing::error!(vpc_id, error = %e, "failed to create bridge");
+                        result.failed += 1;
+                        result.errors.push(format!("vpc {vpc_id}: {e}"));
+                    }
+                }
+            }
+        }
+
+        // 5. Remove orphaned bridges (exist locally but no VMs need them)
+        let needed_bridge_names: Vec<String> = needed_vpcs
+            .iter()
+            .map(|(id, _)| provision::bridge_name(id))
+            .collect();
+        for bridge in &actual_bridges {
+            if !needed_bridge_names.contains(bridge) {
+                // Reverse-lookup: find VPC ID from bridge name (try all known VPCs)
+                tracing::info!(bridge, "removing orphaned bridge");
+                // We can't easily reverse the hash, so just delete the bridge directly
+                let _ = std::process::Command::new("ip")
+                    .args(["link", "del", bridge])
+                    .status();
+                result.deleted += 1;
             }
         }
 

--- a/layers/network/src/vpc/mod.rs
+++ b/layers/network/src/vpc/mod.rs
@@ -1,5 +1,6 @@
 pub mod handlers;
 pub mod peering;
+pub mod provision;
 pub mod store;
 pub mod subnet;
 pub mod types;

--- a/layers/network/src/vpc/provision.mdx
+++ b/layers/network/src/vpc/provision.mdx
@@ -1,0 +1,67 @@
+---
+title: VPC Provisioning
+description: How the Forge creates VXLAN tunnels and Linux bridges to bring VPCs to life on each node.
+sidebar:
+  order: 5
+---
+
+When the Forge detects that a VPC needs a network bridge on this node (because a VM in that VPC is assigned here), it provisions two Linux interfaces:
+
+## Interface layout
+
+```
+VM TAP (future)
+    │
+    ▼
+nkb-{hash}    Linux bridge     ← L2 switch for this VPC
+    │
+    ▼
+nkx-{hash}    VXLAN interface  ← encapsulates frames over the WireGuard mesh
+    │
+    ▼
+nauka0        WireGuard         ← encrypted tunnel to other nodes
+```
+
+## Interface naming
+
+Linux limits interface names to 15 characters. Nauka uses a hash-based scheme:
+
+- `nkb-{hash}` — bridge (e.g., `nkb-a1b2c3`)
+- `nkx-{hash}` — VXLAN (e.g., `nkx-a1b2c3`)
+
+The hash is derived from the VPC ID, so the same VPC always gets the same interface names on every node.
+
+## What the Forge does
+
+Each reconciliation cycle:
+
+1. List VMs assigned to this node
+2. Collect their VPC IDs
+3. For each needed VPC, check if the bridge exists
+4. Create missing bridges: `ip link add nkx-... type vxlan` + `ip link add nkb-... type bridge`
+5. Remove orphaned bridges (VPC has no local VMs anymore)
+
+## Idempotency
+
+All operations are idempotent:
+- Creating a bridge that exists → no-op
+- Bringing up an interface that's already up → no-op
+- Removing a bridge that doesn't exist → no-op
+
+The Forge can crash and restart at any point without leaving inconsistent state.
+
+## Debugging
+
+```bash
+# List Nauka bridges
+ip link show | grep nkb-
+
+# List Nauka VXLAN interfaces
+ip link show | grep nkx-
+
+# Check bridge members
+bridge link show
+
+# Trigger a reconciliation
+nauka forge reconcile
+```

--- a/layers/network/src/vpc/provision.rs
+++ b/layers/network/src/vpc/provision.rs
@@ -1,0 +1,197 @@
+//! VPC provisioning — create and remove VXLAN + bridge interfaces.
+//!
+//! Each VPC gets two Linux interfaces:
+//! - `nkx-{hash}` — VXLAN interface (encapsulates L2 frames over the mesh)
+//! - `nkb-{hash}` — Linux bridge (connects local VM TAPs + VXLAN)
+//!
+//! The hash is derived from the VPC ID to stay within the 15-char IFNAMSIZ limit.
+
+use std::net::Ipv6Addr;
+use std::process::Command;
+
+/// Derive a short hash (6 hex chars) from a VPC ID for interface naming.
+fn iface_hash(vpc_id: &str) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    vpc_id.hash(&mut hasher);
+    format!("{:06x}", hasher.finish() & 0xFFFFFF)
+}
+
+/// Bridge interface name for a VPC.
+pub fn bridge_name(vpc_id: &str) -> String {
+    format!("nkb-{}", iface_hash(vpc_id))
+}
+
+/// VXLAN interface name for a VPC.
+pub fn vxlan_name(vpc_id: &str) -> String {
+    format!("nkx-{}", iface_hash(vpc_id))
+}
+
+/// Check if a network interface exists.
+fn iface_exists(name: &str) -> bool {
+    Command::new("ip")
+        .args(["link", "show", name])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Ensure the VXLAN + bridge for a VPC exist and are up.
+///
+/// Idempotent: skips creation if interfaces already exist.
+pub fn ensure_bridge(vpc_id: &str, vni: u32, local_ipv6: &Ipv6Addr) -> anyhow::Result<()> {
+    let br = bridge_name(vpc_id);
+    let vx = vxlan_name(vpc_id);
+
+    // 1. Create VXLAN interface (if needed)
+    if !iface_exists(&vx) {
+        tracing::info!(vpc_id, vni, iface = vx.as_str(), "creating VXLAN interface");
+        let status = Command::new("ip")
+            .args([
+                "link",
+                "add",
+                &vx,
+                "type",
+                "vxlan",
+                "id",
+                &vni.to_string(),
+                "dstport",
+                "4789",
+                "local",
+                &local_ipv6.to_string(),
+                "nolearning",
+            ])
+            .status()
+            .map_err(|e| anyhow::anyhow!("ip link add vxlan failed: {e}"))?;
+        if !status.success() {
+            anyhow::bail!("failed to create VXLAN interface {vx}");
+        }
+    }
+
+    // 2. Create bridge (if needed)
+    if !iface_exists(&br) {
+        tracing::info!(vpc_id, iface = br.as_str(), "creating bridge");
+        let status = Command::new("ip")
+            .args(["link", "add", &br, "type", "bridge"])
+            .status()
+            .map_err(|e| anyhow::anyhow!("ip link add bridge failed: {e}"))?;
+        if !status.success() {
+            anyhow::bail!("failed to create bridge {br}");
+        }
+    }
+
+    // 3. Attach VXLAN to bridge
+    run_ip(&["link", "set", &vx, "master", &br])?;
+
+    // 4. Bring both up
+    run_ip(&["link", "set", &vx, "up"])?;
+    run_ip(&["link", "set", &br, "up"])?;
+
+    tracing::info!(
+        vpc_id,
+        bridge = br.as_str(),
+        vxlan = vx.as_str(),
+        vni,
+        "VPC bridge ready"
+    );
+    Ok(())
+}
+
+/// Remove the VXLAN + bridge for a VPC.
+///
+/// Idempotent: skips if interfaces don't exist.
+pub fn remove_bridge(vpc_id: &str) -> anyhow::Result<()> {
+    let br = bridge_name(vpc_id);
+    let vx = vxlan_name(vpc_id);
+
+    if iface_exists(&vx) {
+        tracing::info!(vpc_id, iface = vx.as_str(), "removing VXLAN interface");
+        run_ip(&["link", "del", &vx])?;
+    }
+
+    if iface_exists(&br) {
+        tracing::info!(vpc_id, iface = br.as_str(), "removing bridge");
+        run_ip(&["link", "del", &br])?;
+    }
+
+    Ok(())
+}
+
+/// List VPC IDs that have active bridges on this node.
+///
+/// Scans `ip link show` for interfaces matching the `nkb-` prefix,
+/// then reverse-maps to VPC IDs using a provided mapping.
+pub fn list_active_bridges() -> Vec<String> {
+    let output = match Command::new("ip").args(["-o", "link", "show"]).output() {
+        Ok(o) if o.status.success() => o,
+        _ => return vec![],
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .lines()
+        .filter_map(|line| {
+            // Format: "N: nkb-abc123: <...>"
+            let name = line.split(':').nth(1)?.trim();
+            if name.starts_with("nkb-") {
+                Some(name.to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn run_ip(args: &[&str]) -> anyhow::Result<()> {
+    let status = Command::new("ip")
+        .args(args)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map_err(|e| anyhow::anyhow!("ip command failed: {e}"))?;
+    // Don't fail on non-zero — some operations (e.g., set master on already-attached) are benign
+    if !status.success() {
+        tracing::debug!(
+            args = args.join(" ").as_str(),
+            "ip command returned non-zero"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iface_hash_deterministic() {
+        let a = iface_hash("vpc-01knq123");
+        let b = iface_hash("vpc-01knq123");
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 6);
+    }
+
+    #[test]
+    fn iface_hash_different_vpcs() {
+        let a = iface_hash("vpc-aaa");
+        let b = iface_hash("vpc-bbb");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn bridge_name_within_limit() {
+        let name = bridge_name("vpc-01knqczg3xabdsv9wmvgzdsswe");
+        assert!(name.len() <= 15, "name too long: {name} ({})", name.len());
+        assert!(name.starts_with("nkb-"));
+    }
+
+    #[test]
+    fn vxlan_name_within_limit() {
+        let name = vxlan_name("vpc-01knqczg3xabdsv9wmvgzdsswe");
+        assert!(name.len() <= 15, "name too long: {name} ({})", name.len());
+        assert!(name.starts_with("nkx-"));
+    }
+}


### PR DESCRIPTION
## Summary
The Forge now creates real Linux network interfaces when a VPC has VMs on the node:

- `nkx-{hash}`: VXLAN interface (`nolearning`, `dstport 4789`, local mesh IPv6)
- `nkb-{hash}`: Linux bridge (connects VM TAPs + VXLAN)
- Orphaned bridges/VXLAN removed when no local VMs need them

## Tested on Hetzner (49.12.233.86)

```
=== FORGE RECONCILE ===
vpc: 1 desired, 0 actual — created:1

=== ip link show ===
nkx-0a9f1f: vxlan id 100 local fdc6:... dstport 4789 nolearning
nkb-0a9f1f: bridge, master of nkx-0a9f1f

=== SECOND RECONCILE (idempotent) ===
vpc: 1 desired, 1 actual — in sync

=== DELETE VM + RECONCILE ===
vpc: 0 desired, 1 actual — deleted:1
```

## Test plan
- [x] 10 unit tests pass (CIDR + interface naming)
- [x] Bridge creation verified on live server
- [x] VXLAN VNI correct (100)
- [x] Idempotency: second reconcile = in sync
- [x] Cleanup: delete VM → orphaned bridge removed
- [x] All CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)