### PR TITLE
feat: IPAM + TAP provisioning

### DIFF
--- a/layers/compute/src/vm/mod.rs
+++ b/layers/compute/src/vm/mod.rs
@@ -1,3 +1,4 @@
 pub mod handlers;
+pub mod provision;
 pub mod store;
 pub mod types;

--- a/layers/compute/src/vm/provision.rs
+++ b/layers/compute/src/vm/provision.rs
@@ -1,0 +1,134 @@
+//! VM provisioning — TAP interface creation.
+//!
+//! Each VM gets a TAP interface attached to its VPC bridge:
+//! - `nkt-{hash}` — TAP interface (will be passed to Cloud Hypervisor)
+//!
+//! The hash is derived from the VM ID.
+
+use std::process::Command;
+
+/// Derive a short hash (6 hex chars) from an ID for interface naming.
+fn iface_hash(id: &str) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    id.hash(&mut hasher);
+    format!("{:06x}", hasher.finish() & 0xFFFFFF)
+}
+
+/// TAP interface name for a VM.
+pub fn tap_name(vm_id: &str) -> String {
+    format!("nkt-{}", iface_hash(vm_id))
+}
+
+/// Check if a network interface exists.
+fn iface_exists(name: &str) -> bool {
+    Command::new("ip")
+        .args(["link", "show", name])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Ensure a TAP interface exists for a VM, attached to its VPC bridge.
+///
+/// Idempotent: skips creation if the TAP already exists.
+pub fn ensure_tap(vm_id: &str, vpc_bridge: &str) -> anyhow::Result<String> {
+    let tap = tap_name(vm_id);
+
+    if !iface_exists(&tap) {
+        tracing::info!(
+            vm_id,
+            tap = tap.as_str(),
+            bridge = vpc_bridge,
+            "creating TAP interface"
+        );
+
+        // Create TAP
+        let status = Command::new("ip")
+            .args(["tuntap", "add", &tap, "mode", "tap"])
+            .status()
+            .map_err(|e| anyhow::anyhow!("ip tuntap add failed: {e}"))?;
+        if !status.success() {
+            anyhow::bail!("failed to create TAP interface {tap}");
+        }
+    }
+
+    // Attach to bridge (idempotent)
+    let _ = Command::new("ip")
+        .args(["link", "set", &tap, "master", vpc_bridge])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+
+    // Bring up
+    let _ = Command::new("ip")
+        .args(["link", "set", &tap, "up"])
+        .status();
+
+    tracing::info!(vm_id, tap = tap.as_str(), "TAP ready");
+    Ok(tap)
+}
+
+/// Remove a TAP interface for a VM.
+///
+/// Idempotent: skips if the TAP doesn't exist.
+pub fn remove_tap(vm_id: &str) -> anyhow::Result<()> {
+    let tap = tap_name(vm_id);
+
+    if iface_exists(&tap) {
+        tracing::info!(vm_id, tap = tap.as_str(), "removing TAP interface");
+        let _ = Command::new("ip").args(["link", "del", &tap]).status();
+    }
+
+    Ok(())
+}
+
+/// List VM IDs that have active TAP interfaces on this node.
+pub fn list_taps() -> Vec<String> {
+    let output = match Command::new("ip").args(["-o", "link", "show"]).output() {
+        Ok(o) if o.status.success() => o,
+        _ => return vec![],
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .lines()
+        .filter_map(|line| {
+            let name = line.split(':').nth(1)?.trim();
+            if name.starts_with("nkt-") {
+                Some(name.to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tap_name_within_limit() {
+        let name = tap_name("vm-01knqhx4v5hpxp7dwgvd43qv90");
+        assert!(name.len() <= 15, "name too long: {name} ({})", name.len());
+        assert!(name.starts_with("nkt-"));
+    }
+
+    #[test]
+    fn tap_name_deterministic() {
+        let a = tap_name("vm-01abc");
+        let b = tap_name("vm-01abc");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn tap_name_different_vms() {
+        let a = tap_name("vm-aaa");
+        let b = tap_name("vm-bbb");
+        assert_ne!(a, b);
+    }
+}

--- a/layers/compute/src/vm/store.rs
+++ b/layers/compute/src/vm/store.rs
@@ -78,8 +78,21 @@ impl VmStore {
             anyhow::bail!("vm '{name}' already exists in environment '{env_name}'");
         }
 
+        // Generate VM ID first — needed for IPAM allocation
+        let vm_id = VmId::generate().to_string();
+
+        // Allocate private IP from subnet IPAM
+        let private_ip = nauka_network::vpc::subnet::ipam::allocate(
+            &self.db,
+            &subnet.meta.id,
+            &subnet.cidr,
+            &subnet.gateway,
+            &vm_id,
+        )
+        .await?;
+
         let vm = Vm {
-            meta: ResourceMeta::new(VmId::generate().to_string(), name),
+            meta: ResourceMeta::new(vm_id, name),
             org_id: org.meta.id.clone().into(),
             org_name: org.meta.name.clone(),
             project_id: project.meta.id.clone().into(),
@@ -96,7 +109,7 @@ impl VmStore {
             image: image.to_string(),
             region: region.to_string(),
             zone: zone.to_string(),
-            private_ip: None,
+            private_ip: Some(private_ip),
             hypervisor_id: Some(crate::scheduler::schedule(region, zone)?),
             state: VmState::Pending,
         };
@@ -220,6 +233,10 @@ impl VmStore {
                 vm.state
             );
         }
+
+        // Release IPAM allocation
+        nauka_network::vpc::subnet::ipam::release(&self.db, vm.subnet_id.as_str(), &vm.meta.id)
+            .await?;
 
         let idx_key = format!("{}/{}", vm.env_id.as_str(), vm.meta.name);
         self.db.delete(NS_VM, &vm.meta.id).await?;

--- a/layers/forge/src/reconciler/vm.rs
+++ b/layers/forge/src/reconciler/vm.rs
@@ -1,6 +1,8 @@
-//! VM reconciler — ensures VMs assigned to this node are running.
+//! VM reconciler — ensures TAP interfaces exist for VMs on this node.
 
+use nauka_compute::vm::provision;
 use nauka_compute::vm::types::VmState;
+use nauka_network::vpc::provision as vpc_provision;
 
 use crate::types::{ReconcileContext, ReconcileResult};
 
@@ -15,7 +17,7 @@ impl super::Reconciler for VmReconciler {
     async fn reconcile(&self, ctx: &ReconcileContext) -> anyhow::Result<ReconcileResult> {
         let mut result = ReconcileResult::new("vm");
 
-        // 1. Get VMs assigned to this node that should be running
+        // 1. Get VMs assigned to this node
         let vm_store = nauka_compute::vm::store::VmStore::new(ctx.db.clone());
         let all_vms = vm_store.list(None, None, None).await?;
         let local_vms: Vec<_> = all_vms
@@ -23,36 +25,49 @@ impl super::Reconciler for VmReconciler {
             .filter(|vm| vm.hypervisor_id.as_deref() == Some(&ctx.hypervisor_id))
             .collect();
 
-        let should_run: Vec<_> = local_vms
+        // VMs that should have TAPs (pending or running — anything assigned to this node)
+        let need_tap: Vec<_> = local_vms
             .iter()
-            .filter(|vm| vm.state == VmState::Running)
+            .filter(|vm| vm.state == VmState::Pending || vm.state == VmState::Running)
             .collect();
 
-        result.desired = should_run.len();
+        result.desired = need_tap.len();
 
-        // 2. Check actual state (stub: no processes running)
-        let actual_processes = crate::observer::process::list_vms();
-        result.actual = actual_processes.len();
+        // 2. Check actual TAPs
+        let actual_taps = provision::list_taps();
+        result.actual = actual_taps.len();
 
-        // 3. Diff and apply
-        for vm in &should_run {
-            if !actual_processes.iter().any(|p| p == &vm.meta.id) {
-                tracing::info!(
-                    vm_id = vm.meta.id.as_str(),
-                    vm_name = vm.meta.name.as_str(),
-                    image = vm.image.as_str(),
-                    vcpus = vm.vcpus,
-                    memory_mb = vm.memory_mb,
-                    "would start VM"
-                );
-                result.created += 1;
+        // 3. Create missing TAPs
+        for vm in &need_tap {
+            let expected_tap = provision::tap_name(&vm.meta.id);
+            if !actual_taps.iter().any(|t| t == &expected_tap) {
+                let bridge = vpc_provision::bridge_name(vm.vpc_id.as_str());
+                match provision::ensure_tap(&vm.meta.id, &bridge) {
+                    Ok(_) => result.created += 1,
+                    Err(e) => {
+                        tracing::error!(
+                            vm_id = vm.meta.id.as_str(),
+                            error = %e,
+                            "failed to create TAP"
+                        );
+                        result.failed += 1;
+                        result.errors.push(format!("vm {}: {e}", vm.meta.id));
+                    }
+                }
             }
         }
 
-        // 4. Check for orphaned processes (running but not in desired state)
-        for process_id in &actual_processes {
-            if !should_run.iter().any(|vm| vm.meta.id == *process_id) {
-                tracing::info!(vm_id = process_id, "would stop orphaned VM");
+        // 4. Remove orphaned TAPs
+        let needed_tap_names: Vec<String> = need_tap
+            .iter()
+            .map(|vm| provision::tap_name(&vm.meta.id))
+            .collect();
+        for tap in &actual_taps {
+            if !needed_tap_names.contains(tap) {
+                tracing::info!(tap, "removing orphaned TAP");
+                let _ = std::process::Command::new("ip")
+                    .args(["link", "del", tap])
+                    .status();
                 result.deleted += 1;
             }
         }

--- a/layers/network/src/vpc/provision.rs
+++ b/layers/network/src/vpc/provision.rs
@@ -39,6 +39,30 @@ fn iface_exists(name: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Remove all stale nauka network interfaces (nkb-*, nkx-*, nkt-*).
+///
+/// Called during cleanup or when stale interfaces from a previous cluster exist.
+pub fn cleanup_all() {
+    let output = match Command::new("ip").args(["-o", "link", "show"]).output() {
+        Ok(o) if o.status.success() => o,
+        _ => return,
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if let Some(name) = line.split(':').nth(1).map(|s| s.trim()) {
+            if name.starts_with("nkb-") || name.starts_with("nkx-") || name.starts_with("nkt-") {
+                tracing::info!(iface = name, "cleaning up stale interface");
+                let _ = Command::new("ip")
+                    .args(["link", "del", name])
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .status();
+            }
+        }
+    }
+}
+
 /// Ensure the VXLAN + bridge for a VPC exist and are up.
 ///
 /// Idempotent: skips creation if interfaces already exist.
@@ -48,6 +72,9 @@ pub fn ensure_bridge(vpc_id: &str, vni: u32, local_ipv6: &Ipv6Addr) -> anyhow::R
 
     // 1. Create VXLAN interface (if needed)
     if !iface_exists(&vx) {
+        // Clean up any stale VXLAN with the same VNI but different name
+        cleanup_stale_vxlan(vni);
+
         tracing::info!(vpc_id, vni, iface = vx.as_str(), "creating VXLAN interface");
         let status = Command::new("ip")
             .args([
@@ -143,6 +170,38 @@ pub fn list_active_bridges() -> Vec<String> {
             }
         })
         .collect()
+}
+
+/// Remove any VXLAN interface using a specific VNI (stale from previous cluster).
+fn cleanup_stale_vxlan(vni: u32) {
+    let output = match Command::new("ip")
+        .args(["-d", "-o", "link", "show"])
+        .output()
+    {
+        Ok(o) if o.status.success() => o,
+        _ => return,
+    };
+
+    let vni_str = format!("vxlan id {vni} ");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if line.contains(&vni_str) {
+            if let Some(name) = line
+                .split(':')
+                .nth(1)
+                .map(|s| s.trim().split('@').next().unwrap_or("").trim())
+            {
+                if !name.is_empty() {
+                    tracing::info!(
+                        iface = name,
+                        vni,
+                        "removing stale VXLAN with conflicting VNI"
+                    );
+                    let _ = Command::new("ip").args(["link", "del", name]).status();
+                }
+            }
+        }
+    }
 }
 
 fn run_ip(args: &[&str]) -> anyhow::Result<()> {

--- a/layers/network/src/vpc/subnet/ipam.mdx
+++ b/layers/network/src/vpc/subnet/ipam.mdx
@@ -1,0 +1,48 @@
+---
+title: IPAM
+description: Automatic IP address allocation from subnet CIDR ranges.
+sidebar:
+  order: 5
+---
+
+When a VM is created, IPAM (IP Address Management) automatically assigns a private IP from the subnet's CIDR range. The IP is visible immediately in the create response.
+
+## How it works
+
+Given a subnet `10.0.1.0/24`:
+- `10.0.1.0` — reserved (network address)
+- `10.0.1.1` — reserved (gateway, assigned to the bridge)
+- `10.0.1.2` — first VM gets this
+- `10.0.1.3` — second VM gets this
+- ...
+- `10.0.1.254` — last allocatable address
+
+## Allocation
+
+```bash
+nauka vm create web-1 --org acme --project backend --env production \
+  --vpc prod-net --subnet web --cpu 2 --memory 4096 --disk 40 --image ubuntu-24.04
+```
+
+```
+  Private IP:      10.0.1.2     ← assigned automatically
+```
+
+## Release
+
+When a VM is deleted, its IP is released back to the pool:
+
+```bash
+nauka vm delete web-1 --yes
+# 10.0.1.2 is now available for the next VM
+```
+
+## Exhaustion
+
+If all IPs in a subnet are allocated:
+
+```
+Error: no IPs available in subnet 10.0.1.0/24 (all 253 addresses allocated)
+```
+
+Create a new subnet with a larger or different CIDR range.

--- a/layers/network/src/vpc/subnet/ipam.rs
+++ b/layers/network/src/vpc/subnet/ipam.rs
@@ -1,0 +1,131 @@
+//! IPAM — IP Address Management for subnets.
+//!
+//! Allocates private IPs from a subnet's CIDR range. Uses a simple
+//! list of allocated IPs stored in TiKV (one key per subnet).
+//!
+//! Reserved addresses:
+//! - .0 = network address
+//! - .1 = gateway (assigned to the bridge)
+//! - .255 = broadcast (for /24)
+
+use nauka_hypervisor::controlplane::ClusterDb;
+
+const NS_IPAM: &str = "ipam";
+
+/// Allocated IPs for a subnet, stored as a list in TiKV.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
+struct Allocations {
+    ips: Vec<Allocation>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct Allocation {
+    ip: String,
+    vm_id: String,
+}
+
+/// Allocate the next available IP from a subnet.
+///
+/// Skips network (.0), gateway (.1), and broadcast addresses.
+/// Returns the allocated IP as a string (e.g., "10.0.1.2").
+pub async fn allocate(
+    db: &ClusterDb,
+    subnet_id: &str,
+    subnet_cidr: &str,
+    gateway: &str,
+    vm_id: &str,
+) -> anyhow::Result<String> {
+    let net: ipnet::Ipv4Net = subnet_cidr
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid subnet CIDR: {e}"))?;
+
+    // Load current allocations
+    let mut allocs: Allocations = db.get(NS_IPAM, subnet_id).await?.unwrap_or_default();
+
+    // Check if this VM already has an IP
+    if let Some(existing) = allocs.ips.iter().find(|a| a.vm_id == vm_id) {
+        return Ok(existing.ip.clone());
+    }
+
+    let allocated_ips: Vec<&str> = allocs.ips.iter().map(|a| a.ip.as_str()).collect();
+
+    // Find next available host IP
+    for host_ip in net.hosts() {
+        let ip_str = host_ip.to_string();
+
+        // Skip gateway
+        if ip_str == gateway {
+            continue;
+        }
+
+        // Skip already allocated
+        if allocated_ips.contains(&ip_str.as_str()) {
+            continue;
+        }
+
+        // Found one — allocate it
+        allocs.ips.push(Allocation {
+            ip: ip_str.clone(),
+            vm_id: vm_id.to_string(),
+        });
+        db.put(NS_IPAM, subnet_id, &allocs).await?;
+
+        return Ok(ip_str);
+    }
+
+    anyhow::bail!(
+        "no IPs available in subnet {} (all {} addresses allocated)",
+        subnet_cidr,
+        allocs.ips.len()
+    )
+}
+
+/// Release an IP allocation for a VM.
+pub async fn release(db: &ClusterDb, subnet_id: &str, vm_id: &str) -> anyhow::Result<()> {
+    let mut allocs: Allocations = db.get(NS_IPAM, subnet_id).await?.unwrap_or_default();
+
+    allocs.ips.retain(|a| a.vm_id != vm_id);
+    db.put(NS_IPAM, subnet_id, &allocs).await?;
+
+    Ok(())
+}
+
+/// Get the allocated IP for a VM in a subnet.
+pub async fn get_allocation(
+    db: &ClusterDb,
+    subnet_id: &str,
+    vm_id: &str,
+) -> anyhow::Result<Option<String>> {
+    let allocs: Allocations = db.get(NS_IPAM, subnet_id).await?.unwrap_or_default();
+
+    Ok(allocs
+        .ips
+        .iter()
+        .find(|a| a.vm_id == vm_id)
+        .map(|a| a.ip.clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allocations_serde_roundtrip() {
+        let allocs = Allocations {
+            ips: vec![
+                Allocation {
+                    ip: "10.0.1.2".to_string(),
+                    vm_id: "vm-01".to_string(),
+                },
+                Allocation {
+                    ip: "10.0.1.3".to_string(),
+                    vm_id: "vm-02".to_string(),
+                },
+            ],
+        };
+        let json = serde_json::to_string(&allocs).unwrap();
+        let back: Allocations = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.ips.len(), 2);
+        assert_eq!(back.ips[0].ip, "10.0.1.2");
+    }
+}

--- a/layers/network/src/vpc/subnet/mod.rs
+++ b/layers/network/src/vpc/subnet/mod.rs
@@ -1,3 +1,4 @@
 pub mod handlers;
+pub mod ipam;
 pub mod store;
 pub mod types;


### PR DESCRIPTION
## Summary

**IPAM**: automatic IP allocation from subnet CIDR at `vm create`.
- First available host IP (skips network, gateway, broadcast)
- Released on `vm delete`, reusable by next VM
- Stored per-subnet in TiKV

**TAP**: Forge creates TAP interfaces for VMs, attached to VPC bridge.
- `nkt-{hash}` per VM, attached to `nkb-{hash}` bridge
- Created for pending + running VMs, orphans cleaned up

**Stale VNI cleanup**: handles leftover VXLAN from previous clusters.

## Tested on Hetzner

```
$ nauka vm create web-1 ...
  Private IP: 10.0.1.2        ← IPAM assigns immediately
  Hypervisor: hv-01knrjta...  ← scheduler assigns

$ nauka forge reconcile
  vpc: 1 desired, 0 actual — created:1
  vm:  1 desired, 0 actual — created:1

$ bridge link show
  nkx-0bba67 master nkb-0bba67 (VXLAN → bridge)
  nkt-6b3356 master nkb-0bba67 (TAP → bridge)
```

## Test plan
- [x] IPAM: first VM gets .2, second gets .3, delete+recreate reuses .3
- [x] TAP: created and attached to correct bridge
- [x] Stale VNI cleanup works
- [x] Idempotent reconciliation
- [x] All tests pass (15 unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)