### PR TITLE
feat(network): FDB distribution for cross-node VXLAN traffic

### DIFF
--- a/layers/compute/src/scheduler.rs
+++ b/layers/compute/src/scheduler.rs
@@ -30,8 +30,10 @@ pub fn schedule(region: &str, zone: &str) -> anyhow::Result<String> {
         .ok_or_else(|| anyhow::anyhow!("cluster not initialized"))?;
 
     // Build candidate list: self + peers
+    // Use node NAME as the canonical identifier — it's the only ID
+    // that all nodes can resolve (peers know each other by name).
     let mut candidates = vec![Candidate {
-        id: state.hypervisor.id.as_str().to_string(),
+        id: state.hypervisor.name.clone(),
         name: state.hypervisor.name.clone(),
         region: state.hypervisor.region.clone(),
         zone: state.hypervisor.zone.clone(),

--- a/layers/forge/src/reconciler/vpc.rs
+++ b/layers/forge/src/reconciler/vpc.rs
@@ -1,4 +1,4 @@
-//! VPC reconciler — ensures VXLAN bridges exist for VPCs with local VMs.
+//! VPC reconciler — ensures VXLAN bridges + FDB entries for cross-node traffic.
 
 use nauka_network::vpc::provision;
 
@@ -30,7 +30,7 @@ impl super::Reconciler for VpcReconciler {
 
         // 2. Collect unique VPC IDs needed on this node + resolve their VNIs
         let vpc_store = nauka_network::vpc::store::VpcStore::new(ctx.db.clone());
-        let mut needed_vpcs: Vec<(String, u32)> = Vec::new(); // (vpc_id, vni)
+        let mut needed_vpcs: Vec<(String, u32)> = Vec::new();
         for vm in &local_vms {
             let vpc_id = vm.vpc_id.as_str().to_string();
             if !needed_vpcs.iter().any(|(id, _)| id == &vpc_id) {
@@ -42,7 +42,7 @@ impl super::Reconciler for VpcReconciler {
 
         result.desired = needed_vpcs.len();
 
-        // 3. Check actual state — scan for existing bridges
+        // 3. Check actual state
         let actual_bridges = crate::observer::network::list_bridges();
         result.actual = actual_bridges.len();
 
@@ -61,7 +61,7 @@ impl super::Reconciler for VpcReconciler {
             }
         }
 
-        // 5. Remove orphaned bridges (exist locally but no VMs need them)
+        // 5. Remove orphaned bridges
         let needed_bridge_names: Vec<String> = needed_vpcs
             .iter()
             .map(|(id, _)| provision::bridge_name(id))
@@ -69,7 +69,6 @@ impl super::Reconciler for VpcReconciler {
         for bridge in &actual_bridges {
             if !needed_bridge_names.contains(bridge) {
                 tracing::info!(bridge, "removing orphaned bridge");
-                // Derive VXLAN name from bridge name (nkb-HASH → nkx-HASH)
                 let vxlan = bridge.replace("nkb-", "nkx-");
                 let _ = std::process::Command::new("ip")
                     .args(["link", "del", &vxlan])
@@ -81,6 +80,81 @@ impl super::Reconciler for VpcReconciler {
             }
         }
 
+        // 6. FDB distribution — add entries for remote VMs in our VPCs
+        for (vpc_id, _vni) in &needed_vpcs {
+            // Find ALL VMs in this VPC (local + remote)
+            let vpc_vms: Vec<_> = all_vms
+                .iter()
+                .filter(|vm| vm.vpc_id.as_str() == vpc_id)
+                .collect();
+
+            // For each remote VM, add FDB + ARP entry
+            for vm in &vpc_vms {
+                // Skip local VMs (they don't need FDB entries)
+                let is_local = vm
+                    .hypervisor_id
+                    .as_ref()
+                    .map(|hid| ctx.node_ids.iter().any(|nid| nid == hid))
+                    .unwrap_or(false);
+                if is_local {
+                    continue;
+                }
+
+                let ip = match &vm.private_ip {
+                    Some(ip) => ip,
+                    None => continue,
+                };
+
+                let mac = match provision::mac_from_ip(ip) {
+                    Some(mac) => mac,
+                    None => continue,
+                };
+
+                // Resolve remote hypervisor's mesh IPv6
+                let remote_ipv6 = resolve_hypervisor_ipv6(ctx, vm.hypervisor_id.as_deref());
+                let remote_ipv6 = match remote_ipv6 {
+                    Some(ip) => ip,
+                    None => {
+                        tracing::warn!(
+                            vm_id = vm.meta.id.as_str(),
+                            hypervisor = vm.hypervisor_id.as_deref().unwrap_or("?"),
+                            "cannot resolve remote hypervisor mesh IPv6 for FDB"
+                        );
+                        continue;
+                    }
+                };
+
+                let _ = provision::add_fdb_entry(vpc_id, &mac, &remote_ipv6);
+                let _ = provision::add_arp_proxy(vpc_id, ip, &mac);
+            }
+        }
+
         Ok(result)
     }
+}
+
+/// Resolve a hypervisor identifier (HV ID or name) to its mesh IPv6.
+fn resolve_hypervisor_ipv6(
+    _ctx: &ReconcileContext,
+    hypervisor_id: Option<&str>,
+) -> Option<std::net::Ipv6Addr> {
+    let hid = hypervisor_id?;
+
+    // Load peer list from local fabric state
+    let db = nauka_state::LocalDb::open("hypervisor").ok()?;
+    let state = nauka_hypervisor::fabric::state::FabricState::load(&db).ok()??;
+
+    // Check if it's self
+    if hid == state.hypervisor.id.as_str() || hid == state.hypervisor.name {
+        return Some(state.hypervisor.mesh_ipv6);
+    }
+
+    // Check peers (by ID or name)
+    for peer in &state.peers.peers {
+        if peer.id.as_str() == hid || peer.name == hid {
+            return Some(peer.mesh_ipv6);
+        }
+    }
+
+    None
 }

--- a/layers/network/src/vpc/provision.rs
+++ b/layers/network/src/vpc/provision.rs
@@ -204,6 +204,135 @@ fn cleanup_stale_vxlan(vni: u32) {
     }
 }
 
+// ═══════════════════════════════════════════════════
+// FDB — Forwarding Database for VXLAN cross-node traffic
+// ═══════════════════════════════════════════════════
+
+/// Derive a deterministic MAC address from an IPv4 address.
+///
+/// Format: `02:00:{a}.{b}.{c}.{d}` where a.b.c.d are the IP octets in hex.
+/// The `02` prefix marks it as a locally administered unicast MAC.
+pub fn mac_from_ip(ip: &str) -> Option<String> {
+    let addr: std::net::Ipv4Addr = ip.parse().ok()?;
+    let octets = addr.octets();
+    Some(format!(
+        "02:00:{:02x}:{:02x}:{:02x}:{:02x}",
+        octets[0], octets[1], octets[2], octets[3]
+    ))
+}
+
+/// Add an FDB entry for a remote VM.
+///
+/// Tells the VXLAN interface: "frames destined for this MAC should be
+/// sent via VXLAN to this remote mesh IPv6 address."
+pub fn add_fdb_entry(vpc_id: &str, mac: &str, remote_ipv6: &Ipv6Addr) -> anyhow::Result<()> {
+    let vx = vxlan_name(vpc_id);
+
+    tracing::info!(
+        vpc_id,
+        mac,
+        remote = %remote_ipv6,
+        vxlan = vx.as_str(),
+        "adding FDB entry"
+    );
+
+    // bridge fdb add <mac> dev <vxlan> dst <remote_ipv6>
+    let _ = Command::new("bridge")
+        .args([
+            "fdb",
+            "replace",
+            mac,
+            "dev",
+            &vx,
+            "dst",
+            &remote_ipv6.to_string(),
+            "self",
+            "permanent",
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+
+    Ok(())
+}
+
+/// Add an ARP proxy entry for a remote VM.
+///
+/// The bridge answers ARP requests on behalf of the remote VM,
+/// so local VMs don't need to broadcast ARP over the VXLAN.
+pub fn add_arp_proxy(vpc_id: &str, ip: &str, mac: &str) -> anyhow::Result<()> {
+    let br = bridge_name(vpc_id);
+
+    let _ = Command::new("ip")
+        .args([
+            "neigh",
+            "replace",
+            ip,
+            "lladdr",
+            mac,
+            "dev",
+            &br,
+            "nud",
+            "permanent",
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+
+    Ok(())
+}
+
+/// Remove FDB + ARP entries for a remote VM.
+pub fn remove_fdb_entry(vpc_id: &str, mac: &str, ip: &str) -> anyhow::Result<()> {
+    let vx = vxlan_name(vpc_id);
+    let br = bridge_name(vpc_id);
+
+    let _ = Command::new("bridge")
+        .args(["fdb", "del", mac, "dev", &vx])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+
+    let _ = Command::new("ip")
+        .args(["neigh", "del", ip, "dev", &br])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+
+    Ok(())
+}
+
+/// List current FDB entries for a VXLAN interface.
+pub fn list_fdb_entries(vpc_id: &str) -> Vec<(String, String)> {
+    let vx = vxlan_name(vpc_id);
+
+    let output = match Command::new("bridge")
+        .args(["fdb", "show", "dev", &vx])
+        .output()
+    {
+        Ok(o) if o.status.success() => o,
+        _ => return vec![],
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .lines()
+        .filter_map(|line| {
+            // Format: "02:00:0a:00:01:03 dst fd47:... self permanent"
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 4 && parts[1] == "dst" {
+                let mac = parts[0].to_string();
+                let dst = parts[2].to_string();
+                // Skip 00:00:00:00:00:00 (default entry)
+                if !mac.starts_with("00:00:00:00:00:00") {
+                    return Some((mac, dst));
+                }
+            }
+            None
+        })
+        .collect()
+}
+
 fn run_ip(args: &[&str]) -> anyhow::Result<()> {
     let status = Command::new("ip")
         .args(args)
@@ -245,6 +374,28 @@ mod tests {
         let name = bridge_name("vpc-01knqczg3xabdsv9wmvgzdsswe");
         assert!(name.len() <= 15, "name too long: {name} ({})", name.len());
         assert!(name.starts_with("nkb-"));
+    }
+
+    #[test]
+    fn mac_from_ip_format() {
+        assert_eq!(
+            mac_from_ip("10.0.1.2"),
+            Some("02:00:0a:00:01:02".to_string())
+        );
+        assert_eq!(
+            mac_from_ip("192.168.1.100"),
+            Some("02:00:c0:a8:01:64".to_string())
+        );
+    }
+
+    #[test]
+    fn mac_from_ip_deterministic() {
+        assert_eq!(mac_from_ip("10.0.1.5"), mac_from_ip("10.0.1.5"));
+    }
+
+    #[test]
+    fn mac_from_ip_invalid() {
+        assert!(mac_from_ip("not-an-ip").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
The VPC reconciler now populates FDB + ARP proxy entries for remote VMs, enabling cross-node VXLAN traffic.

- **MAC derivation**: deterministic from IP (`02:00:{ip_hex}`)
- **FDB entry**: `bridge fdb replace {mac} dev nkx-{hash} dst {remote_mesh_ipv6} self permanent`
- **ARP proxy**: `ip neigh replace {ip} lladdr {mac} dev nkb-{hash} nud permanent`
- **Scheduler fix**: uses node name (not HV ID) for universal resolvability across nodes

## Tested multi-node on Hetzner

```
Server 1 (nur) — web-1 (10.0.1.2):
  FDB:  02:00:0a:00:01:03 → dst fd47:...:1736 (server 2)
  ARP:  10.0.1.3 → 02:00:0a:00:01:03

Server 2 (fsn1) — web-2 (10.0.1.3):
  FDB:  02:00:0a:00:01:02 → dst fd47:...:835f (server 1)
  ARP:  10.0.1.2 → 02:00:0a:00:01:02
```

Both nodes know where to forward frames for remote VMs.

## Test plan
- [x] 7 provision unit tests (including 3 MAC derivation tests)
- [x] FDB entries created on both servers
- [x] ARP proxy entries created on both servers
- [x] Remote IPv6 resolution via peer list works
- [x] All CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)