### PR TITLE
feat: container networking — veth pairs + cross-node ping

### DIFF
--- a/layers/compute/src/runtime/gvisor.rs
+++ b/layers/compute/src/runtime/gvisor.rs
@@ -128,7 +128,26 @@ impl Runtime for GVisorRuntime {
             0
         };
 
-        // 6. Write PID + runtime marker
+        // 6. Set up container networking (veth into netns)
+        if pid > 0 && !config.private_ip.is_empty() {
+            let mac = nauka_network::vpc::provision::mac_from_ip(&config.private_ip)
+                .unwrap_or_else(|| "02:00:00:00:00:00".to_string());
+            if let Err(e) = crate::vm::provision::setup_container_net(
+                &config.vm_id,
+                pid,
+                &config.private_ip,
+                &config.gateway,
+                &mac,
+            ) {
+                tracing::warn!(
+                    vm_id = config.vm_id.as_str(),
+                    error = %e,
+                    "container networking setup failed (container still running)"
+                );
+            }
+        }
+
+        // 7. Write PID + runtime marker
         std::fs::write(vm_dir.join("pid"), pid.to_string())?;
         std::fs::write(vm_dir.join("runtime"), "container")?;
 

--- a/layers/compute/src/vm/provision.rs
+++ b/layers/compute/src/vm/provision.rs
@@ -86,6 +86,159 @@ pub fn remove_tap(vm_id: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+// ═══════════════════════════════════════════════════
+// Veth pair — for container networking
+// ═══════════════════════════════════════════════════
+
+/// Host-side veth name for a container.
+pub fn veth_host_name(vm_id: &str) -> String {
+    format!("nkh-{}", iface_hash(vm_id))
+}
+
+/// Guest-side veth name (before being renamed to eth0 in the container).
+pub fn veth_guest_name(vm_id: &str) -> String {
+    format!("nkg-{}", iface_hash(vm_id))
+}
+
+/// Create a veth pair and attach the host side to the VPC bridge.
+///
+/// The guest side stays in the host netns until `move_veth_to_container`
+/// moves it into the container's network namespace.
+pub fn ensure_veth(vm_id: &str, vpc_bridge: &str) -> anyhow::Result<()> {
+    let host = veth_host_name(vm_id);
+    let guest = veth_guest_name(vm_id);
+
+    if !iface_exists(&host) {
+        tracing::info!(
+            vm_id,
+            host = host.as_str(),
+            guest = guest.as_str(),
+            "creating veth pair"
+        );
+
+        let status = Command::new("ip")
+            .args(["link", "add", &host, "type", "veth", "peer", "name", &guest])
+            .status()
+            .map_err(|e| anyhow::anyhow!("ip link add veth failed: {e}"))?;
+        if !status.success() {
+            anyhow::bail!("failed to create veth pair {host}/{guest}");
+        }
+    }
+
+    // Attach host side to bridge
+    let _ = Command::new("ip")
+        .args(["link", "set", &host, "master", vpc_bridge])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+
+    // Bring host side up
+    let _ = Command::new("ip")
+        .args(["link", "set", &host, "up"])
+        .status();
+
+    Ok(())
+}
+
+/// Move the guest-side veth into the container's network namespace
+/// and configure IP address + default route.
+pub fn setup_container_net(
+    vm_id: &str,
+    container_pid: u32,
+    ip: &str,
+    gateway: &str,
+    mac: &str,
+) -> anyhow::Result<()> {
+    let guest = veth_guest_name(vm_id);
+    let pid = container_pid.to_string();
+
+    tracing::info!(
+        vm_id,
+        pid = pid.as_str(),
+        ip,
+        gateway,
+        "setting up container networking"
+    );
+
+    // 1. Move guest veth into container netns
+    let status = Command::new("ip")
+        .args(["link", "set", &guest, "netns", &pid])
+        .status()
+        .map_err(|e| anyhow::anyhow!("move veth to netns failed: {e}"))?;
+    if !status.success() {
+        anyhow::bail!("failed to move {guest} to netns of PID {pid}");
+    }
+
+    // 2. Inside the container netns: rename to eth0, set MAC, configure IP, bring up
+    let nsenter = |args: &[&str]| -> anyhow::Result<()> {
+        let status = Command::new("nsenter")
+            .args(["--net", &format!("--target={pid}")])
+            .args(args)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map_err(|e| anyhow::anyhow!("nsenter failed: {e}"))?;
+        if !status.success() {
+            tracing::debug!(
+                args = args.join(" ").as_str(),
+                "nsenter command returned non-zero"
+            );
+        }
+        Ok(())
+    };
+
+    // Rename to eth0
+    nsenter(&["ip", "link", "set", &guest, "name", "eth0"])?;
+
+    // Set MAC address (deterministic from IP)
+    nsenter(&["ip", "link", "set", "eth0", "address", mac])?;
+
+    // Add IP address
+    let cidr = format!("{ip}/24");
+    nsenter(&["ip", "addr", "add", &cidr, "dev", "eth0"])?;
+
+    // Bring up lo and eth0
+    nsenter(&["ip", "link", "set", "lo", "up"])?;
+    nsenter(&["ip", "link", "set", "eth0", "up"])?;
+
+    // Default route via gateway
+    nsenter(&["ip", "route", "add", "default", "via", gateway])?;
+
+    tracing::info!(vm_id, ip, "container networking ready");
+    Ok(())
+}
+
+/// Remove veth pair for a container.
+pub fn remove_veth(vm_id: &str) -> anyhow::Result<()> {
+    let host = veth_host_name(vm_id);
+    if iface_exists(&host) {
+        tracing::info!(vm_id, iface = host.as_str(), "removing veth pair");
+        let _ = Command::new("ip").args(["link", "del", &host]).status();
+    }
+    Ok(())
+}
+
+/// List VM IDs that have active veth host interfaces on this node.
+pub fn list_veths() -> Vec<String> {
+    let output = match Command::new("ip").args(["-o", "link", "show"]).output() {
+        Ok(o) if o.status.success() => o,
+        _ => return vec![],
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .lines()
+        .filter_map(|line| {
+            let name = line.split(':').nth(1)?.trim();
+            if name.starts_with("nkh-") {
+                Some(name.to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
 /// List VM IDs that have active TAP interfaces on this node.
 pub fn list_taps() -> Vec<String> {
     let output = match Command::new("ip").args(["-o", "link", "show"]).output() {

--- a/layers/forge/src/reconciler/vm.rs
+++ b/layers/forge/src/reconciler/vm.rs
@@ -57,19 +57,33 @@ impl super::Reconciler for VmReconciler {
         let actual_processes = crate::observer::process::list_vms();
         result.actual = actual_processes.len();
 
-        // 3. Create TAPs + start processes for missing VMs
+        // 3. Create network interface + start processes for missing VMs
+        let use_veth = ctx.runtime == RuntimeMode::Container;
         for vm in &should_exist {
-            let expected_tap = provision::tap_name(&vm.meta.id);
-            let actual_taps = provision::list_taps();
+            let bridge = vpc_provision::bridge_name(vm.vpc_id.as_str());
 
-            // Ensure TAP exists
-            if !actual_taps.iter().any(|t| t == &expected_tap) {
-                let bridge = vpc_provision::bridge_name(vm.vpc_id.as_str());
-                if let Err(e) = provision::ensure_tap(&vm.meta.id, &bridge) {
-                    tracing::error!(vm_id = vm.meta.id.as_str(), error = %e, "failed to create TAP");
-                    result.failed += 1;
-                    result.errors.push(format!("tap {}: {e}", vm.meta.id));
-                    continue;
+            // Ensure network interface exists (veth for containers, TAP for KVM)
+            if use_veth {
+                let expected = provision::veth_host_name(&vm.meta.id);
+                let actual = provision::list_veths();
+                if !actual.iter().any(|v| v == &expected) {
+                    if let Err(e) = provision::ensure_veth(&vm.meta.id, &bridge) {
+                        tracing::error!(vm_id = vm.meta.id.as_str(), error = %e, "failed to create veth");
+                        result.failed += 1;
+                        result.errors.push(format!("veth {}: {e}", vm.meta.id));
+                        continue;
+                    }
+                }
+            } else {
+                let expected = provision::tap_name(&vm.meta.id);
+                let actual = provision::list_taps();
+                if !actual.iter().any(|t| t == &expected) {
+                    if let Err(e) = provision::ensure_tap(&vm.meta.id, &bridge) {
+                        tracing::error!(vm_id = vm.meta.id.as_str(), error = %e, "failed to create TAP");
+                        result.failed += 1;
+                        result.errors.push(format!("tap {}: {e}", vm.meta.id));
+                        continue;
+                    }
                 }
             }
 
@@ -91,7 +105,11 @@ impl super::Reconciler for VmReconciler {
                     memory_mb: vm.memory_mb,
                     disk_gb: vm.disk_gb,
                     image: vm.image.clone(),
-                    tap_name: provision::tap_name(&vm.meta.id),
+                    tap_name: if use_veth {
+                        provision::veth_guest_name(&vm.meta.id)
+                    } else {
+                        provision::tap_name(&vm.meta.id)
+                    },
                     private_ip: vm.private_ip.clone().unwrap_or_default(),
                     gateway,
                     subnet_cidr: cidr,
@@ -116,13 +134,17 @@ impl super::Reconciler for VmReconciler {
             }
         }
 
-        // 4. Remove orphaned processes + TAPs
+        // 4. Remove orphaned processes + network interfaces
         let needed_ids: Vec<&str> = should_exist.iter().map(|vm| vm.meta.id.as_str()).collect();
         for vm_id in &actual_processes {
             if !needed_ids.contains(&vm_id.as_str()) {
                 tracing::info!(vm_id, "stopping orphaned VM");
                 let _ = rt.stop(vm_id);
-                let _ = provision::remove_tap(vm_id);
+                if use_veth {
+                    let _ = provision::remove_veth(vm_id);
+                } else {
+                    let _ = provision::remove_tap(vm_id);
+                }
                 result.deleted += 1;
             }
         }

--- a/layers/forge/src/reconciler/vpc.rs
+++ b/layers/forge/src/reconciler/vpc.rs
@@ -126,11 +126,76 @@ impl super::Reconciler for VpcReconciler {
 
                 let _ = provision::add_fdb_entry(vpc_id, &mac, &remote_ipv6);
                 let _ = provision::add_arp_proxy(vpc_id, ip, &mac);
+
+                // Add static ARP inside local containers so they can reach this remote VM
+                for local_vm in &local_vms {
+                    if local_vm.vpc_id.as_str() == *vpc_id {
+                        if let Some(pid) = get_container_pid(&local_vm.meta.id) {
+                            let _ = add_arp_in_container(pid, ip, &mac);
+                        }
+                    }
+                }
+            }
+        }
+
+        // 7. Set gateway IP on bridges so containers can reach the gateway
+        for (vpc_id, _) in &needed_vpcs {
+            let br = provision::bridge_name(vpc_id);
+            // Look up the subnet gateway from any local VM in this VPC
+            if let Some(local_vm) = local_vms.iter().find(|vm| vm.vpc_id.as_str() == *vpc_id) {
+                let subnet_store =
+                    nauka_network::vpc::subnet::store::SubnetStore::new(ctx.db.clone());
+                if let Ok(Some(subnet)) = subnet_store
+                    .get(local_vm.subnet_id.as_str(), None, None)
+                    .await
+                {
+                    let gw_cidr = format!("{}/24", subnet.gateway);
+                    let _ = std::process::Command::new("ip")
+                        .args(["addr", "replace", &gw_cidr, "dev", &br])
+                        .stdout(std::process::Stdio::null())
+                        .stderr(std::process::Stdio::null())
+                        .status();
+                }
             }
         }
 
         Ok(result)
     }
+}
+
+/// Get the PID of a running container by VM ID.
+fn get_container_pid(vm_id: &str) -> Option<u32> {
+    let pid_path = std::path::PathBuf::from("/run/nauka/vms")
+        .join(vm_id)
+        .join("pid");
+    std::fs::read_to_string(pid_path)
+        .ok()
+        .and_then(|s| s.trim().parse::<u32>().ok())
+        .filter(|&pid| unsafe { libc::kill(pid as i32, 0) == 0 })
+}
+
+/// Add a static ARP entry inside a container's network namespace.
+fn add_arp_in_container(container_pid: u32, ip: &str, mac: &str) -> anyhow::Result<()> {
+    let pid = container_pid.to_string();
+    let _ = std::process::Command::new("nsenter")
+        .args([
+            "--net",
+            &format!("--target={pid}"),
+            "ip",
+            "neigh",
+            "replace",
+            ip,
+            "lladdr",
+            mac,
+            "dev",
+            "eth0",
+            "nud",
+            "permanent",
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+    Ok(())
 }
 
 /// Resolve a hypervisor identifier (HV ID or name) to its mesh IPv6.


### PR DESCRIPTION
## Summary

Enables real container networking for cross-node communication:

- **Veth pairs** for containers (instead of TAPs used for KVM)
  - `nkh-{hash}`: host side, attached to VPC bridge
  - `nkg-{hash}`: moved into container netns, renamed to `eth0`
- **Container net setup**: IP, MAC, gateway configured via `nsenter`
- **ARP injection**: static ARP entries injected into containers for remote VMs
- **Bridge gateway**: VPC bridge gets the gateway IP (e.g., 10.0.1.1/24)

## Cross-node ping verified on Hetzner

```
web-1 (10.0.1.2, Nuremberg) → web-2 (10.0.1.3, Falkenstein)

$ ping 10.0.1.3
64 bytes from 10.0.1.3: icmp_seq=1 ttl=64 time=0.580 ms
64 bytes from 10.0.1.3: icmp_seq=2 ttl=64 time=0.648 ms
3 packets transmitted, 3 received, 0% packet loss

Path: Container → veth → bridge → VXLAN → WireGuard → internet → WireGuard → VXLAN → bridge → veth → Container
```

## Test plan
- [x] Veth pairs created and attached to bridge
- [x] Container has eth0 with correct IP/MAC/gateway
- [x] Cross-node ping works bidirectionally (0.6ms RTT)
- [x] All CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)