### PR TITLE
docs: Architecture + Networking platform guides

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -96,6 +96,13 @@ export default defineConfig({
 						{ label: 'Troubleshooting', slug: 'getting-started/troubleshooting' },
 					],
 				},
+				{
+					label: 'Platform',
+					items: [
+						{ label: 'Architecture', slug: 'architecture' },
+						{ label: 'Networking', slug: 'networking' },
+					],
+				},
 				...layerSidebar,
 				{
 					label: 'API Reference',

--- a/docs/src/content/docs/architecture.mdx
+++ b/docs/src/content/docs/architecture.mdx
@@ -1,0 +1,107 @@
+---
+title: Architecture
+description: How Nauka turns bare-metal servers into a programmable cloud — layers, resource model, and the reconciliation loop.
+sidebar:
+  order: 1
+---
+
+import Mermaid from '../../components/Mermaid.astro';
+
+Nauka is built as a stack of layers, each responsible for one concern. Lower layers never depend on higher layers. The CLI and REST API are auto-generated from resource definitions — you define a resource once and get both interfaces for free.
+
+## Layer stack
+
+<Mermaid chart={`
+graph TD
+  subgraph "Platform Layers"
+    Compute["Compute<br/>VM lifecycle, scheduler"]
+    Network["Network<br/>VPC, subnet, IPAM, peering"]
+    Org["Organization<br/>Org → Project → Env"]
+  end
+  subgraph "Infrastructure Layers"
+    Forge["Forge<br/>Per-node reconciler"]
+    Hypervisor["Hypervisor<br/>WireGuard mesh, TiKV, ZeroFS"]
+  end
+  subgraph "Foundation"
+    Core["Core<br/>Resource framework, IDs, crypto"]
+    State["State<br/>LocalDb + ClusterDb"]
+  end
+  Compute --> Network
+  Compute --> Org
+  Network --> Org
+  Forge --> Compute
+  Forge --> Network
+  Compute --> Hypervisor
+  Network --> Hypervisor
+  Org --> Hypervisor
+  Hypervisor --> Core
+  Hypervisor --> State
+`} />
+
+| Layer | Crate | Purpose |
+|---|---|---|
+| **Core** | `nauka-core` | Resource framework, typed IDs, crypto, validation, API generation |
+| **State** | `nauka-state` | Local persistence (JSON) + distributed persistence (TiKV) |
+| **Hypervisor** | `nauka-hypervisor` | WireGuard mesh, TiKV control plane, ZeroFS storage, compute setup |
+| **Organization** | `nauka-org` | Org → Project → Environment hierarchy |
+| **Network** | `nauka-network` | VPC, Subnet, IPAM, VPC Peering, VXLAN provisioning |
+| **Compute** | `nauka-compute` | VM lifecycle, scheduler, OCI runtime (crun/Cloud Hypervisor) |
+| **Forge** | `nauka-forge` | Per-node reconciler — bridges desired state (TiKV) to actual state (kernel) |
+
+## Resource model
+
+Every cloud resource follows the same pattern:
+
+1. **ResourceDef** — declares the resource (name, fields, operations, parent scope)
+2. **CLI** — auto-generated from the ResourceDef (`nauka vpc create ...`)
+3. **REST API** — auto-generated with plural URLs (`POST /v1/vpcs`)
+4. **Store** — CRUD in TiKV with name index + ID registry
+5. **ApiResource trait** — enforces consistent JSON responses (ISO 8601 timestamps, status, labels)
+
+Resources are organized as **peers** (independent layers) or **children** (nested within a parent):
+
+```
+Peers (flat):        Children (nested):
+  hypervisor           org → project → env
+  org                  vpc → subnet
+  vpc                       → peering
+  vm
+  forge
+```
+
+Rule: **flat for peers, nested for children.** A project can't exist without an org (child). A VPC can exist independently of any org (peer, references org via `--org`).
+
+## Desired state vs actual state
+
+Nauka separates what you want from what exists:
+
+```
+nauka vm create web-1 ...
+  → writes desired state to TiKV: "VM web-1 should exist with 2 vCPUs, 4GB RAM"
+
+nauka forge reconcile
+  → reads TiKV: "VM web-1 should exist"
+  → reads kernel: "no such container"
+  → action: create VXLAN bridge, create veth pair, start container
+  → reports: "vm: 1 desired, 0 actual — created:1"
+```
+
+The Forge runs as a daemon on each node, polling TiKV every 30 seconds. It never modifies TiKV — it only reads desired state and converges the kernel toward it.
+
+## Dual runtime
+
+Each node detects its compute capability at `hypervisor init`:
+
+| `/dev/kvm` | Runtime | Isolation | Use case |
+|---|---|---|---|
+| Present | Cloud Hypervisor | Hardware (VT-x) | Bare-metal servers |
+| Absent | crun (OCI container) | Linux namespaces | VPS, cloud instances |
+
+The user never sees the difference — `nauka vm create` works the same on both.
+
+## IDs and naming
+
+- **IDs**: lowercase ULID with type prefix (`vpc-01knqczg...`, `vm-01knrtj0...`)
+- **Names**: immutable, unique within parent scope, DNS-label format (3-63 chars, lowercase alphanumeric + hyphens)
+- **Scheduler**: uses node **names** (not IDs) for cross-node resolution
+- **MAC addresses**: derived deterministically from IP (`02:00:{ip_hex}`)

--- a/docs/src/content/docs/networking.mdx
+++ b/docs/src/content/docs/networking.mdx
@@ -1,0 +1,176 @@
+---
+title: Networking
+description: How Nauka provides isolated virtual networks across bare-metal servers — VPCs, VXLAN overlay, FDB distribution, and container networking.
+sidebar:
+  order: 2
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import Mermaid from '../../components/Mermaid.astro';
+
+Nauka networking has two layers: the **underlay** (WireGuard mesh between servers) and the **overlay** (VXLAN virtual networks for VMs/containers).
+
+## Underlay vs overlay
+
+**Underlay** = the physical network. WireGuard tunnels between servers, encrypted IPv6 mesh. This is the fabric layer — already in place after `hypervisor init`.
+
+**Overlay** = virtual networks on top. Each VPC gets a VXLAN tunnel that encapsulates ethernet frames inside the WireGuard mesh. VMs in different VPCs are completely isolated.
+
+```
+Container (10.0.1.2)
+    │ ethernet frame
+    ▼
+eth0 (veth guest side)
+    │
+    ▼ ────────────── overlay ──────────────
+bridge (nkb-{hash})     L2 switch for this VPC
+    │
+VXLAN (nkx-{hash})      encapsulates in UDP:4789
+    │
+    ▼ ────────────── underlay ─────────────
+nauka0 (WireGuard)       encrypts, sends to remote node
+    │
+internet
+```
+
+## VPC isolation
+
+Each VPC gets a unique VXLAN Network Identifier (VNI). VNIs start at 100 and are auto-assigned. Frames with different VNIs never mix — this is the isolation boundary.
+
+```
+VPC prod-net (VNI 100)  →  bridge nkb-fa3639
+VPC staging-net (VNI 101)  →  bridge nkb-abc123  (separate bridge, no crosstalk)
+```
+
+Two VMs in different VPCs cannot communicate unless the VPCs are peered.
+
+## Subnets
+
+A subnet is an IP range within a VPC. Subnets are **cross-zone** — a VM in any availability zone can use any subnet (like GCP, unlike AWS where subnets are zone-scoped).
+
+Multiple subnets in the same VPC share the same bridge. The bridge carries the gateway IPs for all subnets, acting as an inter-subnet router:
+
+```
+bridge nkb-fa3639:
+  10.0.1.1/24  ← gateway for subnet "web"
+  10.0.2.1/24  ← gateway for subnet "api"
+
+VM in web (10.0.1.2) can reach VM in api (10.0.2.2) via the bridge
+```
+
+## IPAM
+
+When a VM is created, IPAM automatically assigns the next available IP from the subnet:
+
+- `.0` = network address (reserved)
+- `.1` = gateway (reserved, assigned to the bridge)
+- `.2` = first VM
+- `.3` = second VM
+- `.254` = last address in a /24
+
+IPs are released when VMs are deleted and reused by new VMs.
+
+## Container networking
+
+Each container gets a **veth pair** connecting it to the VPC bridge:
+
+```
+Container netns              Host
+  eth0 (veth guest)  ←→  nkh-{hash} (veth host) → bridge → VXLAN
+```
+
+The Forge sets up networking after starting the container:
+1. Creates veth pair (`nkh-`/`nkg-`)
+2. Attaches host side to VPC bridge
+3. Moves guest side into container's network namespace
+4. Renames to `eth0`, sets MAC (deterministic from IP)
+5. Configures IP address + default route
+
+<Aside type="note">
+KVM VMs (Cloud Hypervisor) use TAP interfaces instead of veth pairs. The TAP is passed directly to the VMM as a network backend.
+</Aside>
+
+## FDB distribution
+
+VXLAN uses **static FDB** (no flood-and-learn). The Forge populates FDB entries for remote VMs so the bridge knows where to send frames:
+
+```
+bridge fdb replace 02:00:0a:00:01:03 dev nkx-{hash} dst {remote_mesh_ipv6} self permanent
+```
+
+This tells the VXLAN: "frames destined for MAC `02:00:0a:00:01:03` should be sent via the tunnel to the remote node at `{mesh_ipv6}`."
+
+ARP proxy entries are injected into each container so they know the MAC of remote VMs without broadcasting:
+
+```
+ip neigh replace 10.0.1.3 lladdr 02:00:0a:00:01:03 dev eth0 nud permanent
+```
+
+## MAC derivation
+
+MAC addresses are derived deterministically from IP addresses:
+
+```
+IP: 10.0.1.2  →  MAC: 02:00:0a:00:01:02
+IP: 10.0.1.3  →  MAC: 02:00:0a:00:01:03
+```
+
+Format: `02:00:{IP octets in hex}`. The `02` prefix marks it as a locally administered unicast MAC. No MAC allocation service needed.
+
+## Packet path (cross-node)
+
+When `web-nbg` (10.0.1.2, Nuremberg) pings `web-hel` (10.0.1.4, Helsinki):
+
+```
+1. Container sends ICMP to 10.0.1.4
+2. ARP table says: 10.0.1.4 → MAC 02:00:0a:00:01:04
+3. Frame exits via eth0 (veth guest)
+4. Frame arrives on nkh-{hash} (veth host), enters bridge
+5. Bridge FDB says: MAC 02:00:0a:00:01:04 → via VXLAN to fd...:7a6b
+6. VXLAN encapsulates the frame in UDP:4789
+7. WireGuard encrypts and sends to Helsinki via internet
+8. Helsinki WireGuard decrypts
+9. VXLAN decapsulates
+10. Bridge forwards to container via veth
+11. Container receives the ping reply
+```
+
+Measured latency:
+- Nuremberg ↔ Falkenstein: **~3ms**
+- Nuremberg ↔ Helsinki: **~24ms**
+- Falkenstein ↔ Helsinki: **~25ms**
+
+## Interface naming
+
+Linux limits interface names to 15 characters. Nauka uses hash-based names:
+
+| Prefix | Type | Example |
+|---|---|---|
+| `nkb-` | Bridge (one per VPC) | `nkb-fa3639` |
+| `nkx-` | VXLAN (one per VPC) | `nkx-fa3639` |
+| `nkh-` | Veth host side (one per container) | `nkh-f00e45` |
+| `nkg-` | Veth guest side (renamed to eth0) | `nkg-f00e45` |
+| `nkt-` | TAP (one per KVM VM) | `nkt-97a963` |
+
+The hash is derived from the VPC ID (for bridges/VXLAN) or VM ID (for veth/TAP), ensuring the same resource always gets the same interface name.
+
+## VPC peering
+
+Two VPCs can be peered to allow their VMs to communicate. Requirements:
+- CIDRs must not overlap
+- Cannot peer a VPC with itself
+- Only one peering per VPC pair
+
+```bash
+nauka vpc peering create --vpc prod-net --peer-vpc partner-net
+```
+
+## Design decisions
+
+**Why no explicit NIC resource?** — Following the GCP model: the network interface is implicit, created automatically with the VM. Simpler for operators. If multi-NIC support is needed later, a NIC resource can be extracted.
+
+**Why static FDB, not flood-and-learn?** — The control plane knows where every VM is (TiKV + Forge). Static entries avoid broadcast storms on the VXLAN and make the network deterministic.
+
+**Why deterministic MACs?** — Derived from IP, so no MAC allocation service needed. Every node can compute the MAC for any VM independently.
+
+**Why cross-zone subnets (GCP model)?** — The WireGuard mesh is a flat full-mesh. Zone boundaries are metadata for the scheduler, not network boundaries. A subnet that spans zones is simpler and matches the overlay topology.


### PR DESCRIPTION
Adds two top-level documentation pages:

- **Architecture** — layer stack, resource model, desired vs actual state, dual runtime, ID/naming conventions
- **Networking** — underlay vs overlay, VPC isolation, subnets, IPAM, container networking (veth pairs), FDB distribution, MAC derivation, full packet path with measured latencies, interface naming, design decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)