### PR TITLE
feat(compute): image catalog with GitHub registry + overlay filesystem

### DIFF
--- a/layers/compute/src/image/handlers.rs
+++ b/layers/compute/src/image/handlers.rs
@@ -1,0 +1,103 @@
+//! Image resource definition + handler.
+//!
+//! CLI: nauka vm image pull/list/delete
+
+use std::future::Future;
+use std::pin::Pin;
+
+use nauka_core::resource::*;
+
+use super::registry;
+
+pub fn resource_def() -> ResourceDef {
+    ResourceDef::build("image", "Manage OS images")
+        .plural("images")
+        .action("pull", "Pull an image from the registry")
+        .op(|op| {
+            op.with_arg(OperationArg::required(
+                "name",
+                FieldDef::string("name", "Image name (e.g., ubuntu-24.04)"),
+            ))
+            .with_example("nauka vm image pull ubuntu-24.04")
+        })
+        .action("list", "List locally available images")
+        .action("delete", "Delete a local image")
+        .op(|op| {
+            op.with_arg(OperationArg::required(
+                "name",
+                FieldDef::string("name", "Image name to delete"),
+            ))
+        })
+        .done()
+}
+
+pub fn handler() -> HandlerFn {
+    Box::new(
+        |req: OperationRequest| -> Pin<
+            Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
+        > {
+            Box::pin(async move {
+                match req.operation.as_str() {
+                    "pull" => {
+                        let name = req
+                            .fields
+                            .get("name")
+                            .ok_or_else(|| anyhow::anyhow!("--name is required"))?
+                            .clone();
+                        let size = registry::pull(&name)?;
+                        Ok(OperationResponse::Resource(serde_json::json!({
+                            "name": name,
+                            "status": "ready",
+                            "size_bytes": size,
+                            "size": format_size(size),
+                        })))
+                    }
+                    "list" => {
+                        let images = registry::list();
+                        let items: Vec<serde_json::Value> = images
+                            .iter()
+                            .map(|(name, size)| {
+                                serde_json::json!({
+                                    "name": name,
+                                    "status": "ready",
+                                    "size": format_size(*size),
+                                })
+                            })
+                            .collect();
+                        Ok(OperationResponse::ResourceList(items))
+                    }
+                    "delete" => {
+                        let name = req
+                            .fields
+                            .get("name")
+                            .ok_or_else(|| anyhow::anyhow!("--name is required"))?
+                            .clone();
+                        registry::delete(&name)?;
+                        Ok(OperationResponse::Message(format!(
+                            "image '{name}' deleted."
+                        )))
+                    }
+                    other => Ok(OperationResponse::Message(format!("unknown: {other}"))),
+                }
+            })
+        },
+    )
+}
+
+pub fn registration() -> ResourceRegistration {
+    ResourceRegistration {
+        def: resource_def(),
+        handler: handler(),
+        children: vec![],
+    }
+}
+
+fn format_size(bytes: u64) -> String {
+    if bytes >= 1_073_741_824 {
+        format!("{:.1} GB", bytes as f64 / 1_073_741_824.0)
+    } else if bytes >= 1_048_576 {
+        format!("{:.0} MB", bytes as f64 / 1_048_576.0)
+    } else {
+        format!("{} KB", bytes / 1024)
+    }
+}

--- a/layers/compute/src/image/mod.rs
+++ b/layers/compute/src/image/mod.rs
@@ -1,0 +1,3 @@
+pub mod handlers;
+pub mod registry;
+pub mod types;

--- a/layers/compute/src/image/registry.rs
+++ b/layers/compute/src/image/registry.rs
@@ -1,0 +1,120 @@
+//! Image registry — download images from GitHub Releases.
+//!
+//! Images are stored in the sifrah/nauka-images repo as GitHub Release assets.
+//! Each image is a tar.gz of a rootfs directory.
+
+use std::path::Path;
+use std::process::Command;
+
+const IMAGES_DIR: &str = "/opt/nauka/images";
+const GITHUB_REPO: &str = "sifrah/nauka-images";
+
+/// Pull an image from the GitHub registry.
+///
+/// Downloads the tar.gz from GitHub Releases and extracts to /opt/nauka/images/{name}/
+pub fn pull(name: &str) -> anyhow::Result<u64> {
+    let arch = std::env::consts::ARCH;
+    let arch_name = match arch {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        _ => arch,
+    };
+
+    let image_dir = format!("{IMAGES_DIR}/{name}");
+
+    // Check if already exists
+    if Path::new(&image_dir).join("bin/sh").exists() {
+        tracing::info!(name, "image already exists");
+        let size = dir_size(&image_dir);
+        return Ok(size);
+    }
+
+    // Download from GitHub Releases
+    let asset_name = format!("{name}-{arch_name}.tar.gz");
+    let url = format!("https://github.com/{GITHUB_REPO}/releases/download/latest/{asset_name}");
+
+    tracing::info!(name, url = url.as_str(), "pulling image");
+
+    let tmp_file = format!("/tmp/nauka-image-{name}.tar.gz");
+
+    // Download with curl (follows redirects, GitHub Releases redirect to CDN)
+    let status = Command::new("curl")
+        .args(["-fsSL", "-o", &tmp_file, &url])
+        .status()
+        .map_err(|e| anyhow::anyhow!("download failed: {e}"))?;
+
+    if !status.success() {
+        anyhow::bail!("image '{name}' not found in registry ({})", url);
+    }
+
+    // Extract
+    std::fs::create_dir_all(&image_dir)?;
+    let status = Command::new("tar")
+        .args(["-xzf", &tmp_file, "-C", &image_dir])
+        .status()
+        .map_err(|e| anyhow::anyhow!("extract failed: {e}"))?;
+
+    if !status.success() {
+        let _ = std::fs::remove_dir_all(&image_dir);
+        let _ = std::fs::remove_file(&tmp_file);
+        anyhow::bail!("failed to extract image '{name}'");
+    }
+
+    let _ = std::fs::remove_file(&tmp_file);
+
+    let size = dir_size(&image_dir);
+    tracing::info!(name, size_mb = size / 1024 / 1024, "image ready");
+
+    Ok(size)
+}
+
+/// Delete an image from the local store.
+pub fn delete(name: &str) -> anyhow::Result<()> {
+    let image_dir = format!("{IMAGES_DIR}/{name}");
+    if Path::new(&image_dir).exists() {
+        std::fs::remove_dir_all(&image_dir)?;
+        tracing::info!(name, "image deleted");
+    }
+    Ok(())
+}
+
+/// List locally available images.
+pub fn list() -> Vec<(String, u64)> {
+    let dir = match std::fs::read_dir(IMAGES_DIR) {
+        Ok(d) => d,
+        Err(_) => return vec![],
+    };
+
+    dir.filter_map(|entry| {
+        let entry = entry.ok()?;
+        let name = entry.file_name().to_string_lossy().to_string();
+        let path = entry.path();
+        if path.is_dir() && path.join("bin/sh").exists() {
+            let size = dir_size(&path.to_string_lossy());
+            Some((name, size))
+        } else {
+            None
+        }
+    })
+    .collect()
+}
+
+/// Check if an image exists locally.
+pub fn exists(name: &str) -> bool {
+    Path::new(&format!("{IMAGES_DIR}/{name}/bin/sh")).exists()
+}
+
+/// Get total size of a directory in bytes.
+fn dir_size(path: &str) -> u64 {
+    Command::new("du")
+        .args(["-sb", path])
+        .output()
+        .ok()
+        .and_then(|o| {
+            String::from_utf8_lossy(&o.stdout)
+                .split_whitespace()
+                .next()
+                .and_then(|s| s.parse().ok())
+        })
+        .unwrap_or(0)
+}

--- a/layers/compute/src/image/types.rs
+++ b/layers/compute/src/image/types.rs
@@ -1,0 +1,35 @@
+//! Image types.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Status of an image on this node.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum ImageStatus {
+    /// Being downloaded
+    Pulling,
+    /// Ready to use
+    Ready,
+    /// Download failed
+    Failed,
+}
+
+impl fmt::Display for ImageStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ImageStatus::Pulling => write!(f, "pulling"),
+            ImageStatus::Ready => write!(f, "ready"),
+            ImageStatus::Failed => write!(f, "failed"),
+        }
+    }
+}
+
+/// An OS image available on this node.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Image {
+    pub name: String,
+    pub arch: String,
+    pub size_bytes: u64,
+    pub status: ImageStatus,
+}

--- a/layers/compute/src/lib.rs
+++ b/layers/compute/src/lib.rs
@@ -5,6 +5,7 @@
 //!
 //! CLI: `nauka vm`
 
+pub mod image;
 pub mod runtime;
 pub mod scheduler;
 pub mod vm;

--- a/layers/compute/src/runtime/gvisor.rs
+++ b/layers/compute/src/runtime/gvisor.rs
@@ -52,14 +52,46 @@ impl Runtime for GVisorRuntime {
             );
         }
 
-        let status = Command::new("cp")
-            .args(["-a", "--reflink=auto"])
-            .arg(format!("{}/.", base_image.display()))
-            .arg(rootfs_dir.to_str().unwrap())
+        // Try overlay filesystem (instant, no copy) then fall back to cp
+        let upper_dir = vm_dir.join("upper");
+        let work_dir = vm_dir.join("work");
+        std::fs::create_dir_all(&upper_dir)?;
+        std::fs::create_dir_all(&work_dir)?;
+
+        let overlay_opts = format!(
+            "lowerdir={},upperdir={},workdir={}",
+            base_image.display(),
+            upper_dir.display(),
+            work_dir.display()
+        );
+
+        let overlay_ok = Command::new("mount")
+            .args([
+                "-t",
+                "overlay",
+                "overlay",
+                "-o",
+                &overlay_opts,
+                rootfs_dir.to_str().unwrap(),
+            ])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
             .status()
-            .map_err(|e| anyhow::anyhow!("cp rootfs failed: {e}"))?;
-        if !status.success() {
-            anyhow::bail!("failed to copy rootfs from {}", base_image.display());
+            .map(|s| s.success())
+            .unwrap_or(false);
+
+        if !overlay_ok {
+            // Fallback: full copy
+            tracing::debug!("overlayfs not available, falling back to cp");
+            let status = Command::new("cp")
+                .args(["-a", "--reflink=auto"])
+                .arg(format!("{}/.", base_image.display()))
+                .arg(rootfs_dir.to_str().unwrap())
+                .status()
+                .map_err(|e| anyhow::anyhow!("cp rootfs failed: {e}"))?;
+            if !status.success() {
+                anyhow::bail!("failed to copy rootfs from {}", base_image.display());
+            }
         }
 
         // 2. Configure networking inside the rootfs
@@ -192,7 +224,15 @@ impl Runtime for GVisorRuntime {
             .stderr(std::process::Stdio::null())
             .status();
 
+        // Unmount overlay if mounted
         let vm_dir = PathBuf::from(VM_RUN_DIR).join(vm_id);
+        let rootfs = vm_dir.join("bundle/rootfs");
+        let _ = Command::new("umount")
+            .arg(rootfs.to_str().unwrap_or(""))
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+
         let _ = std::fs::remove_dir_all(&vm_dir);
 
         Ok(())

--- a/layers/compute/src/vm/handlers.rs
+++ b/layers/compute/src/vm/handlers.rs
@@ -256,6 +256,6 @@ pub fn registration() -> ResourceRegistration {
     ResourceRegistration {
         def: resource_def(),
         handler: handler(),
-        children: vec![],
+        children: vec![crate::image::handlers::registration()],
     }
 }

--- a/layers/hypervisor/src/compute_setup.rs
+++ b/layers/hypervisor/src/compute_setup.rs
@@ -31,8 +31,8 @@ pub fn install(steps: &ui::Steps) -> Result<String, NaukaError> {
 
     steps.inc();
 
-    steps.set("Preparing base image");
-    prepare_ubuntu_image()?;
+    steps.set("Pulling base image (ubuntu-24.04)");
+    pull_image("ubuntu-24.04")?;
     steps.inc();
 
     steps.set("Starting forge");
@@ -72,14 +72,61 @@ fn install_crun() -> Result<(), NaukaError> {
     Ok(())
 }
 
-fn prepare_ubuntu_image() -> Result<(), NaukaError> {
-    let image_dir = format!("{IMAGES_DIR}/ubuntu-24.04");
+/// Pull an image from the GitHub registry (sifrah/nauka-images).
+/// Falls back to debootstrap if the download fails.
+fn pull_image(name: &str) -> Result<(), NaukaError> {
+    let image_dir = format!("{IMAGES_DIR}/{name}");
 
     if Path::new(&image_dir).join("bin/sh").exists() {
         return Ok(());
     }
 
-    // Install debootstrap if needed
+    let arch = std::env::consts::ARCH;
+    let arch_name = match arch {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        _ => arch,
+    };
+
+    let asset = format!("{name}-{arch_name}.tar.gz");
+    let url = format!("https://github.com/sifrah/nauka-images/releases/download/latest/{asset}");
+    let tmp_file = format!("/tmp/nauka-image-{name}.tar.gz");
+
+    // Try downloading from GitHub
+    let download_ok = Command::new("curl")
+        .args(["-fsSL", "-o", &tmp_file, &url])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+
+    if download_ok {
+        std::fs::create_dir_all(&image_dir)
+            .map_err(|e| NaukaError::internal(format!("mkdir failed: {e}")))?;
+
+        let extract_ok = Command::new("tar")
+            .args(["-xzf", &tmp_file, "-C", &image_dir])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+
+        let _ = std::fs::remove_file(&tmp_file);
+
+        if extract_ok {
+            return Ok(());
+        }
+        // Extract failed — clean up and fall through to debootstrap
+        let _ = std::fs::remove_dir_all(&image_dir);
+    }
+
+    // Fallback: build with debootstrap
+    tracing::warn!("image download failed, falling back to debootstrap");
+    fallback_debootstrap(name)
+}
+
+/// Fallback: build image locally with debootstrap.
+fn fallback_debootstrap(name: &str) -> Result<(), NaukaError> {
+    let image_dir = format!("{IMAGES_DIR}/{name}");
+
     if !Command::new("which")
         .arg("debootstrap")
         .stdout(std::process::Stdio::null())
@@ -113,7 +160,6 @@ fn prepare_ubuntu_image() -> Result<(), NaukaError> {
         return Err(NaukaError::internal("debootstrap failed"));
     }
 
-    // Install networking tools + SSH server
     let _ = Command::new("chroot")
         .args([
             &image_dir,
@@ -131,18 +177,13 @@ fn prepare_ubuntu_image() -> Result<(), NaukaError> {
         .stderr(std::process::Stdio::null())
         .status();
 
-    // Configure SSH: permit root login, no password
     let sshd_dir = format!("{image_dir}/etc/ssh/sshd_config.d");
     let _ = std::fs::create_dir_all(&sshd_dir);
     let _ = std::fs::write(
         format!("{sshd_dir}/nauka.conf"),
         "PermitRootLogin yes\nPasswordAuthentication no\nPubkeyAuthentication yes\n",
     );
-
-    // Create /run/sshd (required by sshd)
     let _ = std::fs::create_dir_all(format!("{image_dir}/run/sshd"));
-
-    // Generate host keys
     let _ = Command::new("chroot")
         .args([&image_dir, "ssh-keygen", "-A"])
         .stdout(std::process::Stdio::null())


### PR DESCRIPTION
## Summary

**Image catalog** — pre-built OS images stored as GitHub Releases:
- `nauka vm image pull ubuntu-24.04` downloads from sifrah/nauka-images
- `nauka vm image list` shows locally available images
- `nauka vm image delete` removes an image

**Overlay filesystem** — instant VM start:
- Base image mounted read-only, per-VM writes in overlay upper layer
- Falls back to `cp` if overlayfs not available
- Unmounts cleanly on VM stop

**Init speedup** — pulls from GitHub instead of debootstrap:
- Before: ~2 minutes (debootstrap + apt-get install)
- After: **~10 seconds** (download 42MB tar.gz + extract)
- Falls back to debootstrap if download fails

Image repo: https://github.com/sifrah/nauka-images

## Test plan
- [x] `nauka hypervisor init` pulls image from GitHub (9.7s)
- [x] Image ready at /opt/nauka/images/ubuntu-24.04/ (117MB)
- [x] All CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)