### PR TITLE
docs: image catalog — pull, cache, overlay, registry

### DIFF
--- a/layers/compute/src/image/overview.mdx
+++ b/layers/compute/src/image/overview.mdx
@@ -1,0 +1,119 @@
+---
+title: Images
+description: Pre-built OS images for VMs — pull from the catalog, cache locally, mount instantly with overlay filesystem.
+sidebar:
+  order: 5
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Images are pre-built OS rootfs tarballs that contain everything a VM needs: the base OS, SSH server, networking tools, and default configuration. When you create a VM, the image is mounted instantly via overlay filesystem — no copying.
+
+## Pulling an image
+
+```bash
+nauka vm image pull ubuntu-24.04
+```
+
+This downloads the image from the [nauka-images](https://github.com/sifrah/nauka-images) GitHub repository (stored as a Release asset) and extracts it to `/opt/nauka/images/ubuntu-24.04/`.
+
+## Listing images
+
+```bash
+nauka vm image list
+```
+
+Shows all images available locally on this node.
+
+## Deleting an image
+
+```bash
+nauka vm image delete ubuntu-24.04
+```
+
+<Aside type="caution">
+Deleting an image that is in use by running VMs will cause issues. Stop and delete the VMs first.
+</Aside>
+
+## How images work
+
+### One pull, many VMs
+
+An image is pulled **once** per node and cached at `/opt/nauka/images/{name}/`. All VMs on that node share the same base image. The pull is skipped if the image already exists locally.
+
+### Overlay filesystem
+
+When a VM starts, the runtime mounts the base image as a read-only lower layer using Linux overlay filesystem:
+
+```
+/opt/nauka/images/ubuntu-24.04/     ← base image (read-only, shared)
+/run/nauka/vms/{vm_id}/upper/       ← VM-specific writes (initially empty)
+/run/nauka/vms/{vm_id}/bundle/rootfs/  ← overlay mount point
+```
+
+- **Read operations** go to the base image (instant, no copy)
+- **Write operations** go to the upper layer (per-VM, isolated)
+- **Startup time** is milliseconds instead of minutes
+
+If overlay filesystem is not available on the kernel, the runtime falls back to a full copy (`cp --reflink=auto`).
+
+### Auto-pull on init
+
+During `nauka hypervisor init`, the `ubuntu-24.04` image is pulled automatically from GitHub. If the download fails (no internet, GitHub down), the init falls back to building the image locally with `debootstrap`.
+
+## Image contents
+
+Each official image includes:
+
+| Package | Purpose |
+|---|---|
+| `openssh-server` | SSH access into the VM |
+| `iproute2` | `ip` command for networking |
+| `iputils-ping` | `ping` for connectivity testing |
+| `net-tools` | `ifconfig`, `netstat` |
+| `ca-certificates` | HTTPS support |
+
+SSH is pre-configured:
+- `PermitRootLogin yes`
+- `PubkeyAuthentication yes`
+- `PasswordAuthentication no`
+- Host keys pre-generated
+
+The host's SSH authorized keys (`/root/.ssh/authorized_keys`) are injected into the VM at startup, so you can SSH in with the same key used to access the hypervisor.
+
+## Image registry
+
+Official images are built by CI in the [sifrah/nauka-images](https://github.com/sifrah/nauka-images) repository:
+
+1. A build script creates the rootfs with `debootstrap`
+2. GitHub Actions packages it as a `.tar.gz`
+3. The tarball is uploaded as a GitHub Release asset
+4. `nauka vm image pull` downloads from the Release
+
+### Adding a new image
+
+To add a new image to the catalog:
+
+```bash
+# In the nauka-images repo
+mkdir images/debian-12
+# Create images/debian-12/build.sh
+
+# Add to the CI matrix in .github/workflows/build.yml
+# Push → CI builds and uploads automatically
+```
+
+### Custom images
+
+Operators can create custom images by:
+
+1. Pulling a base image: `nauka vm image pull ubuntu-24.04`
+2. Modifying the rootfs: add packages, configs, etc.
+3. The modified rootfs at `/opt/nauka/images/my-custom/` is ready to use
+4. Create VMs with `--image my-custom`
+
+## Available images
+
+| Image | Size (compressed) | Size (extracted) | Base |
+|---|---|---|---|
+| `ubuntu-24.04` | 42 MB | 117 MB | Ubuntu 24.04 LTS Noble |

--- a/layers/compute/src/overview.mdx
+++ b/layers/compute/src/overview.mdx
@@ -7,6 +7,12 @@ sidebar:
 
 The compute layer manages virtual machines across hypervisor nodes. A VM is placed in an organization's project and environment, connected to a VPC subnet.
 
+Key components:
+- **VM** — lifecycle management (create, start, stop, delete)
+- **Scheduler** — automatic hypervisor assignment by zone
+- **Runtime** — dual runtime: Cloud Hypervisor (KVM) or crun (container)
+- **Images** — pre-built OS images pulled from a GitHub catalog, cached locally, mounted via overlay filesystem
+
 ## Creating a VM
 
 ```bash


### PR DESCRIPTION
Adds `layers/compute/src/image/overview.mdx` documenting:
- How to pull/list/delete images
- One-pull-many-VMs caching model
- Overlay filesystem (instant startup vs full copy)
- Auto-pull on hypervisor init + debootstrap fallback
- Image contents (SSH, networking tools)
- Image registry (GitHub Releases CI/CD)
- How to add new images or create custom images

Updates compute overview to list all components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)