### PR TITLE
feat(network): hyperscaler-grade host isolation from VPC networks

### DIFF
--- a/layers/forge/src/reconciler/vpc.rs
+++ b/layers/forge/src/reconciler/vpc.rs
@@ -150,6 +150,9 @@ impl super::Reconciler for VpcReconciler {
                     .await
                 {
                     let gw_cidr = format!("{}/24", subnet.gateway);
+                    let table = vni.to_string();
+
+                    // Set gateway IP on the bridge
                     let _ = std::process::Command::new("ip")
                         .args(["addr", "replace", &gw_cidr, "dev", &br])
                         .stdout(std::process::Stdio::null())
@@ -157,7 +160,6 @@ impl super::Reconciler for VpcReconciler {
                         .status();
 
                     // Add subnet route in the VPC's routing table (for policy routing)
-                    let table = vni.to_string();
                     let _ = std::process::Command::new("ip")
                         .args([
                             "route",
@@ -168,6 +170,16 @@ impl super::Reconciler for VpcReconciler {
                             "table",
                             &table,
                         ])
+                        .stdout(std::process::Stdio::null())
+                        .stderr(std::process::Stdio::null())
+                        .status();
+
+                    // HOST ISOLATION: remove the auto-created route from the main
+                    // routing table. The kernel adds a connected route when we set
+                    // the IP, but we only want the route in the VPC's table.
+                    // This prevents the host from reaching VM IPs directly.
+                    let _ = std::process::Command::new("ip")
+                        .args(["route", "del", &subnet.cidr, "dev", &br, "table", "main"])
                         .stdout(std::process::Stdio::null())
                         .stderr(std::process::Stdio::null())
                         .status();

--- a/layers/network/src/vpc/provision.rs
+++ b/layers/network/src/vpc/provision.rs
@@ -165,15 +165,55 @@ pub fn ensure_bridge(vpc_id: &str, vni: u32, local_ipv6: &Ipv6Addr) -> anyhow::R
     run_ip(&["link", "set", &vx, "up"])?;
     run_ip(&["link", "set", &br, "up"])?;
 
+    // 7. Host isolation: block host process from originating traffic to VPC bridges.
+    //    Defense in depth — even if a route exists in main table, nftables blocks it.
+    //    This ensures the hypervisor operator cannot access tenant VM networks.
+    ensure_host_isolation(&br);
+
     tracing::info!(
         vpc_id,
         vrf = vrf.as_str(),
         bridge = br.as_str(),
         vxlan = vx.as_str(),
         vni,
-        "VPC network ready (VRF + bridge + VXLAN)"
+        "VPC network ready (isolated)"
     );
     Ok(())
+}
+
+/// Block host-originated traffic to a VPC bridge via nftables.
+///
+/// Allows forwarded traffic (VM-to-VM via bridge) but blocks traffic
+/// originating from the host itself. This prevents the hypervisor
+/// from accessing tenant networks.
+fn ensure_host_isolation(bridge: &str) {
+    // Create the nauka table if it doesn't exist
+    let _ = Command::new("nft")
+        .args(["add", "table", "inet", "nauka"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+
+    let _ = Command::new("nft")
+        .args([
+            "add",
+            "chain",
+            "inet",
+            "nauka",
+            "output",
+            "{ type filter hook output priority 0; }",
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+
+    // Block host → VPC bridge traffic (but allow bridge forwarding for VM-to-VM)
+    let rule = format!("oifname {bridge} drop");
+    let _ = Command::new("nft")
+        .args(["add", "rule", "inet", "nauka", "output", &rule])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
 }
 
 /// Ensure VPC peering route leak between two VRFs.


### PR DESCRIPTION
## Summary

The hypervisor host can no longer access tenant VM networks. Two layers:

**1. Routing isolation**
```
ip route del {subnet_cidr} dev nkb-{hash} table main
```
The subnet route only exists in the VPC's policy routing table. The host's main routing table has no path to VM IPs.

**2. nftables defense in depth**
```
nft add rule inet nauka output oifname nkb-{hash} drop
```
Even if a route somehow exists, nftables blocks host-originated traffic to VPC bridges. VM-to-VM forwarding (bridge) is unaffected.

**Result:**
```
From host:  ssh root@10.0.1.2 → "No route to host" ✗
From VM:    ping 10.0.1.3 → works ✓ (via bridge forwarding)
```

Matches AWS/GCP model: hypervisor cannot access tenant networks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)