### PR TITLE
docs: Chaos Monkey layers 2-5 — 40 tests (50 total)

### DIFF
--- a/docs/src/content/docs/chaos-monkey/layer-1-fabric.mdx
+++ b/docs/src/content/docs/chaos-monkey/layer-1-fabric.mdx
@@ -18,10 +18,10 @@ Provision a 3-node cluster:
 nauka hypervisor init --name node-nbg --region eu --zone nbg1 ...
 
 # Node 2 (fsn1)
-nauka hypervisor join --target {node1_ip} --pin {pin} --name node-fsn --region eu --zone fsn1
+nauka hypervisor join --target NODE1_IP --pin PIN --name node-fsn --region eu --zone fsn1
 
 # Node 3 (hel1)
-nauka hypervisor join --target {node1_ip} --pin {pin} --name node-hel --region eu --zone hel1
+nauka hypervisor join --target NODE1_IP --pin PIN --name node-hel --region eu --zone hel1
 
 # Create VMs
 nauka org create acme && nauka vpc create net --org acme --cidr 10.0.0.0/16
@@ -56,7 +56,7 @@ ip link set nauka0 down
 ### Expected failure
 
 - Node-nbg loses connectivity to all other nodes
-- `ping6 {peer_mesh_ipv6}` fails from node-nbg
+- `ping6 PEER_MESH_IPV6` fails from node-nbg
 - TiKV on node-nbg loses contact with PD leader
 - VMs on node-nbg cannot reach VMs on other nodes (VXLAN tunnel broken)
 - VMs on node-fsn and node-hel **continue to communicate** with each other (mesh is full-mesh, not hub-and-spoke)
@@ -86,9 +86,9 @@ ip link set nauka0 up
 
 ```bash
 # From node-nbg:
-ping6 -c 1 {node_fsn_mesh_ipv6}              # mesh recovered
+ping6 -c 1 NODE_FSN_MESH_IPV6              # mesh recovered
 nauka org list                                 # TiKV works
-nsenter --net --target={pid} ping 10.0.1.3    # cross-node ping recovered
+nsenter --net --target=PID ping 10.0.1.3    # cross-node ping recovered
 ```
 
 ---
@@ -183,7 +183,7 @@ systemctl start nauka-announce
 
 ```bash
 # On node-nbg, remove node-fsn as a peer:
-wg set nauka0 peer {node_fsn_public_key} remove
+wg set nauka0 peer NODE_FSN_PUBKEY remove
 ```
 
 ### Expected failure
@@ -250,7 +250,7 @@ nauka hypervisor leave --yes
 nauka hypervisor peering
 
 # Re-join:
-nauka hypervisor join --target {host_ip} --pin {pin} ...
+nauka hypervisor join --target {host_ip} --pin PIN ...
 ```
 
 ### Expected recovery
@@ -318,8 +318,8 @@ Automatic:
 
 ```bash
 # On node-nbg, block all traffic from node-fsn:
-iptables -A INPUT -s {node_fsn_public_ip} -j DROP
-iptables -A OUTPUT -d {node_fsn_public_ip} -j DROP
+iptables -A INPUT -s NODE_FSN_PUBLIC_IP -j DROP
+iptables -A OUTPUT -d NODE_FSN_PUBLIC_IP -j DROP
 ```
 
 ### Expected failure
@@ -338,8 +338,8 @@ iptables -A OUTPUT -d {node_fsn_public_ip} -j DROP
 ### Recovery
 
 ```bash
-iptables -D INPUT -s {node_fsn_public_ip} -j DROP
-iptables -D OUTPUT -d {node_fsn_public_ip} -j DROP
+iptables -D INPUT -s NODE_FSN_PUBLIC_IP -j DROP
+iptables -D OUTPUT -d NODE_FSN_PUBLIC_IP -j DROP
 ```
 
 ### Expected recovery
@@ -386,7 +386,7 @@ echo '{"corrupted": true}' > ~/.nauka/hypervisor.json
 ```bash
 # Option 1: Re-join the cluster (if another node is available)
 nauka hypervisor leave --yes
-nauka hypervisor join --target {peer_ip} --pin {pin} ...
+nauka hypervisor join --target {peer_ip} --pin PIN ...
 
 # Option 2: Restore from backup (if you have one)
 cp ~/.nauka/hypervisor.json.bak ~/.nauka/hypervisor.json

--- a/docs/src/content/docs/chaos-monkey/layer-2-state.mdx
+++ b/docs/src/content/docs/chaos-monkey/layer-2-state.mdx
@@ -1,0 +1,465 @@
+---
+title: "Layer 2: State"
+description: Chaos tests for TiKV/PD — the distributed state store that holds all cluster data.
+sidebar:
+  order: 3
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+TiKV is the distributed key-value store that holds all Nauka state: organizations, VPCs, VMs, IPAM allocations, peerings. PD (Placement Driver) manages consensus via Raft. If the state store breaks, the control plane is blind — but existing VMs keep running.
+
+## Setup
+
+Same as Layer 1: 3-node cluster with VMs, verified baseline.
+
+---
+
+## CM-011: Kill TiKV on one node (quorum maintained)
+
+| | |
+|---|---|
+| **Severity** | Medium |
+| **Action** | Stop TiKV on one node while 2 others are healthy |
+| **Blast radius** | One storage replica lost, cluster continues with 2/3 quorum |
+
+### Break
+
+```bash
+# On node-nbg:
+systemctl stop nauka-tikv
+```
+
+### Expected failure
+
+- TiKV on node-nbg stops responding
+- PD detects the store as "Disconnected" within 30 seconds
+
+### Expected resilience
+
+- **All reads and writes continue** — Raft quorum is 2/3, still met
+- `nauka org list`, `nauka vm create` work normally from any node
+- VMs on node-nbg keep running (they don't depend on local TiKV)
+- Cross-node networking unaffected (VXLAN is in the kernel, not TiKV)
+
+### Recovery
+
+```bash
+systemctl start nauka-tikv
+```
+
+### Expected recovery
+
+- TiKV rejoins the cluster, syncs missed writes from Raft log
+- PD marks the store as "Up" within 30 seconds
+- Recovery time: **10-30 seconds**
+
+---
+
+## CM-012: Kill PD leader
+
+| | |
+|---|---|
+| **Severity** | High |
+| **Action** | Stop PD on the node that is currently the Raft leader |
+| **Blast radius** | Brief write unavailability during leader election |
+
+### Break
+
+```bash
+# Find the PD leader:
+curl -s http://[MESH_IPV6]:2379/pd/api/v1/leader | python3 -c "import sys,json; print(json.load(sys.stdin)['name'])"
+
+# Kill PD on that node:
+systemctl stop nauka-pd
+```
+
+### Expected failure
+
+- PD leader is gone — remaining PD members start election
+- Writes may fail for 1-2 seconds during election
+- `nauka org create` may return "Leader not found" briefly
+
+### Expected resilience
+
+- Election completes within 2 seconds (Raft election timeout)
+- After new leader elected, all operations resume
+- TiKV continues serving reads during election
+- VMs and networking unaffected
+
+### Recovery
+
+```bash
+systemctl start nauka-pd
+```
+
+### Expected recovery
+
+- PD rejoins as follower, syncs from new leader
+- Recovery time: **2-5 seconds** (election) + **10 seconds** (rejoin)
+
+---
+
+## CM-013: Kill TiKV on 2 nodes (quorum lost)
+
+| | |
+|---|---|
+| **Severity** | Critical |
+| **Action** | Stop TiKV on 2 out of 3 nodes |
+| **Blast radius** | Raft quorum lost — all writes fail cluster-wide |
+
+### Break
+
+```bash
+# On node-nbg AND node-fsn:
+systemctl stop nauka-tikv
+```
+
+### Expected failure
+
+- Only 1/3 TiKV nodes alive — **quorum lost**
+- All writes fail: `nauka org create` → "Leader not found"
+- All reads may fail or return stale data
+- `nauka vm create` fails (can't write to TiKV)
+
+### Expected resilience
+
+- **VMs keep running** — containers are kernel state, not TiKV state
+- **Networking keeps working** — bridges, VXLAN, FDB are kernel state
+- The Forge on node-hel continues reconciling local resources
+- WireGuard mesh fully operational
+
+### Recovery
+
+```bash
+# On both nodes:
+systemctl start nauka-tikv
+```
+
+### Expected recovery
+
+- Quorum restored as soon as 2 nodes are back
+- Missed writes are impossible (they were rejected)
+- Recovery time: **10-30 seconds** per node
+
+<Aside type="caution">
+With `max-replicas=1` (single-node bootstrap), killing the only TiKV means total data loss if the disk is also lost. Always scale to 3 nodes for production.
+</Aside>
+
+---
+
+## CM-014: Kill all PD members simultaneously
+
+| | |
+|---|---|
+| **Severity** | Critical |
+| **Action** | Stop PD on all nodes |
+| **Blast radius** | TiKV has no metadata service — can't find regions/leaders |
+
+### Break
+
+```bash
+# On ALL nodes:
+systemctl stop nauka-pd
+```
+
+### Expected failure
+
+- TiKV can't reach PD — all region operations fail
+- No leader elections, no region splits, no scheduling
+- All Nauka CLI commands that touch TiKV fail
+
+### Expected resilience
+
+- **VMs and networking continue** (kernel state, independent of PD)
+- TiKV data is intact on disk (RocksDB files)
+
+### Recovery
+
+```bash
+# Start PD on all nodes:
+systemctl start nauka-pd
+```
+
+### Expected recovery
+
+- PD members re-form Raft group, elect leader
+- TiKV reconnects, regions find their leaders
+- Recovery time: **10-20 seconds**
+
+---
+
+## CM-015: Corrupt TiKV data directory
+
+| | |
+|---|---|
+| **Severity** | High |
+| **Action** | Delete TiKV data on one node |
+| **Blast radius** | One replica's data lost, Raft replicates from others |
+
+### Break
+
+```bash
+# On node-nbg:
+systemctl stop nauka-tikv
+rm -rf /var/lib/nauka/tikv
+systemctl start nauka-tikv
+```
+
+### Expected failure
+
+- TiKV on node-nbg starts with empty data
+- PD detects a new empty store
+- Raft begins replicating data from the other 2 nodes
+
+### Expected resilience
+
+- Cluster continues operating (2/3 replicas still have all data)
+- Reads and writes work normally during re-replication
+
+### Recovery
+
+Automatic — Raft replication restores the missing data.
+
+### Expected recovery
+
+- Small dataset (< 100 MB): **seconds**
+- Large dataset: proportional to data size
+
+---
+
+## CM-016: Delete PD data directory
+
+| | |
+|---|---|
+| **Severity** | High |
+| **Action** | Delete PD metadata on one node |
+| **Blast radius** | One PD member loses its Raft log and state |
+
+### Break
+
+```bash
+# On node-nbg (non-leader):
+systemctl stop nauka-pd
+rm -rf /var/lib/nauka/pd
+systemctl start nauka-pd
+```
+
+### Expected failure
+
+- PD on node-nbg starts fresh, rejoins as empty member
+- PD leader detects a new member, adds it to the Raft group
+
+### Expected resilience
+
+- Other PD members have full state
+- Leader continues operating
+
+### Recovery
+
+Automatic — PD member syncs from leader.
+
+### Expected recovery
+
+- Recovery time: **5-10 seconds**
+
+<Aside type="caution">
+Never delete PD data on the leader. Stop PD, wait for a new leader to be elected, then delete and rejoin.
+</Aside>
+
+---
+
+## CM-017: TiKV slow disk simulation
+
+| | |
+|---|---|
+| **Severity** | Medium |
+| **Action** | Throttle I/O on TiKV's data directory |
+| **Blast radius** | Writes slow down, Raft may lag behind |
+
+### Break
+
+```bash
+# Simulate slow disk with cgroup I/O throttle:
+TIKV_PID=$(systemctl show nauka-tikv --property=MainPID --value)
+echo "$TIKV_PID" > /sys/fs/cgroup/system.slice/nauka-tikv.service/cgroup.procs
+echo "8:0 wbps=1048576" > /sys/fs/cgroup/system.slice/nauka-tikv.service/io.max  # 1MB/s write limit
+```
+
+### Expected failure
+
+- TiKV writes slow down dramatically
+- Raft log application lags
+- `nauka vm create` takes seconds instead of milliseconds
+
+### Expected resilience
+
+- Reads still work (from memory/cache)
+- Other nodes compensate (Raft leader may move to a faster node)
+- VMs continue running
+
+### Recovery
+
+```bash
+echo "" > /sys/fs/cgroup/system.slice/nauka-tikv.service/io.max
+```
+
+### Expected recovery
+
+- Immediate — TiKV catches up from Raft log
+- Recovery time: **seconds** (depends on backlog size)
+
+---
+
+## CM-018: Max-replicas mismatch
+
+| | |
+|---|---|
+| **Severity** | Critical |
+| **Action** | Set max-replicas higher than available stores |
+| **Blast radius** | Regions can't form quorum — writes fail |
+
+### Break
+
+```bash
+# On a 2-node cluster, set max-replicas=3:
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"max-replicas": 3}' \
+  http://[MESH_IPV6]:2379/pd/api/v1/config/replicate
+```
+
+### Expected failure
+
+- PD tries to place 3 replicas on 2 stores — impossible
+- New regions can't be fully replicated
+- Some writes may fail
+
+### Expected resilience
+
+- Existing regions with 2 replicas continue working
+- Nauka's `leave_with_mesh` auto-adjusts max-replicas (this is the bug we fixed in PR #21)
+
+### Recovery
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"max-replicas": 2}' \
+  http://[MESH_IPV6]:2379/pd/api/v1/config/replicate
+```
+
+### Expected recovery
+
+- PD stops trying to place impossible replicas
+- Recovery time: **immediate** (next scheduling round)
+
+---
+
+## CM-019: TiKV network partition (store isolated from PD)
+
+| | |
+|---|---|
+| **Severity** | High |
+| **Action** | Block TiKV traffic to PD on one node |
+| **Blast radius** | One store can't heartbeat to PD, marked offline |
+
+### Break
+
+```bash
+# On node-nbg, block PD port:
+iptables -A OUTPUT -p tcp --dport 2379 -j DROP
+```
+
+### Expected failure
+
+- TiKV on node-nbg can't reach PD
+- PD marks this store as "Disconnected" after 30 seconds
+- Regions with leader on this store lose their leader
+
+### Expected resilience
+
+- Other stores have replicas, PD schedules new leaders
+- WireGuard mesh works (different port)
+- VXLAN traffic works (different port)
+
+### Recovery
+
+```bash
+iptables -D OUTPUT -p tcp --dport 2379 -j DROP
+```
+
+### Expected recovery
+
+- TiKV reconnects to PD
+- Store marked "Up", regions rebalance
+- Recovery time: **30 seconds**
+
+---
+
+## CM-020: Concurrent writes during leader failover
+
+| | |
+|---|---|
+| **Severity** | Medium |
+| **Action** | Create VMs rapidly while killing the PD leader |
+| **Blast radius** | Some writes may fail during the 1-2 second election window |
+
+### Break
+
+```bash
+# In parallel:
+# Terminal 1: create VMs in a loop
+for i in $(seq 1 20); do
+  nauka vm create "stress-$i" --org acme --project backend --env prod \
+    --vpc net --subnet web --cpu 1 --memory 1024 --disk 10 --image ubuntu-24.04 &
+done
+
+# Terminal 2: kill PD leader mid-write
+sleep 2
+systemctl stop nauka-pd  # on the leader node
+```
+
+### Expected failure
+
+- Some VM creates fail with "Leader not found"
+- Other VM creates succeed (hit the new leader after election)
+- No duplicate VMs (IPAM allocation is atomic)
+
+### Expected resilience
+
+- VMs that were successfully created are correctly stored
+- IPAM allocations are consistent (no duplicate IPs)
+- The cluster state is not corrupted
+
+### Recovery
+
+```bash
+systemctl start nauka-pd
+# Retry failed VM creates:
+nauka vm create "stress-3" ...  # the ones that failed
+```
+
+### Expected recovery
+
+- PD rejoins, writes resume
+- Recovery time: **2-5 seconds**
+
+---
+
+## Results template
+
+```markdown
+## CM-0XX Results
+
+- **Date**: YYYY-MM-DD
+- **Cluster**: 3 nodes (nbg1, fsn1, hel1)
+- **Nauka version**: v0.x.x
+- **TiKV stores**: [count, statuses]
+- **PD members**: [count, leader]
+- **Action taken**: [exact command]
+- **Failure observed**: [what broke]
+- **Resilience confirmed**: [what kept working]
+- **Recovery method**: [automatic / manual command]
+- **Recovery time**: [measured]
+- **Data integrity**: [verified — no corruption / duplicates]
+- **Pass/Fail**: [did the behavior match expectations?]
+```

--- a/docs/src/content/docs/chaos-monkey/layer-3-network.mdx
+++ b/docs/src/content/docs/chaos-monkey/layer-3-network.mdx
@@ -1,0 +1,413 @@
+---
+title: "Layer 3: Network"
+description: Chaos tests for VPC overlay networking — bridges, VXLAN, FDB, policy routing.
+sidebar:
+  order: 4
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+The network layer creates virtual networks on top of the WireGuard mesh. Each VPC gets a bridge + VXLAN + routing rules. The Forge is responsible for recreating any missing infrastructure.
+
+## Setup
+
+Same as Layer 1: 3-node cluster with VMs, verified cross-node ping before each test.
+
+---
+
+## CM-021: Delete VPC bridge
+
+| | |
+|---|---|
+| **Severity** | High |
+| **Action** | Delete the Linux bridge for a VPC |
+| **Blast radius** | All VMs in that VPC on this node lose connectivity |
+
+### Break
+
+```bash
+ip link del nkb-HASH
+```
+
+### Expected failure
+
+- All veth pairs detach (their master bridge is gone)
+- VMs on this node can't reach each other or remote VMs
+- VXLAN orphaned (no bridge to attach to)
+
+### Expected resilience
+
+- VMs on **other nodes** continue communicating
+- VMs keep running (containers alive, just no network)
+- TiKV unaffected
+
+### Recovery
+
+```bash
+nauka forge reconcile
+```
+
+### Expected recovery
+
+- Forge recreates bridge + reattaches VXLAN + reattaches veths
+- FDB and ARP entries re-populated
+- Recovery time: **< 1 second** (overlay mount, no rootfs copy)
+
+---
+
+## CM-022: Delete VXLAN interface
+
+| | |
+|---|---|
+| **Severity** | High |
+| **Action** | Delete the VXLAN tunnel interface |
+| **Blast radius** | Cross-node traffic stops, local traffic on same bridge continues |
+
+### Break
+
+```bash
+ip link del nkx-HASH
+```
+
+### Expected failure
+
+- Cross-node VM traffic stops (no encapsulation path)
+- VMs on the same node/same bridge can still talk (local bridging)
+- FDB entries still reference the deleted interface
+
+### Expected resilience
+
+- Local VM-to-VM on same node continues
+- TiKV unaffected (uses WireGuard directly, not VXLAN)
+
+### Recovery
+
+```bash
+nauka forge reconcile
+```
+
+### Expected recovery
+
+- Forge recreates VXLAN with same VNI, reattaches to bridge
+- FDB entries re-created
+- Recovery time: **< 1 second**
+
+---
+
+## CM-023: Delete all FDB entries
+
+| | |
+|---|---|
+| **Severity** | Medium |
+| **Action** | Flush FDB entries for the VPC VXLAN |
+| **Blast radius** | Cross-node traffic fails (bridge doesn't know where to send frames) |
+
+### Break
+
+```bash
+bridge fdb flush dev nkx-HASH
+```
+
+### Expected failure
+
+- Cross-node pings fail (unknown destination MAC → frame dropped)
+- Local pings still work (bridge learns local MACs automatically)
+
+### Expected resilience
+
+- VMs continue running
+- Bridge and VXLAN still intact
+- Local connectivity works
+
+### Recovery
+
+```bash
+nauka forge reconcile
+```
+
+### Expected recovery
+
+- Forge re-adds all FDB entries for remote VMs
+- Cross-node pings resume
+- Recovery time: **< 1 second**
+
+---
+
+## CM-024: Delete policy routing rules
+
+| | |
+|---|---|
+| **Severity** | High |
+| **Action** | Remove the ip rules that isolate VPC traffic |
+| **Blast radius** | VPC isolation broken — cross-VPC traffic may be possible |
+
+### Break
+
+```bash
+ip rule del iif nkb-HASH table VNI
+ip rule del oif nkb-HASH table VNI
+```
+
+### Expected failure
+
+- VPC traffic falls through to the main routing table
+- If another VPC has the same CIDR, routing becomes ambiguous
+- Host might be able to reach VM IPs (isolation breach)
+
+### Expected resilience
+
+- VMs continue running
+- Same-VPC traffic continues (bridge still forwards locally)
+
+### Recovery
+
+```bash
+nauka forge reconcile
+```
+
+### Expected recovery
+
+- Forge re-creates ip rules
+- Isolation restored
+- Recovery time: **< 1 second**
+
+---
+
+## CM-025: Delete veth pair for a VM
+
+| | |
+|---|---|
+| **Severity** | Low |
+| **Action** | Delete the host-side veth, disconnecting a single VM |
+| **Blast radius** | One VM loses network, others unaffected |
+
+### Break
+
+```bash
+ip link del nkh-HASH
+# This automatically deletes the guest-side veth (nkg-) too
+```
+
+### Expected failure
+
+- The target VM loses its eth0 interface
+- Pings to/from this VM fail
+- Other VMs on the same bridge are unaffected
+
+### Expected resilience
+
+- The container keeps running (just no network)
+- Other VMs fully operational
+
+### Recovery
+
+```bash
+nauka forge reconcile
+```
+
+### Expected recovery
+
+- Forge creates new veth pair, reattaches to bridge and container netns
+- IP and MAC reconfigured
+- Recovery time: **< 1 second**
+
+---
+
+## CM-026: Corrupt nftables rules
+
+| | |
+|---|---|
+| **Severity** | High |
+| **Action** | Flush the nauka nftables table |
+| **Blast radius** | Host isolation lost — host can reach VM networks |
+
+### Break
+
+```bash
+nft flush table inet nauka
+```
+
+### Expected failure
+
+- Host-to-VM isolation broken
+- Host can now ping VMs directly and SSH into them
+- Security boundary violated
+
+### Expected resilience
+
+- VM-to-VM traffic unaffected
+- Cross-node traffic unaffected
+
+### Recovery
+
+```bash
+nauka forge reconcile
+```
+
+### Expected recovery
+
+- Forge re-adds nftables output drop rules for each bridge
+- Host isolation restored
+- Recovery time: **< 1 second**
+
+---
+
+## CM-027: Delete gateway IP from bridge
+
+| | |
+|---|---|
+| **Severity** | Medium |
+| **Action** | Remove the gateway IP address from the VPC bridge |
+| **Blast radius** | VMs can't reach their gateway — inter-subnet routing breaks |
+
+### Break
+
+```bash
+ip addr del 10.0.1.1/24 dev nkb-HASH
+```
+
+### Expected failure
+
+- VMs in this subnet can't route to other subnets (no gateway)
+- Same-subnet VMs can still talk (direct L2)
+- ARP for the gateway fails
+
+### Expected resilience
+
+- Cross-node same-subnet traffic still works (FDB + VXLAN)
+- VMs on other nodes unaffected
+
+### Recovery
+
+```bash
+nauka forge reconcile
+```
+
+### Expected recovery
+
+- Forge re-adds the gateway IP + route in the VPC routing table
+- Re-deletes the route from the main table (host isolation)
+- Recovery time: **< 1 second**
+
+---
+
+## CM-028: Delete ARP proxy entries inside container
+
+| | |
+|---|---|
+| **Severity** | Low |
+| **Action** | Flush ARP table inside a container |
+| **Blast radius** | Container can't resolve remote VM MACs |
+
+### Break
+
+```bash
+PID=$(crun state VM_ID | python3 -c "import sys,json; print(json.load(sys.stdin)['pid'])")
+nsenter --net --target=$PID ip neigh flush all
+```
+
+### Expected failure
+
+- Container's ARP table is empty
+- Next ping to a remote VM triggers ARP broadcast (which may not be answered without ARP proxy)
+- Cross-node pings fail
+
+### Expected resilience
+
+- Local loopback works
+- The container is otherwise healthy
+
+### Recovery
+
+```bash
+nauka forge reconcile
+```
+
+### Expected recovery
+
+- Forge re-injects static ARP entries into the container
+- Cross-node pings resume
+- Recovery time: **< 1 second**
+
+---
+
+## CM-029: Delete VPC peering routes
+
+| | |
+|---|---|
+| **Severity** | Medium |
+| **Action** | Remove the route leak entries between two peered VPCs |
+| **Blast radius** | Cross-VPC traffic stops |
+
+### Break
+
+```bash
+ip route del PEER_CIDR table VNI
+```
+
+### Expected failure
+
+- VMs in VPC A can't reach VMs in VPC B
+- Within each VPC, traffic continues normally
+
+### Expected resilience
+
+- Each VPC works independently
+- TiKV unaffected
+
+### Recovery
+
+```bash
+nauka forge reconcile
+```
+
+### Expected recovery
+
+- Forge re-reads peerings from TiKV, re-adds routes
+- Recovery time: **< 1 second**
+
+---
+
+## CM-030: Delete all network interfaces simultaneously
+
+| | |
+|---|---|
+| **Severity** | Critical |
+| **Action** | Delete every nauka network interface on a node |
+| **Blast radius** | Complete network destruction on one node |
+
+### Break
+
+```bash
+ip link show | grep -oP 'nk[bxthgv]-[a-f0-9]+' | sort -u | while read iface; do
+  ip link del $iface 2>/dev/null
+done
+```
+
+### Expected failure
+
+- All VMs on this node lose networking
+- No bridges, no VXLAN, no veths
+- Cross-node traffic to this node fails
+
+### Expected resilience
+
+- VMs keep running (containers alive)
+- Other nodes fully operational
+- TiKV continues (WireGuard is separate from nk* interfaces)
+
+### Recovery
+
+```bash
+nauka forge reconcile
+```
+
+### Expected recovery
+
+- Forge recreates everything: VRF/rules → bridge → VXLAN → veths → FDB → ARP → nftables
+- Full network recovery in a single reconcile cycle
+- Recovery time: **< 1 second**
+
+<Aside type="tip">
+This is the ultimate network resilience test. If the Forge can recover from total network destruction in under a second, the overlay networking is truly robust.
+</Aside>

--- a/docs/src/content/docs/chaos-monkey/layer-4-compute.mdx
+++ b/docs/src/content/docs/chaos-monkey/layer-4-compute.mdx
@@ -1,0 +1,407 @@
+---
+title: "Layer 4: Compute"
+description: Chaos tests for containers, overlay filesystem, images, and the OCI runtime.
+sidebar:
+  order: 5
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+The compute layer manages VM containers — rootfs overlay, crun lifecycle, sshd, and the init process. These tests verify that the Forge can recover containers from various failure modes.
+
+---
+
+## CM-031: Kill a container
+
+| | |
+|---|---|
+| **Severity** | Medium |
+| **Action** | Force-kill a running container |
+| **Blast radius** | One VM stops, others unaffected |
+
+### Break
+
+```bash
+crun kill VM_ID SIGKILL
+```
+
+### Expected failure
+
+- Container process dies (PID gone)
+- The VM's veth guest-side disappears (netns destroyed)
+- sshd stops
+
+### Expected resilience
+
+- Other VMs continue running
+- Network interfaces (bridge, VXLAN) remain intact
+- TiKV state still shows the VM as "pending" (Forge will restart it)
+
+### Recovery
+
+```bash
+nauka forge reconcile
+```
+
+### Expected recovery
+
+- Forge detects the container is not running
+- Recreates overlay mount, starts new container, sets up networking, starts sshd
+- Recovery time: **< 1 second**
+
+---
+
+## CM-032: Delete container runtime state
+
+| | |
+|---|---|
+| **Severity** | Medium |
+| **Action** | Delete crun's internal state for a container |
+| **Blast radius** | crun can't manage the container anymore |
+
+### Break
+
+```bash
+rm -rf /run/user/0/crun/VM_ID
+```
+
+### Expected failure
+
+- `crun state VM_ID` returns "not found"
+- `crun exec VM_ID` fails
+- The container process may still be running (orphaned)
+
+### Expected resilience
+
+- Container process continues (Linux doesn't kill it just because crun forgot about it)
+- Other VMs unaffected
+
+### Recovery
+
+```bash
+# Kill orphaned process:
+kill $(cat /run/nauka/vms/VM_ID/pid)
+# Let Forge recreate:
+nauka forge reconcile
+```
+
+### Expected recovery
+
+- Forge detects no running container, recreates it
+- Recovery time: **< 1 second** (after orphan kill)
+
+---
+
+## CM-033: Unmount overlay filesystem
+
+| | |
+|---|---|
+| **Severity** | High |
+| **Action** | Unmount the container's rootfs overlay |
+| **Blast radius** | Container loses its filesystem mid-run |
+
+### Break
+
+```bash
+umount /run/nauka/vms/VM_ID/bundle/rootfs
+```
+
+### Expected failure
+
+- Container may crash (filesystem suddenly empty)
+- Or container continues with stale file handles but new reads fail
+- sshd stops accepting connections
+
+### Expected resilience
+
+- Other VMs unaffected (each has its own overlay mount)
+- Base image intact (read-only lowerdir)
+
+### Recovery
+
+```bash
+crun kill VM_ID SIGKILL 2>/dev/null
+crun delete --force VM_ID 2>/dev/null
+rm -rf /run/nauka/vms/VM_ID
+nauka forge reconcile
+```
+
+### Expected recovery
+
+- Forge remounts overlay from base image, starts fresh container
+- VM data in the upper layer is lost (ephemeral by design)
+- Recovery time: **< 1 second**
+
+---
+
+## CM-034: Delete base image
+
+| | |
+|---|---|
+| **Severity** | High |
+| **Action** | Delete the shared base image |
+| **Blast radius** | Running VMs continue (overlay has cached data), new VMs can't start |
+
+### Break
+
+```bash
+rm -rf /opt/nauka/images/ubuntu-24.04
+```
+
+### Expected failure
+
+- Running VMs **keep working** (overlay upper layer has cached writes, lower layer files are in page cache)
+- New `nauka forge reconcile` for new VMs fails: "image not found"
+- `nauka vm image list` shows no images
+
+### Expected resilience
+
+- Existing containers unaffected (already mounted)
+- TiKV, networking, mesh all fine
+
+### Recovery
+
+```bash
+nauka vm image pull ubuntu-24.04
+nauka forge reconcile
+```
+
+### Expected recovery
+
+- Image re-downloaded from GitHub (42MB, ~10 seconds)
+- New VMs can start again
+- Recovery time: **10 seconds** (download) + **< 1 second** (reconcile)
+
+---
+
+## CM-035: Delete VM runtime directory
+
+| | |
+|---|---|
+| **Severity** | Medium |
+| **Action** | Delete everything in /run/nauka/vms/VM_ID/ |
+| **Blast radius** | PID file, bundle, overlay state all gone |
+
+### Break
+
+```bash
+umount /run/nauka/vms/VM_ID/bundle/rootfs 2>/dev/null
+rm -rf /run/nauka/vms/VM_ID
+```
+
+### Expected failure
+
+- Forge can't find the PID file → thinks the VM is not running
+- Container may still be alive (orphaned)
+
+### Recovery
+
+```bash
+# Kill orphaned container:
+crun delete --force VM_ID 2>/dev/null
+nauka forge reconcile
+```
+
+### Expected recovery
+
+- Full recreation: overlay + container + networking + sshd
+- Recovery time: **< 1 second**
+
+---
+
+## CM-036: Kill sshd inside container
+
+| | |
+|---|---|
+| **Severity** | Low |
+| **Action** | Kill the sshd process inside a container |
+| **Blast radius** | SSH access lost, container still running |
+
+### Break
+
+```bash
+PID=$(crun state VM_ID | python3 -c "import sys,json; print(json.load(sys.stdin)['pid'])")
+nsenter --pid --mount --net --target=$PID kill $(nsenter --pid --mount --target=$PID pgrep sshd)
+```
+
+### Expected failure
+
+- SSH connections to the VM fail
+- Container and networking still functional
+- Pings still work
+
+### Expected resilience
+
+- Container's init process (sleep infinity) keeps running
+- Network interfaces intact
+
+### Recovery
+
+```bash
+nauka forge reconcile
+```
+
+### Expected recovery
+
+- Forge re-runs nsenter to start sshd
+- Recovery time: **< 1 second**
+
+<Aside type="note">
+sshd is not the container's init process — it's started separately via nsenter. If it dies, only SSH access is lost, not the container itself.
+</Aside>
+
+---
+
+## CM-037: Fill the overlay upper layer disk
+
+| | |
+|---|---|
+| **Severity** | Medium |
+| **Action** | Fill /var/lib/nauka/vms/VM_ID/upper/ with data |
+| **Blast radius** | Container can't write new files |
+
+### Break
+
+```bash
+dd if=/dev/zero of=/var/lib/nauka/vms/VM_ID/upper/fill bs=1M count=500
+```
+
+### Expected failure
+
+- Container writes fail with "No space left on device"
+- sshd may stop accepting new connections
+- Existing processes continue (cached in memory)
+
+### Expected resilience
+
+- Other VMs unaffected (separate upper dirs)
+- Base image intact
+
+### Recovery
+
+```bash
+rm /var/lib/nauka/vms/VM_ID/upper/fill
+```
+
+### Expected recovery
+
+- Immediate — filesystem space freed
+- No reconcile needed
+
+---
+
+## CM-038: Corrupt OCI config.json
+
+| | |
+|---|---|
+| **Severity** | Low |
+| **Action** | Overwrite the container's OCI spec |
+| **Blast radius** | Running container unaffected, but recreation would fail |
+
+### Break
+
+```bash
+echo '{}' > /run/nauka/vms/VM_ID/bundle/config.json
+```
+
+### Expected failure
+
+- Running container **continues** (config is only read at create time)
+- If the container is killed and Forge tries to recreate it, `crun create` fails
+
+### Expected resilience
+
+- The Forge regenerates config.json on each reconcile, overwriting the corrupted file
+
+### Recovery
+
+```bash
+nauka forge reconcile
+```
+
+### Expected recovery
+
+- Forge writes a fresh config.json and recreates the container
+- Recovery time: **< 1 second**
+
+---
+
+## CM-039: Kill all containers simultaneously
+
+| | |
+|---|---|
+| **Severity** | High |
+| **Action** | Kill every container on a node |
+| **Blast radius** | All VMs on this node stop |
+
+### Break
+
+```bash
+crun list -f json | python3 -c "import sys,json; [print(c['id']) for c in json.load(sys.stdin)]" | while read id; do
+  crun kill $id SIGKILL
+done
+```
+
+### Expected failure
+
+- All VMs on this node stop
+- All VM veths disappear (netns destroyed)
+- FDB entries become stale (MACs point to dead containers)
+
+### Expected resilience
+
+- VMs on other nodes continue
+- Network infrastructure (bridge, VXLAN) remains
+- TiKV unaffected
+
+### Recovery
+
+```bash
+nauka forge reconcile
+```
+
+### Expected recovery
+
+- Forge recreates all containers in a single cycle
+- Full recovery in **< 1 second** per VM (overlay mount, no copy)
+
+---
+
+## CM-040: Exhaust cgroup memory limit
+
+| | |
+|---|---|
+| **Severity** | Medium |
+| **Action** | Allocate more memory than the container's cgroup limit |
+| **Blast radius** | OOM killer terminates processes inside the container |
+
+### Break
+
+```bash
+PID=$(crun state VM_ID | python3 -c "import sys,json; print(json.load(sys.stdin)['pid'])")
+nsenter --pid --mount --net --target=$PID sh -c "dd if=/dev/zero of=/dev/null bs=1M &"
+# Or: stress-test memory allocation inside the container
+```
+
+### Expected failure
+
+- Linux OOM killer kills processes inside the container
+- sshd or sleep infinity may be killed
+- If init process is killed, container stops
+
+### Expected resilience
+
+- OOM is contained to the cgroup — host and other VMs unaffected
+- cgroup limits prevent one VM from affecting others
+
+### Recovery
+
+```bash
+nauka forge reconcile
+```
+
+### Expected recovery
+
+- If container is dead: Forge recreates it
+- If only sshd was killed: Forge restarts sshd
+- Recovery time: **< 1 second**

--- a/docs/src/content/docs/chaos-monkey/layer-5-forge.mdx
+++ b/docs/src/content/docs/chaos-monkey/layer-5-forge.mdx
@@ -1,0 +1,511 @@
+---
+title: "Layer 5: Forge"
+description: Chaos tests for the reconciler itself — what happens when the thing that fixes things breaks.
+sidebar:
+  order: 6
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+The Forge is the daemon that fixes everything else. These tests verify what happens when the Forge itself fails, and whether the system can survive without it.
+
+---
+
+## CM-041: Kill the Forge process
+
+| | |
+|---|---|
+| **Severity** | Low |
+| **Action** | Stop the Forge systemd service |
+| **Blast radius** | No new reconciliation — but everything currently running continues |
+
+### Break
+
+```bash
+systemctl stop nauka-forge
+```
+
+### Expected failure
+
+- No reconciliation happens
+- New VMs created via `nauka vm create` stay in "pending" forever
+- Deleted bridges/veths/containers are not recreated
+
+### Expected resilience
+
+- **Everything currently running continues** — the Forge is not in the data path
+- VMs keep running, networking keeps working, TiKV keeps working
+- The only thing lost is the ability to converge new changes
+
+### Recovery
+
+```bash
+systemctl start nauka-forge
+```
+
+### Expected recovery
+
+- Forge runs a reconcile cycle immediately
+- All pending VMs are created, missing bridges rebuilt
+- Recovery time: **< 1 second** (reconcile cycle)
+
+<Aside type="note">
+The Forge is a **control plane** component, not a **data plane** component. Killing it doesn't affect running workloads — only the ability to change them.
+</Aside>
+
+---
+
+## CM-042: Forge crash loop
+
+| | |
+|---|---|
+| **Severity** | Medium |
+| **Action** | Cause the Forge to crash on every reconcile cycle |
+| **Blast radius** | Forge enters restart loop, systemd rate-limits restarts |
+
+### Break
+
+```bash
+# Corrupt TiKV to make the Forge crash on connect:
+systemctl stop nauka-tikv
+systemctl start nauka-forge
+# Forge tries to connect to TiKV → fails → crashes → systemd restarts
+```
+
+### Expected failure
+
+- Forge starts, tries to connect to TiKV, fails, exits with error
+- systemd restarts it after 10 seconds (RestartSec=10)
+- After 5 failures, systemd may rate-limit further restarts
+
+### Expected resilience
+
+- VMs keep running (not affected by Forge crashes)
+- CPU usage is minimal (crash + 10s sleep + crash)
+- The system is degraded but not broken
+
+### Recovery
+
+```bash
+systemctl start nauka-tikv
+# Forge will succeed on next restart cycle
+```
+
+### Expected recovery
+
+- Next Forge startup connects to TiKV successfully
+- Reconcile cycle runs normally
+- Recovery time: **10 seconds** (next RestartSec interval)
+
+---
+
+## CM-043: Forge runs with stale state
+
+| | |
+|---|---|
+| **Severity** | Medium |
+| **Action** | Create VMs while the Forge's TiKV connection is partitioned |
+| **Blast radius** | Forge reconciles based on old data, missing new VMs |
+
+### Break
+
+```bash
+# On node-nbg, block TiKV port so Forge can't read:
+iptables -A OUTPUT -p tcp --dport 20160 -j DROP
+# Create new VMs from another node:
+# (on node-fsn): nauka vm create new-vm ...
+# Forge on nbg doesn't see the new VM
+```
+
+### Expected failure
+
+- Forge on node-nbg doesn't know about new VMs assigned to it
+- New VMs are not provisioned on node-nbg
+- Existing VMs continue running (already reconciled)
+
+### Recovery
+
+```bash
+iptables -D OUTPUT -p tcp --dport 20160 -j DROP
+```
+
+### Expected recovery
+
+- Next Forge cycle reads fresh data from TiKV
+- New VMs are provisioned
+- Recovery time: **30 seconds** (next reconcile cycle)
+
+---
+
+## CM-044: Forge reconcile during network destruction
+
+| | |
+|---|---|
+| **Severity** | Medium |
+| **Action** | Delete network interfaces while the Forge is mid-reconcile |
+| **Blast radius** | Race condition — Forge creates interfaces, chaos deletes them |
+
+### Break
+
+```bash
+# In parallel:
+# Terminal 1: run Forge reconcile
+nauka forge reconcile &
+
+# Terminal 2: delete interfaces as they're created
+while true; do
+  ip link show | grep -oP 'nk[bxthg]-[a-f0-9]+' | while read iface; do
+    ip link del $iface 2>/dev/null
+  done
+  sleep 0.1
+done
+```
+
+### Expected failure
+
+- Forge creates an interface, chaos deletes it immediately
+- Forge may report success even though the interface was deleted after creation
+- Cross-node traffic fails intermittently
+
+### Expected resilience
+
+- Forge doesn't crash (all operations handle "interface not found" gracefully)
+- No data corruption (TiKV state is unaffected)
+- Next full reconcile cycle fixes everything
+
+### Recovery
+
+```bash
+# Stop the chaos:
+# Kill Terminal 2
+
+nauka forge reconcile
+```
+
+### Expected recovery
+
+- Full reconcile with no interference succeeds
+- Recovery time: **< 1 second**
+
+---
+
+## CM-045: Delete the Forge systemd unit
+
+| | |
+|---|---|
+| **Severity** | High |
+| **Action** | Remove the Forge service file |
+| **Blast radius** | Forge won't restart after next failure or reboot |
+
+### Break
+
+```bash
+systemctl stop nauka-forge
+rm /etc/systemd/system/nauka-forge.service
+systemctl daemon-reload
+```
+
+### Expected failure
+
+- Forge is stopped and won't auto-restart
+- `systemctl start nauka-forge` → "Unit not found"
+- No reconciliation happens
+
+### Expected resilience
+
+- Everything currently running continues
+- Manual `nauka forge reconcile` still works (the binary exists, just no systemd unit)
+
+### Recovery
+
+```bash
+# Option 1: Re-run compute setup
+nauka hypervisor init  # Would reinstall, but also reinitializes the cluster
+
+# Option 2: Recreate the unit manually
+cat > /etc/systemd/system/nauka-forge.service << 'EOF'
+[Unit]
+Description=Nauka Forge Reconciler
+After=network-online.target nauka-wg.service nauka-tikv.service
+Wants=network-online.target
+Requires=nauka-wg.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/nauka forge run
+Restart=on-failure
+RestartSec=10
+LimitNOFILE=1000000
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl daemon-reload
+systemctl enable --now nauka-forge
+```
+
+### Expected recovery
+
+- Forge service recreated and started
+- Recovery time: **immediate** (manual unit creation)
+
+---
+
+## CM-046: Forge with conflicting concurrent reconciles
+
+| | |
+|---|---|
+| **Severity** | Low |
+| **Action** | Run two Forge reconcile cycles simultaneously |
+| **Blast radius** | Race conditions in container creation or network setup |
+
+### Break
+
+```bash
+nauka forge reconcile &
+nauka forge reconcile &
+wait
+```
+
+### Expected failure
+
+- Two processes try to create the same bridge/container simultaneously
+- One succeeds, the other gets "already exists" errors
+- Possible: duplicate veth pairs or containers
+
+### Expected resilience
+
+- No data corruption (TiKV operations are atomic)
+- The next single reconcile cycle cleans up duplicates
+
+### Recovery
+
+```bash
+nauka forge reconcile  # Single clean cycle
+```
+
+### Expected recovery
+
+- Idempotent operations converge to correct state
+- Recovery time: **< 1 second**
+
+<Aside type="tip">
+In production, the Forge daemon ensures only one reconcile runs at a time (sequential loop). This test validates that even concurrent runs don't cause permanent damage.
+</Aside>
+
+---
+
+## CM-047: Forge with empty TiKV (all data deleted)
+
+| | |
+|---|---|
+| **Severity** | Critical |
+| **Action** | Delete all Nauka keys from TiKV |
+| **Blast radius** | Forge sees no desired state — tries to clean up everything |
+
+### Break
+
+```bash
+# This would require direct TiKV API access to delete all keys
+# Or: recreate TiKV from scratch
+systemctl stop nauka-tikv
+rm -rf /var/lib/nauka/tikv
+systemctl start nauka-tikv
+# TiKV starts empty (if single-node, data is gone)
+```
+
+### Expected failure
+
+- Forge reads empty TiKV: no VMs, no VPCs
+- Forge sees running containers as "orphaned" — kills them all
+- All bridges, VXLANs deleted (no VPCs in desired state)
+- Total infrastructure cleanup
+
+### Expected resilience
+
+- The cleanup is **correct** from the Forge's perspective (no desired state = nothing should exist)
+- WireGuard mesh continues (independent of TiKV data)
+
+### Recovery
+
+```bash
+# Recreate everything:
+nauka org create acme
+nauka vpc create net --org acme --cidr 10.0.0.0/16
+nauka vpc subnet create web --vpc net --org acme --cidr 10.0.1.0/24
+nauka vm create web-1 ... 
+nauka forge reconcile
+```
+
+### Expected recovery
+
+- Full recreation from scratch
+- Recovery time: depends on how much state needs to be recreated
+
+<Aside type="caution">
+This test is destructive. On a 3-node cluster with `max-replicas=3`, deleting TiKV data on one node is recoverable (Raft replicates). Deleting on all nodes is permanent data loss.
+</Aside>
+
+---
+
+## CM-048: Forge PID file becomes stale
+
+| | |
+|---|---|
+| **Severity** | Low |
+| **Action** | Write a fake PID into the VM's PID file |
+| **Blast radius** | Forge thinks the VM is running when it's not |
+
+### Break
+
+```bash
+echo "99999" > /run/nauka/vms/VM_ID/pid
+```
+
+### Expected failure
+
+- Forge checks `kill(99999, 0)` — returns false (no such process)
+- Forge correctly detects the VM is not running
+- Forge recreates the container
+
+### Expected resilience
+
+- The PID check is the source of truth, not the file content
+- If PID 99999 happens to exist, Forge might incorrectly think the VM is running
+
+### Recovery
+
+Automatic — Forge's PID liveness check handles this.
+
+---
+
+## CM-049: Forge with incorrect node identity
+
+| | |
+|---|---|
+| **Severity** | Medium |
+| **Action** | Modify the node name in fabric state |
+| **Blast radius** | Forge can't match VMs to this node |
+
+### Break
+
+```bash
+# Edit hypervisor.json to change the node name
+python3 -c "
+import json
+with open('/root/.nauka/hypervisor.json', 'r+') as f:
+    data = json.load(f)
+    data['fabric/state']['hypervisor']['name'] = 'wrong-name'
+    f.seek(0)
+    json.dump(data, f)
+    f.truncate()
+"
+```
+
+### Expected failure
+
+- Forge reads node name "wrong-name" from state
+- No VMs have `hypervisor_id = "wrong-name"` → Forge sees 0 desired VMs
+- Forge deletes all containers as "orphaned"
+
+### Expected resilience
+
+- The deletion is correct from the Forge's perspective (wrong identity = not my VMs)
+- TiKV data is intact — VMs still exist, just not assigned to "wrong-name"
+
+### Recovery
+
+```bash
+# Fix the name back:
+python3 -c "
+import json
+with open('/root/.nauka/hypervisor.json', 'r+') as f:
+    data = json.load(f)
+    data['fabric/state']['hypervisor']['name'] = 'node-nbg'
+    f.seek(0)
+    json.dump(data, f)
+    f.truncate()
+"
+nauka forge reconcile
+```
+
+### Expected recovery
+
+- Forge matches VMs again, recreates containers
+- Recovery time: **< 1 second**
+
+---
+
+## CM-050: Complete Forge + infrastructure wipe
+
+| | |
+|---|---|
+| **Severity** | Critical |
+| **Action** | Kill everything: Forge, containers, network, overlay mounts |
+| **Blast radius** | Total destruction on one node — only TiKV state and base image remain |
+
+### Break
+
+```bash
+# Kill Forge
+systemctl stop nauka-forge
+
+# Kill all containers
+crun list -f json | python3 -c "import sys,json; [print(c['id']) for c in json.load(sys.stdin)]" | while read id; do
+  crun kill $id SIGKILL 2>/dev/null; sleep 1; crun delete --force $id 2>/dev/null
+done
+
+# Unmount overlays
+for mp in $(mount | grep "nauka/vms" | awk '{print $3}'); do umount -l $mp; done
+
+# Delete all network interfaces
+ip link show | grep -oP 'nk[bxthgv]-[a-f0-9]+' | sort -u | while read iface; do
+  ip link del $iface 2>/dev/null
+done
+
+# Delete runtime state
+rm -rf /run/nauka/vms /var/lib/nauka/vms
+
+# Flush nftables
+nft flush table inet nauka 2>/dev/null
+
+# Delete ip rules
+for rule in $(ip rule show | grep nkb- | awk '{print $NF}'); do
+  ip rule del table $rule 2>/dev/null
+done
+```
+
+### Expected failure
+
+- No containers, no network, no firewall, no overlay mounts
+- Node is a blank slate (only WireGuard + TiKV still running)
+
+### Expected resilience
+
+- TiKV has all desired state intact
+- WireGuard mesh operational
+- Other nodes continue full operation
+- Base image still exists at `/opt/nauka/images/`
+
+### Recovery
+
+```bash
+systemctl start nauka-forge
+# Wait one reconcile cycle (30 seconds)
+```
+
+### Expected recovery
+
+The Forge rebuilds **everything** from scratch:
+1. Reads VMs from TiKV → finds VMs assigned to this node
+2. Creates VRF/rules → bridge → VXLAN for each VPC
+3. Sets gateway IPs, FDB entries, ARP proxies
+4. Mounts overlay → starts containers → configures networking → starts sshd
+5. Adds nftables host isolation rules
+6. Removes host routes from main table
+
+**Total recovery time: < 1 second** (single reconcile cycle with overlay filesystem)
+
+<Aside type="tip">
+This is the ultimate test. If the Forge can recover from total destruction to full operation in under a second, the reconciliation architecture is sound.
+</Aside>

--- a/docs/src/content/docs/chaos-monkey/overview.mdx
+++ b/docs/src/content/docs/chaos-monkey/overview.mdx
@@ -68,10 +68,14 @@ Each test follows the same structure:
 Never run chaos tests on production clusters. Always use dedicated test environments that can be destroyed without consequence.
 </Aside>
 
-## Available test suites
+## Test suites
 
-- [Layer 1: Fabric](/chaos-monkey/layer-1-fabric/) — WireGuard mesh resilience (10 tests)
-- Layer 2: State — TiKV/PD consensus (planned)
-- Layer 3: Network — VPC overlay resilience (planned)
-- Layer 4: Compute — container lifecycle resilience (planned)
-- Layer 5: Forge — reconciler resilience (planned)
+| Layer | Tests | Focus |
+|---|---|---|
+| [Layer 1: Fabric](/chaos-monkey/layer-1-fabric/) | CM-001 → CM-010 | WireGuard mesh, peers, partitions |
+| [Layer 2: State](/chaos-monkey/layer-2-state/) | CM-011 → CM-020 | TiKV/PD consensus, quorum, data integrity |
+| [Layer 3: Network](/chaos-monkey/layer-3-network/) | CM-021 → CM-030 | Bridges, VXLAN, FDB, routing, nftables |
+| [Layer 4: Compute](/chaos-monkey/layer-4-compute/) | CM-031 → CM-040 | Containers, overlay FS, images, sshd |
+| [Layer 5: Forge](/chaos-monkey/layer-5-forge/) | CM-041 → CM-050 | Reconciler crash, race conditions, total wipe |
+
+**50 tests total** covering every failure mode from a single interface down to complete node destruction.


### PR DESCRIPTION
## Summary

Adds 40 chaos tests across 4 layers, completing the 50-test suite:

| Layer | Tests | Highlights |
|---|---|---|
| **State** | CM-011→020 | TiKV kill, PD leader failover, quorum loss, data corruption, concurrent writes |
| **Network** | CM-021→030 | Bridge/VXLAN/FDB deletion, routing corruption, nftables flush, total network wipe |
| **Compute** | CM-031→040 | Container kill, overlay unmount, image deletion, OOM, mass kill |
| **Forge** | CM-041→050 | Crash loop, race conditions, stale state, identity mismatch, total wipe + recovery |

**99 documentation pages** total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)