### PR TITLE
feat: NAT gateway support for VPCs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,6 +1597,7 @@ name = "nauka-network"
 version = "2.0.0"
 dependencies = [
  "anyhow",
+ "hex",
  "ipnet",
  "nauka-core",
  "nauka-hypervisor",
@@ -1604,6 +1605,7 @@ dependencies = [
  "nauka-state",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror 2.0.18",
  "tikv-client",

--- a/layers/compute/src/runtime/gvisor.rs
+++ b/layers/compute/src/runtime/gvisor.rs
@@ -115,9 +115,19 @@ impl Runtime for GVisorRuntime {
                 config.private_ip, config.gateway,
             ),
         )?;
+        // Point DNS to the bridge gateway which runs DNS64 (unbound).
+        // Falls back to 8.8.8.8 if no gateway configured.
+        // Must remove symlink to systemd-resolved first (Ubuntu containers).
+        let dns_server = if config.gateway.is_empty() {
+            "8.8.8.8".to_string()
+        } else {
+            config.gateway.clone()
+        };
+        let resolv_path = rootfs_dir.join("etc/resolv.conf");
+        let _ = std::fs::remove_file(&resolv_path);
         std::fs::write(
-            rootfs_dir.join("etc/resolv.conf"),
-            "nameserver 8.8.8.8\nnameserver 8.8.4.4\n",
+            &resolv_path,
+            format!("nameserver {}\nnameserver 8.8.8.8\n", dns_server),
         )?;
         std::fs::write(rootfs_dir.join("etc/hostname"), &config.vm_name)?;
 
@@ -202,6 +212,7 @@ impl Runtime for GVisorRuntime {
                 &config.private_ip,
                 &config.gateway,
                 &mac,
+                config.vpc_cidr.as_deref(),
             ) {
                 tracing::warn!(
                     vm_id = config.vm_id.as_str(),

--- a/layers/compute/src/runtime/mod.rs
+++ b/layers/compute/src/runtime/mod.rs
@@ -67,4 +67,6 @@ pub struct VmRunConfig {
     pub private_ip: String,
     pub gateway: String,
     pub subnet_cidr: String,
+    /// VPC CIDR — used for DNS64/NAT64 IPv6 addressing. None if no NAT GW.
+    pub vpc_cidr: Option<String>,
 }

--- a/layers/compute/src/vm/provision.rs
+++ b/layers/compute/src/vm/provision.rs
@@ -148,6 +148,7 @@ pub fn setup_container_net(
     ip: &str,
     gateway: &str,
     mac: &str,
+    vpc_cidr: Option<&str>,
 ) -> anyhow::Result<()> {
     let guest = veth_guest_name(vm_id);
     let pid = container_pid.to_string();
@@ -203,6 +204,22 @@ pub fn setup_container_net(
 
     // Default route via gateway
     nsenter(&["ip", "route", "add", "default", "via", gateway])?;
+
+    // IPv6 for DNS64/NAT64: add ULA IPv6 + route for 64:ff9b::/96
+    // The bridge gateway runs a DNS64 resolver (unbound) that synthesizes
+    // AAAA records using 64:ff9b::/96. VMs need IPv6 connectivity to the
+    // bridge to send traffic through Jool NAT64.
+    if let Some(vpc_cidr) = vpc_cidr {
+        let gw_v6 = nauka_network::vpc::natgw::provision::bridge_ipv6_gateway(vpc_cidr);
+        let vm_v6 = nauka_network::vpc::natgw::provision::bridge_ipv6_vm(vpc_cidr, 0);
+        let vm_v6_cidr = format!("{}/64", vm_v6);
+        let gw_v6_str = gw_v6.to_string();
+        nsenter(&["ip", "-6", "addr", "add", &vm_v6_cidr, "dev", "eth0"])?;
+        // Route NAT64 prefix through the bridge gateway
+        nsenter(&["ip", "-6", "route", "add", "64:ff9b::/96", "via", &gw_v6_str])?;
+        // Default IPv6 route for direct IPv6 sites (NAT66 SNAT on host)
+        nsenter(&["ip", "-6", "route", "add", "default", "via", &gw_v6_str])?;
+    }
 
     tracing::info!(vm_id, ip, "container networking ready");
     Ok(())

--- a/layers/compute/src/vm/provision.rs
+++ b/layers/compute/src/vm/provision.rs
@@ -216,7 +216,15 @@ pub fn setup_container_net(
         let gw_v6_str = gw_v6.to_string();
         nsenter(&["ip", "-6", "addr", "add", &vm_v6_cidr, "dev", "eth0"])?;
         // Route NAT64 prefix through the bridge gateway
-        nsenter(&["ip", "-6", "route", "add", "64:ff9b::/96", "via", &gw_v6_str])?;
+        nsenter(&[
+            "ip",
+            "-6",
+            "route",
+            "add",
+            "64:ff9b::/96",
+            "via",
+            &gw_v6_str,
+        ])?;
         // Default IPv6 route for direct IPv6 sites (NAT66 SNAT on host)
         nsenter(&["ip", "-6", "route", "add", "default", "via", &gw_v6_str])?;
     }

--- a/layers/forge/src/reconciler/mod.rs
+++ b/layers/forge/src/reconciler/mod.rs
@@ -3,6 +3,7 @@
 //! Each resource type (VPC, VM) implements `Reconciler`.
 //! The `run_all` function executes them in dependency order.
 
+pub mod natgw;
 pub mod vm;
 pub mod vpc;
 
@@ -24,7 +25,11 @@ pub trait Reconciler: Send + Sync {
 /// then VMs.
 pub async fn run_all(ctx: &ReconcileContext) -> Vec<ReconcileResult> {
     let reconcilers: Vec<Box<dyn Reconciler>> =
-        vec![Box::new(vpc::VpcReconciler), Box::new(vm::VmReconciler)];
+        vec![
+            Box::new(vpc::VpcReconciler),
+            Box::new(natgw::NatGwReconciler),
+            Box::new(vm::VmReconciler),
+        ];
 
     let mut results = Vec::new();
     for r in &reconcilers {

--- a/layers/forge/src/reconciler/mod.rs
+++ b/layers/forge/src/reconciler/mod.rs
@@ -24,12 +24,11 @@ pub trait Reconciler: Send + Sync {
 /// VPCs first (bridges must exist before VMs can attach TAPs),
 /// then VMs.
 pub async fn run_all(ctx: &ReconcileContext) -> Vec<ReconcileResult> {
-    let reconcilers: Vec<Box<dyn Reconciler>> =
-        vec![
-            Box::new(vpc::VpcReconciler),
-            Box::new(natgw::NatGwReconciler),
-            Box::new(vm::VmReconciler),
-        ];
+    let reconcilers: Vec<Box<dyn Reconciler>> = vec![
+        Box::new(vpc::VpcReconciler),
+        Box::new(natgw::NatGwReconciler),
+        Box::new(vm::VmReconciler),
+    ];
 
     let mut results = Vec::new();
     for r in &reconcilers {

--- a/layers/forge/src/reconciler/natgw.rs
+++ b/layers/forge/src/reconciler/natgw.rs
@@ -67,10 +67,9 @@ impl super::Reconciler for NatGwReconciler {
                 }
                 Err(e) => {
                     result.failed += 1;
-                    result.errors.push(format!(
-                        "natgw '{}': {}",
-                        natgw.meta.name, e
-                    ));
+                    result
+                        .errors
+                        .push(format!("natgw '{}': {}", natgw.meta.name, e));
                     tracing::error!(
                         natgw = natgw.meta.name,
                         error = %e,

--- a/layers/forge/src/reconciler/natgw.rs
+++ b/layers/forge/src/reconciler/natgw.rs
@@ -1,0 +1,103 @@
+//! NAT gateway reconciler — ensures Jool NAT64 instances + nftables rules.
+//!
+//! Runs after VPC reconciler (bridges must exist) and before VM reconciler.
+
+use nauka_network::vpc::natgw::provision;
+use nauka_network::vpc::natgw::store::NatGwStore;
+
+use crate::types::{ReconcileContext, ReconcileResult};
+
+pub struct NatGwReconciler;
+
+#[async_trait::async_trait]
+impl super::Reconciler for NatGwReconciler {
+    fn name(&self) -> &str {
+        "natgw"
+    }
+
+    async fn reconcile(&self, ctx: &ReconcileContext) -> anyhow::Result<ReconcileResult> {
+        let mut result = ReconcileResult::new("natgw");
+
+        let store = NatGwStore::new(ctx.db.clone());
+        let all_natgws = store.list(None).await?;
+
+        // Filter NAT gateways assigned to this node
+        let local_natgws: Vec<_> = all_natgws
+            .iter()
+            .filter(|n| ctx.node_ids.iter().any(|nid| nid == &n.hypervisor_id))
+            .collect();
+
+        result.desired = local_natgws.len();
+
+        // Resolve the public interface (interface with default IPv6 route)
+        let public_interface = detect_public_interface().unwrap_or_else(|| "eth0".to_string());
+
+        // Ensure each NAT GW is provisioned
+        for natgw in &local_natgws {
+            // Resolve VPC VNI
+            let vpc_store = nauka_network::vpc::store::VpcStore::new(ctx.db.clone());
+            let vpc = match vpc_store.get(natgw.vpc_id.as_str(), None).await? {
+                Some(v) => v,
+                None => {
+                    tracing::warn!(
+                        natgw = natgw.meta.name,
+                        vpc_id = natgw.vpc_id.as_str(),
+                        "NAT GW references unknown VPC, skipping"
+                    );
+                    result.failed += 1;
+                    continue;
+                }
+            };
+
+            match provision::ensure_nat_gateway(
+                natgw.vpc_id.as_str(),
+                &vpc.cidr,
+                vpc.vni,
+                &natgw.public_ipv6,
+                &public_interface,
+            ) {
+                Ok(()) => {
+                    result.created += 1;
+                    tracing::info!(
+                        natgw = natgw.meta.name,
+                        vpc = natgw.vpc_name,
+                        ipv6 = %natgw.public_ipv6,
+                        "NAT gateway provisioned"
+                    );
+                }
+                Err(e) => {
+                    result.failed += 1;
+                    result.errors.push(format!(
+                        "natgw '{}': {}",
+                        natgw.meta.name, e
+                    ));
+                    tracing::error!(
+                        natgw = natgw.meta.name,
+                        error = %e,
+                        "NAT gateway provisioning failed"
+                    );
+                }
+            }
+        }
+
+        result.actual = result.created;
+
+        Ok(result)
+    }
+}
+
+/// Detect the public-facing network interface (the one with the default IPv6 route).
+fn detect_public_interface() -> Option<String> {
+    let output = std::process::Command::new("ip")
+        .args(["-6", "route", "show", "default"])
+        .output()
+        .ok()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Format: "default via <gw> dev <iface> ..."
+    for part in stdout.split_whitespace().collect::<Vec<_>>().windows(2) {
+        if part[0] == "dev" {
+            return Some(part[1].to_string());
+        }
+    }
+    None
+}

--- a/layers/forge/src/reconciler/vm.rs
+++ b/layers/forge/src/reconciler/vm.rs
@@ -98,6 +98,13 @@ impl super::Reconciler for VmReconciler {
                     None => ("0.0.0.0".to_string(), "0.0.0.0/0".to_string()),
                 };
 
+                // Resolve VPC CIDR for DNS64/NAT64 setup
+                let vpc_store = nauka_network::vpc::store::VpcStore::new(ctx.db.clone());
+                let vpc_cidr = vpc_store
+                    .get(vm.vpc_id.as_str(), None)
+                    .await?
+                    .map(|v| v.cidr);
+
                 let config = VmRunConfig {
                     vm_id: vm.meta.id.clone(),
                     vm_name: vm.meta.name.clone(),
@@ -113,6 +120,7 @@ impl super::Reconciler for VmReconciler {
                     private_ip: vm.private_ip.clone().unwrap_or_default(),
                     gateway,
                     subnet_cidr: cidr,
+                    vpc_cidr,
                 };
 
                 match rt.start(&config) {

--- a/layers/hypervisor/src/fabric/health.rs
+++ b/layers/hypervisor/src/fabric/health.rs
@@ -227,11 +227,19 @@ mod tests {
 
         // Create state with no peers
         let (mesh, secret) = super::super::mesh::create_mesh();
-        let hv = super::super::mesh::create_hypervisor(&super::super::mesh::CreateHypervisorConfig {
-            name: "node-1", region: "eu", zone: "fsn1", port: 51820,
-            endpoint: None, fabric_interface: "", mesh_prefix: &mesh.prefix,
-            ipv6_block: None, ipv4_public: None,
-        }).unwrap();
+        let hv =
+            super::super::mesh::create_hypervisor(&super::super::mesh::CreateHypervisorConfig {
+                name: "node-1",
+                region: "eu",
+                zone: "fsn1",
+                port: 51820,
+                endpoint: None,
+                fabric_interface: "",
+                mesh_prefix: &mesh.prefix,
+                ipv6_block: None,
+                ipv4_public: None,
+            })
+            .unwrap();
         let state = FabricState {
             mesh,
             hypervisor: hv,
@@ -253,11 +261,19 @@ mod tests {
         let db = LayerDb::open_at(&dir.path().join("test.redb")).unwrap();
 
         let (mesh, secret) = super::super::mesh::create_mesh();
-        let hv = super::super::mesh::create_hypervisor(&super::super::mesh::CreateHypervisorConfig {
-            name: "node-1", region: "eu", zone: "fsn1", port: 51820,
-            endpoint: None, fabric_interface: "", mesh_prefix: &mesh.prefix,
-            ipv6_block: None, ipv4_public: None,
-        }).unwrap();
+        let hv =
+            super::super::mesh::create_hypervisor(&super::super::mesh::CreateHypervisorConfig {
+                name: "node-1",
+                region: "eu",
+                zone: "fsn1",
+                port: 51820,
+                endpoint: None,
+                fabric_interface: "",
+                mesh_prefix: &mesh.prefix,
+                ipv6_block: None,
+                ipv4_public: None,
+            })
+            .unwrap();
         let mut peers = super::super::peer::PeerList::new();
         peers
             .add(super::super::peer::Peer::new(

--- a/layers/hypervisor/src/fabric/health.rs
+++ b/layers/hypervisor/src/fabric/health.rs
@@ -227,16 +227,11 @@ mod tests {
 
         // Create state with no peers
         let (mesh, secret) = super::super::mesh::create_mesh();
-        let hv = super::super::mesh::create_hypervisor(
-            "node-1",
-            "eu",
-            "fsn1",
-            51820,
-            None,
-            "",
-            &mesh.prefix,
-        )
-        .unwrap();
+        let hv = super::super::mesh::create_hypervisor(&super::super::mesh::CreateHypervisorConfig {
+            name: "node-1", region: "eu", zone: "fsn1", port: 51820,
+            endpoint: None, fabric_interface: "", mesh_prefix: &mesh.prefix,
+            ipv6_block: None, ipv4_public: None,
+        }).unwrap();
         let state = FabricState {
             mesh,
             hypervisor: hv,
@@ -258,16 +253,11 @@ mod tests {
         let db = LayerDb::open_at(&dir.path().join("test.redb")).unwrap();
 
         let (mesh, secret) = super::super::mesh::create_mesh();
-        let hv = super::super::mesh::create_hypervisor(
-            "node-1",
-            "eu",
-            "fsn1",
-            51820,
-            None,
-            "",
-            &mesh.prefix,
-        )
-        .unwrap();
+        let hv = super::super::mesh::create_hypervisor(&super::super::mesh::CreateHypervisorConfig {
+            name: "node-1", region: "eu", zone: "fsn1", port: 51820,
+            endpoint: None, fabric_interface: "", mesh_prefix: &mesh.prefix,
+            ipv6_block: None, ipv4_public: None,
+        }).unwrap();
         let mut peers = super::super::peer::PeerList::new();
         peers
             .add(super::super::peer::Peer::new(

--- a/layers/hypervisor/src/fabric/mesh.rs
+++ b/layers/hypervisor/src/fabric/mesh.rs
@@ -134,10 +134,24 @@ mod tests {
     use super::*;
 
     /// Test helper: create a hypervisor with minimal defaults.
-    fn make_hv(name: &str, region: &str, zone: &str, port: u16, endpoint: Option<String>, prefix: &Ipv6Addr) -> Result<HypervisorIdentity, nauka_core::error::NaukaError> {
+    fn make_hv(
+        name: &str,
+        region: &str,
+        zone: &str,
+        port: u16,
+        endpoint: Option<String>,
+        prefix: &Ipv6Addr,
+    ) -> Result<HypervisorIdentity, nauka_core::error::NaukaError> {
         create_hypervisor(&CreateHypervisorConfig {
-            name, region, zone, port, endpoint, fabric_interface: "", mesh_prefix: prefix,
-            ipv6_block: None, ipv4_public: None,
+            name,
+            region,
+            zone,
+            port,
+            endpoint,
+            fabric_interface: "",
+            mesh_prefix: prefix,
+            ipv6_block: None,
+            ipv4_public: None,
         })
     }
 
@@ -160,8 +174,7 @@ mod tests {
     #[test]
     fn create_node_has_valid_identity() {
         let (mesh, _) = create_mesh();
-        let node =
-            make_hv("node-1", "eu", "fsn1", 51820, None, &mesh.prefix).unwrap();
+        let node = make_hv("node-1", "eu", "fsn1", 51820, None, &mesh.prefix).unwrap();
 
         assert_eq!(node.name, "node-1");
         assert_eq!(node.region, "eu");
@@ -184,15 +197,22 @@ mod tests {
     #[test]
     fn create_node_with_endpoint() {
         let (mesh, _) = create_mesh();
-        let node = make_hv("node-1", "eu", "fsn1", 51820, Some("46.224.166.60:51820".into()), &mesh.prefix).unwrap();
+        let node = make_hv(
+            "node-1",
+            "eu",
+            "fsn1",
+            51820,
+            Some("46.224.166.60:51820".into()),
+            &mesh.prefix,
+        )
+        .unwrap();
         assert_eq!(node.endpoint, Some("46.224.166.60:51820".into()));
     }
 
     #[test]
     fn node_identity_serde_roundtrip() {
         let (mesh, _) = create_mesh();
-        let node =
-            make_hv("node-1", "eu", "fsn1", 51820, None, &mesh.prefix).unwrap();
+        let node = make_hv("node-1", "eu", "fsn1", 51820, None, &mesh.prefix).unwrap();
         let json = serde_json::to_string(&node).unwrap();
         let back: HypervisorIdentity = serde_json::from_str(&json).unwrap();
         assert_eq!(back.name, "node-1");
@@ -230,8 +250,7 @@ mod tests {
     #[test]
     fn private_key_survives_serde() {
         let (mesh, _) = create_mesh();
-        let node =
-            make_hv("node-1", "eu", "fsn1", 51820, None, &mesh.prefix).unwrap();
+        let node = make_hv("node-1", "eu", "fsn1", 51820, None, &mesh.prefix).unwrap();
         let original_private = node.wg_private_key.clone();
         assert!(!original_private.is_empty());
 

--- a/layers/hypervisor/src/fabric/mesh.rs
+++ b/layers/hypervisor/src/fabric/mesh.rs
@@ -52,6 +52,12 @@ pub struct HypervisorIdentity {
     /// Compute runtime: "kvm" (Cloud Hypervisor) or "container" (gVisor).
     #[serde(default = "default_runtime")]
     pub runtime: String,
+    /// Public IPv6 /64 block allocated by the hosting provider (e.g., "2a01:4f8:c012:abcd::/64").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ipv6_block: Option<String>,
+    /// Public IPv4 address of this server.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ipv4_public: Option<String>,
 }
 
 fn default_runtime() -> String {
@@ -69,28 +75,35 @@ pub fn create_mesh() -> (MeshIdentity, MeshSecret) {
     (mesh, secret)
 }
 
+/// Configuration for creating a new hypervisor identity.
+pub struct CreateHypervisorConfig<'a> {
+    pub name: &'a str,
+    pub region: &'a str,
+    pub zone: &'a str,
+    pub port: u16,
+    pub endpoint: Option<String>,
+    pub fabric_interface: &'a str,
+    pub mesh_prefix: &'a Ipv6Addr,
+    pub ipv6_block: Option<String>,
+    pub ipv4_public: Option<String>,
+}
+
 /// Create a new node identity (called by both init and join).
 /// Validates name, region, zone, and port.
 pub fn create_hypervisor(
-    name: &str,
-    region: &str,
-    zone: &str,
-    port: u16,
-    endpoint: Option<String>,
-    fabric_interface: &str,
-    mesh_prefix: &Ipv6Addr,
+    cfg: &CreateHypervisorConfig<'_>,
 ) -> Result<HypervisorIdentity, nauka_core::error::NaukaError> {
-    nauka_core::validate::name(name)?;
-    nauka_core::validate::region(region)?;
-    nauka_core::validate::zone(zone)?;
-    nauka_core::validate::port(port)?;
+    nauka_core::validate::name(cfg.name)?;
+    nauka_core::validate::region(cfg.region)?;
+    nauka_core::validate::zone(cfg.zone)?;
+    nauka_core::validate::port(cfg.port)?;
 
     let (wg_private, wg_public) = crypto::generate_wg_keypair();
 
     let pub_bytes = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, &wg_public)
         .unwrap_or_default();
 
-    let mesh_ipv6 = addressing::derive_node_address(mesh_prefix, &pub_bytes);
+    let mesh_ipv6 = addressing::derive_node_address(cfg.mesh_prefix, &pub_bytes);
 
     // Detect compute runtime: KVM if /dev/kvm exists, container (gVisor) otherwise
     let runtime = if std::path::Path::new("/dev/kvm").exists() {
@@ -101,22 +114,32 @@ pub fn create_hypervisor(
 
     Ok(HypervisorIdentity {
         id: nauka_core::id::HypervisorId::generate(),
-        name: name.to_string(),
-        region: region.to_string(),
-        zone: zone.to_string(),
+        name: cfg.name.to_string(),
+        region: cfg.region.to_string(),
+        zone: cfg.zone.to_string(),
         wg_private_key: wg_private,
         wg_public_key: wg_public,
-        wg_port: port,
-        endpoint,
-        fabric_interface: fabric_interface.to_string(),
+        wg_port: cfg.port,
+        endpoint: cfg.endpoint.clone(),
+        fabric_interface: cfg.fabric_interface.to_string(),
         mesh_ipv6,
         runtime,
+        ipv6_block: cfg.ipv6_block.clone(),
+        ipv4_public: cfg.ipv4_public.clone(),
     })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Test helper: create a hypervisor with minimal defaults.
+    fn make_hv(name: &str, region: &str, zone: &str, port: u16, endpoint: Option<String>, prefix: &Ipv6Addr) -> Result<HypervisorIdentity, nauka_core::error::NaukaError> {
+        create_hypervisor(&CreateHypervisorConfig {
+            name, region, zone, port, endpoint, fabric_interface: "", mesh_prefix: prefix,
+            ipv6_block: None, ipv4_public: None,
+        })
+    }
 
     #[test]
     fn create_mesh_generates_valid_identity() {
@@ -138,7 +161,7 @@ mod tests {
     fn create_node_has_valid_identity() {
         let (mesh, _) = create_mesh();
         let node =
-            create_hypervisor("node-1", "eu", "fsn1", 51820, None, "", &mesh.prefix).unwrap();
+            make_hv("node-1", "eu", "fsn1", 51820, None, &mesh.prefix).unwrap();
 
         assert_eq!(node.name, "node-1");
         assert_eq!(node.region, "eu");
@@ -152,8 +175,8 @@ mod tests {
     #[test]
     fn create_node_unique_keys() {
         let (mesh, _) = create_mesh();
-        let a = create_hypervisor("node-aaa", "eu", "fsn1", 51820, None, "", &mesh.prefix).unwrap();
-        let b = create_hypervisor("node-bbb", "eu", "fsn1", 51820, None, "", &mesh.prefix).unwrap();
+        let a = make_hv("node-aaa", "eu", "fsn1", 51820, None, &mesh.prefix).unwrap();
+        let b = make_hv("node-bbb", "eu", "fsn1", 51820, None, &mesh.prefix).unwrap();
         assert_ne!(a.wg_public_key, b.wg_public_key);
         assert_ne!(a.mesh_ipv6, b.mesh_ipv6);
     }
@@ -161,16 +184,7 @@ mod tests {
     #[test]
     fn create_node_with_endpoint() {
         let (mesh, _) = create_mesh();
-        let node = create_hypervisor(
-            "node-1",
-            "eu",
-            "fsn1",
-            51820,
-            Some("46.224.166.60:51820".into()),
-            "",
-            &mesh.prefix,
-        )
-        .unwrap();
+        let node = make_hv("node-1", "eu", "fsn1", 51820, Some("46.224.166.60:51820".into()), &mesh.prefix).unwrap();
         assert_eq!(node.endpoint, Some("46.224.166.60:51820".into()));
     }
 
@@ -178,7 +192,7 @@ mod tests {
     fn node_identity_serde_roundtrip() {
         let (mesh, _) = create_mesh();
         let node =
-            create_hypervisor("node-1", "eu", "fsn1", 51820, None, "", &mesh.prefix).unwrap();
+            make_hv("node-1", "eu", "fsn1", 51820, None, &mesh.prefix).unwrap();
         let json = serde_json::to_string(&node).unwrap();
         let back: HypervisorIdentity = serde_json::from_str(&json).unwrap();
         assert_eq!(back.name, "node-1");
@@ -190,25 +204,25 @@ mod tests {
     #[test]
     fn create_node_rejects_empty_name() {
         let (mesh, _) = create_mesh();
-        assert!(create_hypervisor("", "eu", "fsn1", 51820, None, "", &mesh.prefix).is_err());
+        assert!(make_hv("", "eu", "fsn1", 51820, None, &mesh.prefix).is_err());
     }
 
     #[test]
     fn create_node_rejects_bad_region() {
         let (mesh, _) = create_mesh();
-        assert!(create_hypervisor("node-1", "EU!", "fsn1", 51820, None, "", &mesh.prefix).is_err());
+        assert!(make_hv("node-1", "EU!", "fsn1", 51820, None, &mesh.prefix).is_err());
     }
 
     #[test]
     fn create_node_rejects_bad_zone() {
         let (mesh, _) = create_mesh();
-        assert!(create_hypervisor("node-1", "eu", "FSN 1", 51820, None, "", &mesh.prefix).is_err());
+        assert!(make_hv("node-1", "eu", "FSN 1", 51820, None, &mesh.prefix).is_err());
     }
 
     #[test]
     fn create_node_rejects_port_zero() {
         let (mesh, _) = create_mesh();
-        assert!(create_hypervisor("node-1", "eu", "fsn1", 0, None, "", &mesh.prefix).is_err());
+        assert!(make_hv("node-1", "eu", "fsn1", 0, None, &mesh.prefix).is_err());
     }
 
     // ── #5: Private key persistence ──
@@ -217,7 +231,7 @@ mod tests {
     fn private_key_survives_serde() {
         let (mesh, _) = create_mesh();
         let node =
-            create_hypervisor("node-1", "eu", "fsn1", 51820, None, "", &mesh.prefix).unwrap();
+            make_hv("node-1", "eu", "fsn1", 51820, None, &mesh.prefix).unwrap();
         let original_private = node.wg_private_key.clone();
         assert!(!original_private.is_empty());
 
@@ -241,10 +255,10 @@ mod tests {
     fn create_node_long_name() {
         let (mesh, _) = create_mesh();
         let long_name = "a".repeat(63); // max allowed
-        assert!(create_hypervisor(&long_name, "eu", "fsn1", 51820, None, "", &mesh.prefix).is_ok());
+        assert!(make_hv(&long_name, "eu", "fsn1", 51820, None, &mesh.prefix).is_ok());
 
         let too_long = "a".repeat(64);
-        assert!(create_hypervisor(&too_long, "eu", "fsn1", 51820, None, "", &mesh.prefix).is_err());
+        assert!(make_hv(&too_long, "eu", "fsn1", 51820, None, &mesh.prefix).is_err());
     }
 
     #[test]

--- a/layers/hypervisor/src/fabric/ops.rs
+++ b/layers/hypervisor/src/fabric/ops.rs
@@ -30,6 +30,8 @@ pub struct InitConfig<'a> {
     pub network_mode: super::backend::NetworkMode,
     pub fabric_interface: &'a str,
     pub endpoint: Option<String>,
+    pub ipv6_block: Option<String>,
+    pub ipv4_public: Option<String>,
 }
 
 /// Initialize a new mesh.
@@ -64,15 +66,17 @@ pub fn init(
     // Create identities
     steps.set("Creating mesh");
     let (mesh_id, secret) = mesh::create_mesh();
-    let hv = mesh::create_hypervisor(
-        cfg.node_name,
-        cfg.region,
-        cfg.zone,
-        cfg.port,
-        cfg.endpoint.clone(),
-        cfg.fabric_interface,
-        &mesh_id.prefix,
-    )?;
+    let hv = mesh::create_hypervisor(&mesh::CreateHypervisorConfig {
+        name: cfg.node_name,
+        region: cfg.region,
+        zone: cfg.zone,
+        port: cfg.port,
+        endpoint: cfg.endpoint.clone(),
+        fabric_interface: cfg.fabric_interface,
+        mesh_prefix: &mesh_id.prefix,
+        ipv6_block: cfg.ipv6_block.clone(),
+        ipv4_public: cfg.ipv4_public.clone(),
+    })?;
 
     // Setup network via backend
     backend.setup(&hv.wg_private_key, cfg.port, &hv.mesh_ipv6, &[])?;
@@ -281,6 +285,8 @@ pub struct JoinConfig<'a> {
     pub port: u16,
     pub pin: Option<&'a str>,
     pub network_mode: super::backend::NetworkMode,
+    pub ipv6_block: Option<String>,
+    pub ipv4_public: Option<String>,
 }
 
 /// Join an existing cluster.
@@ -364,6 +370,8 @@ pub async fn join(
         fabric_interface: String::new(),
         mesh_ipv6,
         runtime,
+        ipv6_block: cfg.ipv6_block.clone(),
+        ipv4_public: cfg.ipv4_public.clone(),
     };
 
     // Use mesh ID from the accepting node (consistent across cluster)

--- a/layers/hypervisor/src/fabric/state.rs
+++ b/layers/hypervisor/src/fabric/state.rs
@@ -66,12 +66,18 @@ mod tests {
 
     fn make_state() -> FabricState {
         let (mesh_id, secret) = mesh::create_mesh();
-        let node =
-            mesh::create_hypervisor(&mesh::CreateHypervisorConfig {
-                name: "node-1", region: "eu", zone: "fsn1", port: 51820,
-                endpoint: None, fabric_interface: "", mesh_prefix: &mesh_id.prefix,
-                ipv6_block: None, ipv4_public: None,
-            }).unwrap();
+        let node = mesh::create_hypervisor(&mesh::CreateHypervisorConfig {
+            name: "node-1",
+            region: "eu",
+            zone: "fsn1",
+            port: 51820,
+            endpoint: None,
+            fabric_interface: "",
+            mesh_prefix: &mesh_id.prefix,
+            ipv6_block: None,
+            ipv4_public: None,
+        })
+        .unwrap();
 
         FabricState {
             mesh: mesh_id,

--- a/layers/hypervisor/src/fabric/state.rs
+++ b/layers/hypervisor/src/fabric/state.rs
@@ -67,8 +67,11 @@ mod tests {
     fn make_state() -> FabricState {
         let (mesh_id, secret) = mesh::create_mesh();
         let node =
-            mesh::create_hypervisor("node-1", "eu", "fsn1", 51820, None, "", &mesh_id.prefix)
-                .unwrap();
+            mesh::create_hypervisor(&mesh::CreateHypervisorConfig {
+                name: "node-1", region: "eu", zone: "fsn1", port: 51820,
+                endpoint: None, fabric_interface: "", mesh_prefix: &mesh_id.prefix,
+                ipv6_block: None, ipv4_public: None,
+            }).unwrap();
 
         FabricState {
             mesh: mesh_id,

--- a/layers/hypervisor/src/handlers.rs
+++ b/layers/hypervisor/src/handlers.rs
@@ -84,6 +84,14 @@ pub fn resource_def() -> ResourceDef {
                 FieldDef::string("s3-region", "S3 region (e.g., eu-central-1)").with_default(""),
             ))
             .with_arg(OperationArg::optional(
+                "ipv6-block",
+                FieldDef::string("ipv6-block", "Public IPv6 /64 block from hosting provider (e.g., 2a01:4f8:c012:abcd::/64)"),
+            ))
+            .with_arg(OperationArg::optional(
+                "ipv4-public",
+                FieldDef::string("ipv4-public", "Public IPv4 address of this server"),
+            ))
+            .with_arg(OperationArg::optional(
                 "peering",
                 FieldDef::flag(
                     "peering",
@@ -127,6 +135,14 @@ pub fn resource_def() -> ResourceDef {
                 "mode",
                 FieldDef::string("mode", "Network mode: wireguard (default), direct, mock")
                     .with_default("wireguard"),
+            ))
+            .with_arg(OperationArg::optional(
+                "ipv6-block",
+                FieldDef::string("ipv6-block", "Public IPv6 /64 block from hosting provider (e.g., 2a01:4f8:c012:abcd::/64)"),
+            ))
+            .with_arg(OperationArg::optional(
+                "ipv4-public",
+                FieldDef::string("ipv4-public", "Public IPv4 address of this server"),
             ))
             .with_output(OutputKind::Resource)
             .with_example(
@@ -296,6 +312,9 @@ async fn handle_init(req: OperationRequest) -> anyhow::Result<OperationResponse>
         .map(|s| s == "true")
         .unwrap_or(false);
 
+    let ipv6_block = req.fields.get("ipv6-block").cloned();
+    let ipv4_public = req.fields.get("ipv4-public").cloned();
+
     let db = open_db()?;
     let init_cfg = fabric::ops::InitConfig {
         node_name: &node_name,
@@ -305,6 +324,8 @@ async fn handle_init(req: OperationRequest) -> anyhow::Result<OperationResponse>
         network_mode,
         fabric_interface,
         endpoint,
+        ipv6_block,
+        ipv4_public,
     };
 
     // Generate a deterministic encryption password from the S3 secret key + region.
@@ -476,6 +497,9 @@ async fn handle_join(req: OperationRequest) -> anyhow::Result<OperationResponse>
                 .unwrap_or_else(|| "node".to_string())
         });
 
+    let ipv6_block = req.fields.get("ipv6-block").cloned();
+    let ipv4_public = req.fields.get("ipv4-public").cloned();
+
     let db = open_db()?;
     let join_cfg = fabric::ops::JoinConfig {
         target: &target,
@@ -485,6 +509,8 @@ async fn handle_join(req: OperationRequest) -> anyhow::Result<OperationResponse>
         port,
         pin,
         network_mode,
+        ipv6_block,
+        ipv4_public,
     };
 
     // Join: 2 (fabric) + 3 (control plane) + 1 (storage) + 3 (compute+forge) + 1 (announce) = 10

--- a/layers/hypervisor/tests/e2e/peering_test.rs
+++ b/layers/hypervisor/tests/e2e/peering_test.rs
@@ -26,10 +26,17 @@ fn temp_db() -> (tempfile::TempDir, LocalDb) {
 fn init_node(db: &LocalDb, name: &str) -> (FabricState, String) {
     let (mesh_id, secret) = mesh::create_mesh();
     let hv = mesh::create_hypervisor(&mesh::CreateHypervisorConfig {
-        name, region: "eu", zone: "test", port: 51820,
-        endpoint: None, fabric_interface: "", mesh_prefix: &mesh_id.prefix,
-        ipv6_block: None, ipv4_public: None,
-    }).unwrap();
+        name,
+        region: "eu",
+        zone: "test",
+        port: 51820,
+        endpoint: None,
+        fabric_interface: "",
+        mesh_prefix: &mesh_id.prefix,
+        ipv6_block: None,
+        ipv4_public: None,
+    })
+    .unwrap();
 
     let secret_str = secret.to_string();
     let pin = secret.derive_pin();
@@ -247,12 +254,18 @@ fn mesh_identity_generation() {
     assert!(mesh.id.as_str().starts_with("mesh-"));
     assert!(secret.to_string().starts_with("syf_sk_"));
 
-    let hv =
-        mesh::create_hypervisor(&mesh::CreateHypervisorConfig {
-            name: "node-1", region: "eu", zone: "fsn1", port: 51820,
-            endpoint: None, fabric_interface: "", mesh_prefix: &mesh.prefix,
-            ipv6_block: None, ipv4_public: None,
-        }).unwrap();
+    let hv = mesh::create_hypervisor(&mesh::CreateHypervisorConfig {
+        name: "node-1",
+        region: "eu",
+        zone: "fsn1",
+        port: 51820,
+        endpoint: None,
+        fabric_interface: "",
+        mesh_prefix: &mesh.prefix,
+        ipv6_block: None,
+        ipv4_public: None,
+    })
+    .unwrap();
     assert_eq!(hv.name, "node-1");
     assert!(!hv.wg_private_key.is_empty());
     assert!(!hv.wg_public_key.is_empty());

--- a/layers/hypervisor/tests/e2e/peering_test.rs
+++ b/layers/hypervisor/tests/e2e/peering_test.rs
@@ -25,7 +25,11 @@ fn temp_db() -> (tempfile::TempDir, LocalDb) {
 
 fn init_node(db: &LocalDb, name: &str) -> (FabricState, String) {
     let (mesh_id, secret) = mesh::create_mesh();
-    let hv = mesh::create_hypervisor(name, "eu", "test", 51820, None, "", &mesh_id.prefix).unwrap();
+    let hv = mesh::create_hypervisor(&mesh::CreateHypervisorConfig {
+        name, region: "eu", zone: "test", port: 51820,
+        endpoint: None, fabric_interface: "", mesh_prefix: &mesh_id.prefix,
+        ipv6_block: None, ipv4_public: None,
+    }).unwrap();
 
     let secret_str = secret.to_string();
     let pin = secret.derive_pin();
@@ -244,7 +248,11 @@ fn mesh_identity_generation() {
     assert!(secret.to_string().starts_with("syf_sk_"));
 
     let hv =
-        mesh::create_hypervisor("node-1", "eu", "fsn1", 51820, None, "", &mesh.prefix).unwrap();
+        mesh::create_hypervisor(&mesh::CreateHypervisorConfig {
+            name: "node-1", region: "eu", zone: "fsn1", port: 51820,
+            endpoint: None, fabric_interface: "", mesh_prefix: &mesh.prefix,
+            ipv6_block: None, ipv4_public: None,
+        }).unwrap();
     assert_eq!(hv.name, "node-1");
     assert!(!hv.wg_private_key.is_empty());
     assert!(!hv.wg_public_key.is_empty());

--- a/layers/network/Cargo.toml
+++ b/layers/network/Cargo.toml
@@ -19,6 +19,8 @@ anyhow.workspace = true
 thiserror.workspace = true
 tikv-client = "0.4"
 ipnet = "2"
+sha2 = "0.10"
+hex = "0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/layers/network/src/vpc/handlers.rs
+++ b/layers/network/src/vpc/handlers.rs
@@ -121,6 +121,7 @@ pub fn registration() -> ResourceRegistration {
         children: vec![
             super::subnet::handlers::registration(),
             super::peering::handlers::registration(),
+            super::natgw::handlers::registration(),
         ],
     }
 }

--- a/layers/network/src/vpc/natgw/handlers.rs
+++ b/layers/network/src/vpc/natgw/handlers.rs
@@ -1,0 +1,166 @@
+use std::future::Future;
+use std::pin::Pin;
+
+use nauka_core::resource::*;
+
+use super::store::NatGwStore;
+
+pub fn resource_def() -> ResourceDef {
+    ResourceDef::build("nat-gateway", "Manage NAT gateways for outbound internet access")
+        .plural("nat-gateways")
+        .parent("org", "--org", "Organization")
+        .parent("vpc", "--vpc", "VPC")
+        .create()
+        .op(|op| {
+            op.with_arg(OperationArg::optional(
+                "hypervisor",
+                FieldDef::string("hypervisor", "Hypervisor to provision on (auto-selected if omitted)"),
+            ))
+            .with_example("nauka vpc nat-gateway create egress --vpc prod-net --org acme")
+        })
+        .list()
+        .get()
+        .delete()
+        .column("NAME", "name")
+        .column("VPC", "vpc_name")
+        .column("PUBLIC IPv6", "public_ipv6")
+        .column_def(ColumnDef::new("STATE", "state").with_format(DisplayFormat::Status))
+        .column("ID", "id")
+        .column_def(ColumnDef::new("CREATED", "created_at").with_format(DisplayFormat::Timestamp))
+        .empty_message("No NAT gateways found.")
+        .detail_section(
+            None,
+            vec![
+                DetailField::new("Name", "name"),
+                DetailField::new("ID", "id"),
+                DetailField::new("VPC", "vpc_name"),
+                DetailField::new("Public IPv6", "public_ipv6"),
+                DetailField::new("Hypervisor", "hypervisor_id"),
+                DetailField::new("State", "state").with_format(DisplayFormat::Status),
+                DetailField::new("Created", "created_at").with_format(DisplayFormat::Timestamp),
+            ],
+        )
+        .done()
+}
+
+pub fn handler() -> HandlerFn {
+    Box::new(
+        |req: OperationRequest| -> Pin<
+            Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
+        > {
+            Box::pin(async move {
+                let store = NatGwStore::new(nauka_hypervisor::controlplane::connect().await?);
+                match req.operation.as_str() {
+                    "create" => {
+                        let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name"))?;
+                        let vpc = req
+                            .scope
+                            .get("vpc")
+                            .ok_or_else(|| anyhow::anyhow!("--vpc is required"))?
+                            .to_string();
+                        let org = req
+                            .scope
+                            .get("org")
+                            .ok_or_else(|| anyhow::anyhow!("--org is required"))?
+                            .to_string();
+
+                        nauka_core::validate::name(&name)?;
+
+                        // Resolve hypervisor with an IPv6 block
+                        let (hv_id, ipv6_block) = resolve_hypervisor(
+                            req.fields.get("hypervisor").map(|s| s.as_str()),
+                        )?;
+
+                        let natgw = store
+                            .create(&name, &vpc, &org, &hv_id, &ipv6_block)
+                            .await?;
+                        Ok(OperationResponse::Resource(natgw.to_api_json()))
+                    }
+                    "list" => {
+                        let vpc = req.scope.get("vpc").map(|s| s.to_string());
+                        let natgws = store.list(vpc.as_deref()).await?;
+                        let items: Vec<serde_json::Value> =
+                            natgws.iter().map(|n| n.to_api_json()).collect();
+                        Ok(OperationResponse::ResourceList(items))
+                    }
+                    "get" => {
+                        let name = req
+                            .name
+                            .ok_or_else(|| anyhow::anyhow!("missing name or ID"))?;
+                        let vpc = req.scope.get("vpc").map(|s| s.to_string());
+                        let org = req.scope.get("org").map(|s| s.to_string());
+                        let natgw = store
+                            .get(&name, vpc.as_deref(), org.as_deref())
+                            .await?
+                            .ok_or_else(|| anyhow::anyhow!("nat-gateway '{name}' not found"))?;
+                        Ok(OperationResponse::Resource(natgw.to_api_json()))
+                    }
+                    "delete" => {
+                        let name = req
+                            .name
+                            .ok_or_else(|| anyhow::anyhow!("missing name or ID"))?;
+                        let vpc = req
+                            .scope
+                            .get("vpc")
+                            .ok_or_else(|| anyhow::anyhow!("--vpc is required"))?
+                            .to_string();
+                        let org = req
+                            .scope
+                            .get("org")
+                            .ok_or_else(|| anyhow::anyhow!("--org is required"))?
+                            .to_string();
+                        store.delete(&name, &vpc, &org).await?;
+                        Ok(OperationResponse::Message(format!(
+                            "nat-gateway '{name}' deleted."
+                        )))
+                    }
+                    other => Ok(OperationResponse::Message(format!("unknown: {other}"))),
+                }
+            })
+        },
+    )
+}
+
+pub fn registration() -> ResourceRegistration {
+    ResourceRegistration {
+        def: resource_def(),
+        handler: handler(),
+        children: vec![],
+    }
+}
+
+/// Resolve the hypervisor to use for the NAT gateway.
+///
+/// Reads the local fabric state to find a hypervisor with an ipv6_block.
+/// If `preferred` is provided, validates it matches the local node.
+fn resolve_hypervisor(preferred: Option<&str>) -> anyhow::Result<(String, String)> {
+    let dir = nauka_core::process::nauka_dir();
+    let _ = std::fs::create_dir_all(&dir);
+    let db = nauka_state::LayerDb::open("hypervisor")
+        .map_err(|e| anyhow::anyhow!("cannot open hypervisor state: {e}"))?;
+    let state = nauka_hypervisor::fabric::state::FabricState::load(&db)
+        .map_err(|e| anyhow::anyhow!("{e}"))?
+        .ok_or_else(|| {
+            anyhow::anyhow!("hypervisor not initialized. Run 'nauka hypervisor init' first.")
+        })?;
+
+    let hv = &state.hypervisor;
+
+    if let Some(pref) = preferred {
+        if pref != hv.name && pref != hv.id.as_str() {
+            anyhow::bail!(
+                "hypervisor '{pref}' is not the local node. NAT gateways are provisioned locally."
+            );
+        }
+    }
+
+    let ipv6_block = hv.ipv6_block.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "hypervisor '{}' has no IPv6 block configured. \
+             Re-initialize with --ipv6-block to enable NAT gateways.",
+            hv.name
+        )
+    })?;
+
+    Ok((hv.id.to_string(), ipv6_block.clone()))
+}

--- a/layers/network/src/vpc/natgw/handlers.rs
+++ b/layers/network/src/vpc/natgw/handlers.rs
@@ -6,41 +6,47 @@ use nauka_core::resource::*;
 use super::store::NatGwStore;
 
 pub fn resource_def() -> ResourceDef {
-    ResourceDef::build("nat-gateway", "Manage NAT gateways for outbound internet access")
-        .plural("nat-gateways")
-        .parent("org", "--org", "Organization")
-        .parent("vpc", "--vpc", "VPC")
-        .create()
-        .op(|op| {
-            op.with_arg(OperationArg::optional(
+    ResourceDef::build(
+        "nat-gateway",
+        "Manage NAT gateways for outbound internet access",
+    )
+    .plural("nat-gateways")
+    .parent("org", "--org", "Organization")
+    .parent("vpc", "--vpc", "VPC")
+    .create()
+    .op(|op| {
+        op.with_arg(OperationArg::optional(
+            "hypervisor",
+            FieldDef::string(
                 "hypervisor",
-                FieldDef::string("hypervisor", "Hypervisor to provision on (auto-selected if omitted)"),
-            ))
-            .with_example("nauka vpc nat-gateway create egress --vpc prod-net --org acme")
-        })
-        .list()
-        .get()
-        .delete()
-        .column("NAME", "name")
-        .column("VPC", "vpc_name")
-        .column("PUBLIC IPv6", "public_ipv6")
-        .column_def(ColumnDef::new("STATE", "state").with_format(DisplayFormat::Status))
-        .column("ID", "id")
-        .column_def(ColumnDef::new("CREATED", "created_at").with_format(DisplayFormat::Timestamp))
-        .empty_message("No NAT gateways found.")
-        .detail_section(
-            None,
-            vec![
-                DetailField::new("Name", "name"),
-                DetailField::new("ID", "id"),
-                DetailField::new("VPC", "vpc_name"),
-                DetailField::new("Public IPv6", "public_ipv6"),
-                DetailField::new("Hypervisor", "hypervisor_id"),
-                DetailField::new("State", "state").with_format(DisplayFormat::Status),
-                DetailField::new("Created", "created_at").with_format(DisplayFormat::Timestamp),
-            ],
-        )
-        .done()
+                "Hypervisor to provision on (auto-selected if omitted)",
+            ),
+        ))
+        .with_example("nauka vpc nat-gateway create egress --vpc prod-net --org acme")
+    })
+    .list()
+    .get()
+    .delete()
+    .column("NAME", "name")
+    .column("VPC", "vpc_name")
+    .column("PUBLIC IPv6", "public_ipv6")
+    .column_def(ColumnDef::new("STATE", "state").with_format(DisplayFormat::Status))
+    .column("ID", "id")
+    .column_def(ColumnDef::new("CREATED", "created_at").with_format(DisplayFormat::Timestamp))
+    .empty_message("No NAT gateways found.")
+    .detail_section(
+        None,
+        vec![
+            DetailField::new("Name", "name"),
+            DetailField::new("ID", "id"),
+            DetailField::new("VPC", "vpc_name"),
+            DetailField::new("Public IPv6", "public_ipv6"),
+            DetailField::new("Hypervisor", "hypervisor_id"),
+            DetailField::new("State", "state").with_format(DisplayFormat::Status),
+            DetailField::new("Created", "created_at").with_format(DisplayFormat::Timestamp),
+        ],
+    )
+    .done()
 }
 
 pub fn handler() -> HandlerFn {

--- a/layers/network/src/vpc/natgw/ipv6_alloc.rs
+++ b/layers/network/src/vpc/natgw/ipv6_alloc.rs
@@ -1,0 +1,162 @@
+//! IPv6 address allocator for NAT gateways.
+//!
+//! Allocates /128 addresses from a hypervisor's public /64 block.
+//! Each NAT gateway gets a deterministic, unique IPv6 derived from
+//! the /64 prefix + a hash of the NAT gateway ID.
+
+use std::net::Ipv6Addr;
+
+use nauka_hypervisor::controlplane::ClusterDb;
+use serde::{Deserialize, Serialize};
+
+const NS_NATGW_IPV6: &str = "natgw-ipv6";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Ipv6Allocations {
+    entries: Vec<Ipv6Allocation>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Ipv6Allocation {
+    ipv6: Ipv6Addr,
+    nat_gw_id: String,
+}
+
+/// Derive a deterministic IPv6 /128 from a /64 prefix and a NAT gateway ID.
+///
+/// Uses SHA-256 of the NAT GW ID to fill the lower 64 bits (interface ID).
+/// Skips ::1 which is conventionally reserved for the host.
+fn derive_ipv6(prefix_str: &str, nat_gw_id: &str) -> anyhow::Result<Ipv6Addr> {
+    let net: ipnet::Ipv6Net = prefix_str
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid IPv6 block '{}': {}", prefix_str, e))?;
+    if net.prefix_len() != 64 {
+        anyhow::bail!("expected /64 block, got /{}", net.prefix_len());
+    }
+
+    let prefix = net.network();
+    let segs = prefix.segments();
+
+    use sha2::{Digest, Sha256};
+    let hash = Sha256::digest(nat_gw_id.as_bytes());
+
+    // Take 8 bytes from hash to form the interface ID (lower 64 bits)
+    let iid = [
+        u16::from_be_bytes([hash[0], hash[1]]),
+        u16::from_be_bytes([hash[2], hash[3]]),
+        u16::from_be_bytes([hash[4], hash[5]]),
+        u16::from_be_bytes([hash[6], hash[7]]),
+    ];
+
+    let addr = Ipv6Addr::new(segs[0], segs[1], segs[2], segs[3], iid[0], iid[1], iid[2], iid[3]);
+
+    // Avoid ::1 (host) and :: (network)
+    if addr == prefix || addr.segments()[4..] == [0, 0, 0, 1] {
+        // Extremely unlikely with SHA-256, but handle it
+        let addr2 = Ipv6Addr::new(
+            segs[0],
+            segs[1],
+            segs[2],
+            segs[3],
+            iid[0],
+            iid[1],
+            iid[2],
+            iid[3].wrapping_add(1),
+        );
+        return Ok(addr2);
+    }
+
+    Ok(addr)
+}
+
+/// Allocate a public IPv6 address for a NAT gateway from the hypervisor's /64 block.
+pub async fn allocate(
+    db: &ClusterDb,
+    hypervisor_id: &str,
+    ipv6_block: &str,
+    nat_gw_id: &str,
+) -> anyhow::Result<Ipv6Addr> {
+    let mut allocs = load(db, hypervisor_id).await?;
+
+    // Check if already allocated
+    if let Some(existing) = allocs.entries.iter().find(|a| a.nat_gw_id == nat_gw_id) {
+        return Ok(existing.ipv6);
+    }
+
+    let addr = derive_ipv6(ipv6_block, nat_gw_id)?;
+
+    // Check for collision (extremely unlikely with SHA-256)
+    if allocs.entries.iter().any(|a| a.ipv6 == addr) {
+        anyhow::bail!("IPv6 address collision for {addr} — this should not happen");
+    }
+
+    allocs.entries.push(Ipv6Allocation {
+        ipv6: addr,
+        nat_gw_id: nat_gw_id.to_string(),
+    });
+
+    save(db, hypervisor_id, &allocs).await?;
+    Ok(addr)
+}
+
+/// Release the IPv6 address allocated to a NAT gateway.
+pub async fn release(
+    db: &ClusterDb,
+    hypervisor_id: &str,
+    nat_gw_id: &str,
+) -> anyhow::Result<()> {
+    let mut allocs = load(db, hypervisor_id).await?;
+    allocs.entries.retain(|a| a.nat_gw_id != nat_gw_id);
+    save(db, hypervisor_id, &allocs).await
+}
+
+async fn load(db: &ClusterDb, hypervisor_id: &str) -> anyhow::Result<Ipv6Allocations> {
+    let allocs: Option<Ipv6Allocations> = db.get(NS_NATGW_IPV6, hypervisor_id).await?;
+    Ok(allocs.unwrap_or(Ipv6Allocations {
+        entries: Vec::new(),
+    }))
+}
+
+async fn save(
+    db: &ClusterDb,
+    hypervisor_id: &str,
+    allocs: &Ipv6Allocations,
+) -> anyhow::Result<()> {
+    db.put(NS_NATGW_IPV6, hypervisor_id, allocs).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derive_ipv6_deterministic() {
+        let a = derive_ipv6("2a01:4f8:c012:abcd::/64", "nat-01ABCDEF").unwrap();
+        let b = derive_ipv6("2a01:4f8:c012:abcd::/64", "nat-01ABCDEF").unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn derive_ipv6_different_ids_different_addrs() {
+        let a = derive_ipv6("2a01:4f8:c012:abcd::/64", "nat-01ABCDEF").unwrap();
+        let b = derive_ipv6("2a01:4f8:c012:abcd::/64", "nat-02GHIJKL").unwrap();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn derive_ipv6_preserves_prefix() {
+        let addr = derive_ipv6("2a01:4f8:c012:abcd::/64", "nat-test").unwrap();
+        let segs = addr.segments();
+        assert_eq!(segs[0], 0x2a01);
+        assert_eq!(segs[1], 0x04f8);
+        assert_eq!(segs[2], 0xc012);
+        assert_eq!(segs[3], 0xabcd);
+    }
+
+    #[test]
+    fn derive_ipv6_rejects_non_64() {
+        assert!(derive_ipv6("2a01:4f8:c012::/48", "nat-test").is_err());
+        assert!(derive_ipv6("2a01:4f8:c012:abcd::1/128", "nat-test").is_err());
+    }
+}

--- a/layers/network/src/vpc/natgw/ipv6_alloc.rs
+++ b/layers/network/src/vpc/natgw/ipv6_alloc.rs
@@ -48,7 +48,9 @@ fn derive_ipv6(prefix_str: &str, nat_gw_id: &str) -> anyhow::Result<Ipv6Addr> {
         u16::from_be_bytes([hash[6], hash[7]]),
     ];
 
-    let addr = Ipv6Addr::new(segs[0], segs[1], segs[2], segs[3], iid[0], iid[1], iid[2], iid[3]);
+    let addr = Ipv6Addr::new(
+        segs[0], segs[1], segs[2], segs[3], iid[0], iid[1], iid[2], iid[3],
+    );
 
     // Avoid ::1 (host) and :: (network)
     if addr == prefix || addr.segments()[4..] == [0, 0, 0, 1] {
@@ -100,11 +102,7 @@ pub async fn allocate(
 }
 
 /// Release the IPv6 address allocated to a NAT gateway.
-pub async fn release(
-    db: &ClusterDb,
-    hypervisor_id: &str,
-    nat_gw_id: &str,
-) -> anyhow::Result<()> {
+pub async fn release(db: &ClusterDb, hypervisor_id: &str, nat_gw_id: &str) -> anyhow::Result<()> {
     let mut allocs = load(db, hypervisor_id).await?;
     allocs.entries.retain(|a| a.nat_gw_id != nat_gw_id);
     save(db, hypervisor_id, &allocs).await
@@ -117,11 +115,7 @@ async fn load(db: &ClusterDb, hypervisor_id: &str) -> anyhow::Result<Ipv6Allocat
     }))
 }
 
-async fn save(
-    db: &ClusterDb,
-    hypervisor_id: &str,
-    allocs: &Ipv6Allocations,
-) -> anyhow::Result<()> {
+async fn save(db: &ClusterDb, hypervisor_id: &str, allocs: &Ipv6Allocations) -> anyhow::Result<()> {
     db.put(NS_NATGW_IPV6, hypervisor_id, allocs).await?;
     Ok(())
 }

--- a/layers/network/src/vpc/natgw/mod.rs
+++ b/layers/network/src/vpc/natgw/mod.rs
@@ -1,7 +1,5 @@
 pub mod handlers;
-pub mod natgw;
-pub mod peering;
+pub mod ipv6_alloc;
 pub mod provision;
 pub mod store;
-pub mod subnet;
 pub mod types;

--- a/layers/network/src/vpc/natgw/provision.rs
+++ b/layers/network/src/vpc/natgw/provision.rs
@@ -72,8 +72,15 @@ pub fn ensure_nat_gateway(
         let _ = run_cmd(
             "ip",
             &[
-                "route", "replace", "default", "via", &gw, "dev", public_interface,
-                "table", &table,
+                "route",
+                "replace",
+                "default",
+                "via",
+                &gw,
+                "dev",
+                public_interface,
+                "table",
+                &table,
             ],
         );
     }
@@ -81,7 +88,9 @@ pub fn ensure_nat_gateway(
     // ── 2b. ip rule: return traffic for VPC CIDR uses VPC routing table ──
     let _ = run_cmd(
         "ip",
-        &["rule", "add", "to", vpc_cidr, "lookup", &table, "priority", "32763"],
+        &[
+            "rule", "add", "to", vpc_cidr, "lookup", &table, "priority", "32763",
+        ],
     );
 
     // ── 3. NAT44 MASQUERADE for IPv4 outbound (fallback) ──
@@ -96,7 +105,14 @@ pub fn ensure_nat_gateway(
     );
     let _ = run_cmd(
         "jool",
-        &["instance", "add", &instance, "--netfilter", "--pool6", "64:ff9b::/96"],
+        &[
+            "instance",
+            "add",
+            &instance,
+            "--netfilter",
+            "--pool6",
+            "64:ff9b::/96",
+        ],
     );
 
     // ── 5. NAT66 SNAT: VM IPv6 traffic from this VPC exits with its NAT GW public IPv6 ──
@@ -164,9 +180,8 @@ fn detect_bridge_ipv4(bridge: &str) -> Option<String> {
 /// NAT44: MASQUERADE for IPv4 traffic from VPC bridges.
 fn ensure_nft_nat4(out_iface: &str) -> anyhow::Result<()> {
     let _ = run_nft("add table ip nauka_nat4");
-    let _ = run_nft(
-        "add chain ip nauka_nat4 postrouting { type nat hook postrouting priority 100 ; }",
-    );
+    let _ =
+        run_nft("add chain ip nauka_nat4 postrouting { type nat hook postrouting priority 100 ; }");
     let existing = Command::new("nft")
         .args(["list", "chain", "ip", "nauka_nat4", "postrouting"])
         .output()
@@ -188,9 +203,8 @@ fn ensure_nft_nat6(
     out_iface: &str,
 ) -> anyhow::Result<()> {
     let _ = run_nft("add table ip6 nauka_nat");
-    let _ = run_nft(
-        "add chain ip6 nauka_nat postrouting { type nat hook postrouting priority 100 ; }",
-    );
+    let _ =
+        run_nft("add chain ip6 nauka_nat postrouting { type nat hook postrouting priority 100 ; }");
     let ipv6_str = public_ipv6.to_string();
     let existing = Command::new("nft")
         .args(["list", "chain", "ip6", "nauka_nat", "postrouting"])
@@ -256,7 +270,14 @@ fn ensure_dns64(bridge: &str, vpc_cidr: &str) -> anyhow::Result<()> {
     // Add ULA IPv6 to bridge
     let _ = run_cmd(
         "ip",
-        &["-6", "addr", "add", &format!("{}/64", gw_ipv6), "dev", bridge],
+        &[
+            "-6",
+            "addr",
+            "add",
+            &format!("{}/64", gw_ipv6),
+            "dev",
+            bridge,
+        ],
     );
 
     // Clean old nauka DNS64 configs to avoid conflicts

--- a/layers/network/src/vpc/natgw/provision.rs
+++ b/layers/network/src/vpc/natgw/provision.rs
@@ -1,0 +1,361 @@
+//! NAT Gateway provisioning.
+//!
+//! Sets up outbound internet access for VMs in a VPC via a dedicated public IPv6:
+//!
+//! - DNS64 (unbound) on the bridge gateway synthesizes AAAA records using 64:ff9b::/96
+//! - Jool NAT64 translates IPv6 (64:ff9b::) → IPv4 for IPv4-only destinations
+//! - NAT66 (nftables SNAT) pins the public IPv6 as source for all VM IPv6 traffic
+//! - NAT44 (MASQUERADE) as fallback for direct IPv4 outbound
+//!
+//! Flow: VM resolves via DNS64 → gets 64:ff9b::x.x.x.x → sends IPv6 →
+//!       bridge forwards → Jool translates to IPv4 → exits with NAT GW IPv6 as source
+//!       (for IPv6-native sites, NAT66 SNAT applies directly)
+
+use std::net::Ipv6Addr;
+use std::process::Command;
+
+use super::super::provision::bridge_name;
+
+/// Jool instance name for a NAT gateway, derived from VPC ID hash.
+pub fn jool_instance_name(vpc_id: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let hash = Sha256::digest(vpc_id.as_bytes());
+    format!("nk-{}", hex::encode(&hash[..3]))
+}
+
+/// Check if the Jool kernel module is available.
+pub fn jool_available() -> bool {
+    Command::new("modprobe")
+        .args(["--dry-run", "jool"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Derive a ULA IPv6 gateway address for internal use on a VPC bridge.
+pub fn bridge_ipv6_gateway(vpc_cidr: &str) -> Ipv6Addr {
+    use sha2::{Digest, Sha256};
+    let hash = Sha256::digest(vpc_cidr.as_bytes());
+    let seg2 = u16::from_be_bytes([hash[0], hash[1]]);
+    let seg3 = u16::from_be_bytes([hash[2], hash[3]]);
+    Ipv6Addr::new(0xfd00, 0x6e61, seg2, seg3, 0, 0, 0, 1)
+}
+
+/// Derive a ULA IPv6 for a VM inside the VPC bridge.
+pub fn bridge_ipv6_vm(vpc_cidr: &str, vm_index: u16) -> Ipv6Addr {
+    use sha2::{Digest, Sha256};
+    let hash = Sha256::digest(vpc_cidr.as_bytes());
+    let seg2 = u16::from_be_bytes([hash[0], hash[1]]);
+    let seg3 = u16::from_be_bytes([hash[2], hash[3]]);
+    Ipv6Addr::new(0xfd00, 0x6e61, seg2, seg3, 0, 0, 0, 2 + vm_index)
+}
+
+/// Provision NAT gateway for a VPC.
+pub fn ensure_nat_gateway(
+    vpc_id: &str,
+    vpc_cidr: &str,
+    vni: u32,
+    public_ipv6: &Ipv6Addr,
+    public_interface: &str,
+) -> anyhow::Result<()> {
+    let instance = jool_instance_name(vpc_id);
+    let br = bridge_name(vpc_id);
+    let table = vni.to_string();
+
+    // ── 1. Enable forwarding ──
+    let _ = run_cmd("sysctl", &["-w", "net.ipv4.ip_forward=1"]);
+    let _ = run_cmd("sysctl", &["-w", "net.ipv6.conf.all.forwarding=1"]);
+    let _ = run_cmd("sysctl", &["-w", "net.ipv4.conf.all.rp_filter=0"]);
+
+    // ── 2. Default route in VPC routing table via host gateway ──
+    if let Some(gw) = detect_default_gateway() {
+        let _ = run_cmd(
+            "ip",
+            &[
+                "route", "replace", "default", "via", &gw, "dev", public_interface,
+                "table", &table,
+            ],
+        );
+    }
+
+    // ── 2b. ip rule: return traffic for VPC CIDR uses VPC routing table ──
+    let _ = run_cmd(
+        "ip",
+        &["rule", "add", "to", vpc_cidr, "lookup", &table, "priority", "32763"],
+    );
+
+    // ── 3. NAT44 MASQUERADE for IPv4 outbound (fallback) ──
+    ensure_nft_nat4(public_interface)?;
+
+    // ── 4. Jool NAT64 ──
+    let _ = run_cmd("modprobe", &["jool"]);
+    let addr_cidr = format!("{}/128", public_ipv6);
+    let _ = run_cmd(
+        "ip",
+        &["-6", "addr", "add", &addr_cidr, "dev", public_interface],
+    );
+    let _ = run_cmd(
+        "jool",
+        &["instance", "add", &instance, "--netfilter", "--pool6", "64:ff9b::/96"],
+    );
+
+    // ── 5. NAT66 SNAT: VM IPv6 traffic from this VPC exits with its NAT GW public IPv6 ──
+    ensure_nft_nat6(&br, public_ipv6, public_interface)?;
+
+    // ── 6. DNS64 resolver on the bridge ──
+    ensure_dns64(&br, vpc_cidr)?;
+
+    // ── 7. Fix host isolation: allow NDP + DNS + established replies ──
+    fix_host_isolation()?;
+
+    Ok(())
+}
+
+/// Remove NAT gateway provisioning for a VPC.
+pub fn remove_nat_gateway(
+    vpc_id: &str,
+    public_ipv6: &Ipv6Addr,
+    public_interface: &str,
+) -> anyhow::Result<()> {
+    let instance = jool_instance_name(vpc_id);
+    let _ = run_cmd("jool", &["instance", "remove", &instance]);
+    let addr_cidr = format!("{}/128", public_ipv6);
+    let _ = run_cmd(
+        "ip",
+        &["-6", "addr", "del", &addr_cidr, "dev", public_interface],
+    );
+    Ok(())
+}
+
+/// Detect the host's default IPv4 gateway.
+fn detect_default_gateway() -> Option<String> {
+    let output = Command::new("ip")
+        .args(["route", "show", "default"])
+        .output()
+        .ok()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parts: Vec<&str> = stdout.split_whitespace().collect();
+    for window in parts.windows(2) {
+        if window[0] == "via" {
+            return Some(window[1].to_string());
+        }
+    }
+    None
+}
+
+/// Detect the IPv4 address assigned to a bridge interface.
+fn detect_bridge_ipv4(bridge: &str) -> Option<String> {
+    let output = Command::new("ip")
+        .args(["-4", "addr", "show", "dev", bridge])
+        .output()
+        .ok()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("inet ") {
+            if let Some(addr) = rest.split('/').next() {
+                return Some(addr.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// NAT44: MASQUERADE for IPv4 traffic from VPC bridges.
+fn ensure_nft_nat4(out_iface: &str) -> anyhow::Result<()> {
+    let _ = run_nft("add table ip nauka_nat4");
+    let _ = run_nft(
+        "add chain ip nauka_nat4 postrouting { type nat hook postrouting priority 100 ; }",
+    );
+    let existing = Command::new("nft")
+        .args(["list", "chain", "ip", "nauka_nat4", "postrouting"])
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).contains("masquerade"))
+        .unwrap_or(false);
+    if !existing {
+        run_nft(&format!(
+            "add rule ip nauka_nat4 postrouting iifname \"nkb-*\" oifname \"{}\" masquerade",
+            out_iface
+        ))?;
+    }
+    Ok(())
+}
+
+/// NAT66: SNAT VM IPv6 traffic from a specific VPC bridge to the NAT GW's public IPv6.
+fn ensure_nft_nat6(
+    vpc_bridge: &str,
+    public_ipv6: &Ipv6Addr,
+    out_iface: &str,
+) -> anyhow::Result<()> {
+    let _ = run_nft("add table ip6 nauka_nat");
+    let _ = run_nft(
+        "add chain ip6 nauka_nat postrouting { type nat hook postrouting priority 100 ; }",
+    );
+    let ipv6_str = public_ipv6.to_string();
+    let existing = Command::new("nft")
+        .args(["list", "chain", "ip6", "nauka_nat", "postrouting"])
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).contains(&ipv6_str))
+        .unwrap_or(false);
+    if !existing {
+        // SNAT traffic from this VPC's bridge to its dedicated public IPv6
+        run_nft(&format!(
+            "add rule ip6 nauka_nat postrouting iifname \"{}\" oifname \"{}\" snat to {}",
+            vpc_bridge, out_iface, public_ipv6
+        ))?;
+    }
+    Ok(())
+}
+
+/// Fix the host isolation rules to allow NAT Gateway traffic through.
+///
+/// The default host isolation drops ALL output to VPC bridges. NAT Gateway
+/// needs: NDP (IPv6 neighbor discovery), DNS replies, and conntrack return traffic.
+fn fix_host_isolation() -> anyhow::Result<()> {
+    // Check if the nauka table has the raw drop rule
+    let output = Command::new("nft")
+        .args(["list", "chain", "inet", "nauka", "output"])
+        .output();
+    let has_raw_drop = output
+        .as_ref()
+        .map(|o| {
+            let s = String::from_utf8_lossy(&o.stdout);
+            s.contains("oifname") && s.contains("drop") && !s.contains("ct state")
+        })
+        .unwrap_or(false);
+
+    if has_raw_drop {
+        // Replace with a smarter rule set that allows NAT GW traffic
+        let _ = run_nft("flush chain inet nauka output");
+        let _ = run_nft(
+            "add rule inet nauka output oifname \"nkb-*\" ct state established,related accept",
+        );
+        let _ = run_nft("add rule inet nauka output oifname \"nkb-*\" udp sport 53 accept");
+        let _ = run_nft("add rule inet nauka output oifname \"nkb-*\" tcp sport 53 accept");
+        let _ = run_nft("add rule inet nauka output oifname \"nkb-*\" icmpv6 type { nd-neighbor-solicit, nd-neighbor-advert, nd-router-advert } accept");
+        let _ = run_nft("add rule inet nauka output oifname \"nkb-*\" drop");
+    }
+
+    Ok(())
+}
+
+/// Install and configure unbound as a DNS64 resolver on the bridge.
+fn ensure_dns64(bridge: &str, vpc_cidr: &str) -> anyhow::Result<()> {
+    if !Command::new("which")
+        .arg("unbound")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+    {
+        let _ = run_cmd("apt-get", &["install", "-y", "-qq", "unbound"]);
+    }
+
+    let gw_ipv4 = detect_bridge_ipv4(bridge).unwrap_or_else(|| "10.0.1.1".to_string());
+    let gw_ipv6 = bridge_ipv6_gateway(vpc_cidr);
+
+    // Add ULA IPv6 to bridge
+    let _ = run_cmd(
+        "ip",
+        &["-6", "addr", "add", &format!("{}/64", gw_ipv6), "dev", bridge],
+    );
+
+    // Clean old nauka DNS64 configs to avoid conflicts
+    if let Ok(entries) = std::fs::read_dir("/etc/unbound/unbound.conf.d") {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if name_str.starts_with("nauka-dns64-") && !name_str.contains(bridge) {
+                let _ = std::fs::remove_file(entry.path());
+            }
+        }
+    }
+
+    let conf = format!(
+        r#"server:
+    interface: {gw_ipv4}
+    interface: {gw_ipv6}
+    access-control: 0.0.0.0/0 allow
+    access-control: ::/0 allow
+    do-ip6: yes
+    module-config: "dns64 iterator"
+    dns64-prefix: 64:ff9b::/96
+    verbosity: 0
+
+forward-zone:
+    name: "."
+    forward-addr: 8.8.8.8
+    forward-addr: 1.1.1.1
+"#,
+    );
+
+    let conf_path = format!("/etc/unbound/unbound.conf.d/nauka-dns64-{}.conf", bridge);
+    std::fs::write(&conf_path, conf)?;
+
+    let _ = run_cmd("systemctl", &["restart", "unbound"]);
+
+    Ok(())
+}
+
+fn run_cmd(cmd: &str, args: &[&str]) -> anyhow::Result<()> {
+    let output = Command::new(cmd).args(args).output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("{} {} failed: {}", cmd, args.join(" "), stderr.trim());
+    }
+    Ok(())
+}
+
+fn run_nft(rule: &str) -> anyhow::Result<()> {
+    let output = Command::new("nft").arg(rule).output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("nft failed: {}", stderr.trim());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jool_instance_name_deterministic() {
+        let a = jool_instance_name("vpc-01ABCDEF");
+        let b = jool_instance_name("vpc-01ABCDEF");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn jool_instance_name_within_limits() {
+        let name = jool_instance_name("vpc-01ABCDEFGHIJKLMNOP");
+        assert!(name.len() <= 15, "name too long: {}", name);
+    }
+
+    #[test]
+    fn jool_instance_name_different_vpcs() {
+        let a = jool_instance_name("vpc-aaa");
+        let b = jool_instance_name("vpc-bbb");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn bridge_ipv6_gateway_deterministic() {
+        let a = bridge_ipv6_gateway("10.0.0.0/16");
+        let b = bridge_ipv6_gateway("10.0.0.0/16");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn bridge_ipv6_different_cidrs() {
+        let a = bridge_ipv6_gateway("10.0.0.0/16");
+        let b = bridge_ipv6_gateway("10.1.0.0/16");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn bridge_ipv6_vm_different_from_gateway() {
+        let gw = bridge_ipv6_gateway("10.0.0.0/16");
+        let vm = bridge_ipv6_vm("10.0.0.0/16", 0);
+        assert_ne!(gw, vm);
+    }
+}

--- a/layers/network/src/vpc/natgw/store.rs
+++ b/layers/network/src/vpc/natgw/store.rs
@@ -87,7 +87,11 @@ impl NatGwStore {
             if let Some(vpc) = vpc_store.get(vpc_ref, org_name).await? {
                 let idx_key = format!("{}/{}", vpc.meta.id, name_or_id);
                 if let Some(id) = self.db.get::<String>(NS_NATGW_IDX, &idx_key).await? {
-                    return self.db.get::<NatGw>(NS_NATGW, &id).await.map_err(Into::into);
+                    return self
+                        .db
+                        .get::<NatGw>(NS_NATGW, &id)
+                        .await
+                        .map_err(Into::into);
                 }
             }
         }

--- a/layers/network/src/vpc/natgw/store.rs
+++ b/layers/network/src/vpc/natgw/store.rs
@@ -1,0 +1,167 @@
+use nauka_core::id::NatGwId;
+use nauka_core::resource::ResourceMeta;
+use nauka_hypervisor::controlplane::ClusterDb;
+
+use super::ipv6_alloc;
+use super::types::{NatGw, NatGwState};
+
+const NS_NATGW: &str = "natgw";
+const NS_NATGW_IDX: &str = "natgw-idx";
+const REG_NATGWS: (&str, &str) = ("_reg", "natgw-ids");
+
+pub struct NatGwStore {
+    db: ClusterDb,
+}
+
+impl NatGwStore {
+    pub fn new(db: ClusterDb) -> Self {
+        Self { db }
+    }
+
+    /// Create a NAT gateway for a VPC.
+    ///
+    /// Requires that the selected hypervisor has an `ipv6_block` configured.
+    /// Only one NAT gateway per VPC is allowed.
+    pub async fn create(
+        &self,
+        name: &str,
+        vpc_name_or_id: &str,
+        org_name: &str,
+        hypervisor_id: &str,
+        ipv6_block: &str,
+    ) -> anyhow::Result<NatGw> {
+        let vpc_store = crate::vpc::store::VpcStore::new(self.db.clone());
+        let vpc = vpc_store
+            .get(vpc_name_or_id, Some(org_name))
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("vpc '{vpc_name_or_id}' not found"))?;
+
+        // Check: one NAT GW per VPC
+        let existing = self.list_by_vpc(Some(&vpc.meta.id)).await?;
+        if !existing.is_empty() {
+            anyhow::bail!(
+                "vpc '{}' already has a NAT gateway '{}'",
+                vpc.meta.name,
+                existing[0].meta.name
+            );
+        }
+
+        let nat_gw_id = NatGwId::generate();
+
+        // Allocate a public IPv6 from the hypervisor's /64 block
+        let public_ipv6 =
+            ipv6_alloc::allocate(&self.db, hypervisor_id, ipv6_block, nat_gw_id.as_str()).await?;
+
+        let natgw = NatGw {
+            meta: ResourceMeta::new(nat_gw_id.to_string(), name),
+            vpc_id: vpc.meta.id.clone().into(),
+            vpc_name: vpc.meta.name.clone(),
+            public_ipv6,
+            hypervisor_id: hypervisor_id.to_string(),
+            state: NatGwState::Provisioning,
+        };
+
+        // Persist
+        self.db.put(NS_NATGW, &natgw.meta.id, &natgw).await?;
+        let idx_key = format!("{}/{}", vpc.meta.id, name);
+        self.db.put(NS_NATGW_IDX, &idx_key, &natgw.meta.id).await?;
+        add_id(&self.db, &natgw.meta.id).await?;
+
+        Ok(natgw)
+    }
+
+    pub async fn get(
+        &self,
+        name_or_id: &str,
+        vpc_name_or_id: Option<&str>,
+        org_name: Option<&str>,
+    ) -> anyhow::Result<Option<NatGw>> {
+        // Try direct ID lookup first
+        if let Some(natgw) = self.db.get::<NatGw>(NS_NATGW, name_or_id).await? {
+            return Ok(Some(natgw));
+        }
+
+        // Try index lookup by vpc + name
+        if let Some(vpc_ref) = vpc_name_or_id {
+            let vpc_store = crate::vpc::store::VpcStore::new(self.db.clone());
+            if let Some(vpc) = vpc_store.get(vpc_ref, org_name).await? {
+                let idx_key = format!("{}/{}", vpc.meta.id, name_or_id);
+                if let Some(id) = self.db.get::<String>(NS_NATGW_IDX, &idx_key).await? {
+                    return self.db.get::<NatGw>(NS_NATGW, &id).await.map_err(Into::into);
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    pub async fn list(&self, vpc_name: Option<&str>) -> anyhow::Result<Vec<NatGw>> {
+        let all = self.list_by_vpc(None).await?;
+        match vpc_name {
+            Some(name) => Ok(all
+                .into_iter()
+                .filter(|n| n.vpc_name == name || n.vpc_id.as_str() == name)
+                .collect()),
+            None => Ok(all),
+        }
+    }
+
+    async fn list_by_vpc(&self, vpc_id: Option<&str>) -> anyhow::Result<Vec<NatGw>> {
+        let ids = load_ids(&self.db).await?;
+        let mut items = Vec::new();
+        for id in &ids {
+            if let Some(natgw) = self.db.get::<NatGw>(NS_NATGW, id).await? {
+                if let Some(vid) = vpc_id {
+                    if natgw.vpc_id.as_str() == vid {
+                        items.push(natgw);
+                    }
+                } else {
+                    items.push(natgw);
+                }
+            }
+        }
+        Ok(items)
+    }
+
+    pub async fn delete(
+        &self,
+        name_or_id: &str,
+        vpc_name: &str,
+        org_name: &str,
+    ) -> anyhow::Result<()> {
+        let natgw = self
+            .get(name_or_id, Some(vpc_name), Some(org_name))
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("nat-gateway '{name_or_id}' not found"))?;
+
+        // Release the allocated IPv6
+        ipv6_alloc::release(&self.db, &natgw.hypervisor_id, &natgw.meta.id).await?;
+
+        // Remove from store
+        let idx_key = format!("{}/{}", natgw.vpc_id.as_str(), natgw.meta.name);
+        self.db.delete(NS_NATGW, &natgw.meta.id).await?;
+        self.db.delete(NS_NATGW_IDX, &idx_key).await?;
+        remove_id(&self.db, &natgw.meta.id).await?;
+
+        Ok(())
+    }
+}
+
+async fn load_ids(db: &ClusterDb) -> anyhow::Result<Vec<String>> {
+    let ids: Option<Vec<String>> = db.get(REG_NATGWS.0, REG_NATGWS.1).await?;
+    Ok(ids.unwrap_or_default())
+}
+
+async fn add_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
+    let mut ids = load_ids(db).await?;
+    ids.push(id.to_string());
+    db.put(REG_NATGWS.0, REG_NATGWS.1, &ids).await?;
+    Ok(())
+}
+
+async fn remove_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
+    let mut ids = load_ids(db).await?;
+    ids.retain(|i| i != id);
+    db.put(REG_NATGWS.0, REG_NATGWS.1, &ids).await?;
+    Ok(())
+}

--- a/layers/network/src/vpc/natgw/types.rs
+++ b/layers/network/src/vpc/natgw/types.rs
@@ -1,0 +1,53 @@
+use std::net::Ipv6Addr;
+
+use nauka_core::id::VpcId;
+use nauka_core::resource::{ApiResource, ResourceMeta};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum NatGwState {
+    #[serde(rename = "provisioning")]
+    Provisioning,
+    #[serde(rename = "active")]
+    Active,
+    #[serde(rename = "error")]
+    Error,
+}
+
+impl std::fmt::Display for NatGwState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Provisioning => write!(f, "provisioning"),
+            Self::Active => write!(f, "active"),
+            Self::Error => write!(f, "error"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NatGw {
+    #[serde(flatten)]
+    pub meta: ResourceMeta,
+    pub vpc_id: VpcId,
+    pub vpc_name: String,
+    /// Dedicated public IPv6 address for this NAT gateway's outbound traffic.
+    pub public_ipv6: Ipv6Addr,
+    /// Hypervisor where this NAT gateway is provisioned.
+    pub hypervisor_id: String,
+    pub state: NatGwState,
+}
+
+impl ApiResource for NatGw {
+    fn meta(&self) -> &ResourceMeta {
+        &self.meta
+    }
+    fn resource_fields(&self) -> serde_json::Value {
+        serde_json::json!({
+            "vpc_id": self.vpc_id.as_str(),
+            "vpc_name": self.vpc_name,
+            "public_ipv6": self.public_ipv6.to_string(),
+            "hypervisor_id": self.hypervisor_id,
+            "state": self.state.to_string(),
+        })
+    }
+}

--- a/layers/network/src/vpc/store.rs
+++ b/layers/network/src/vpc/store.rs
@@ -129,6 +129,16 @@ impl VpcStore {
             );
         }
 
+        // Check for child NAT gateways
+        let natgw_store = super::natgw::store::NatGwStore::new(self.db.clone());
+        let natgws = natgw_store.list(Some(&vpc.meta.name)).await?;
+        if !natgws.is_empty() {
+            anyhow::bail!(
+                "vpc '{}' has a NAT gateway. Delete it first.",
+                vpc.meta.name,
+            );
+        }
+
         let idx_key = format!("{}/{}", vpc.org_id.as_str(), vpc.meta.name);
         self.db.delete(NS_VPC, &vpc.meta.id).await?;
         self.db.delete(NS_VPC_IDX, &idx_key).await?;


### PR DESCRIPTION
## Summary
- Add NAT gateway module in the network layer (handlers, store, IPv6 allocation, provisioning, types)
- Wire NAT64 (Jool) + NAT66 (SNAT) + NAT44 (MASQUERADE) + DNS64 for full IPv4/IPv6 outbound from VMs
- Add forge reconciler for NAT gateway lifecycle management
- Update hypervisor fabric (mesh, ops, health, state) and compute runtime (gvisor, VM provisioning) to route traffic through NAT gateways

## Test plan
- [x] Tested on real Hetzner servers — VMs can reach IPv4 and IPv6 destinations through NAT gateway