### PR TITLE
docs: NAT gateway, fix runtime naming, broken link, remove stubs

### DIFF
--- a/docs/src/content/docs/cloud/compute/instances.mdx
+++ b/docs/src/content/docs/cloud/compute/instances.mdx
@@ -1,6 +1,0 @@
----
-title: Instances
-description: Create and manage compute instances.
----
-
-Compute instances documentation.

--- a/docs/src/content/docs/cloud/index.mdx
+++ b/docs/src/content/docs/cloud/index.mdx
@@ -1,6 +1,0 @@
----
-title: Nauka Cloud
-description: Deploy your applications on Nauka Cloud.
----
-
-Welcome to Nauka Cloud documentation.

--- a/docs/src/content/docs/cloud/networking/vpc.mdx
+++ b/docs/src/content/docs/cloud/networking/vpc.mdx
@@ -1,6 +1,0 @@
----
-title: VPC
-description: Virtual private clouds.
----
-
-VPC documentation.

--- a/docs/src/content/docs/cloud/storage/volumes.mdx
+++ b/docs/src/content/docs/cloud/storage/volumes.mdx
@@ -1,6 +1,0 @@
----
-title: Volumes
-description: Block storage volumes.
----
-
-Volumes documentation.

--- a/layers/compute/src/runtime/overview.mdx
+++ b/layers/compute/src/runtime/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Runtime
-description: Dual compute runtime — Cloud Hypervisor (KVM) on bare-metal, gVisor on VPS.
+description: Dual compute runtime — Cloud Hypervisor (KVM) on bare-metal, crun (OCI containers) on VPS.
 sidebar:
   order: 4
 ---
@@ -10,7 +10,7 @@ Nauka automatically detects the compute capability of each node and selects the 
 | Node type | `/dev/kvm` | Runtime | Isolation |
 |---|---|---|---|
 | Bare-metal (Hetzner dedicated) | Present | **Cloud Hypervisor** | Hardware (VT-x/AMD-V) |
-| VPS (Hetzner cloud, no nested virt) | Absent | **gVisor (runsc)** | Userspace kernel |
+| VPS (Hetzner cloud, no nested virt) | Absent | **crun (OCI container)** | Linux namespaces + cgroups |
 
 ## How it works
 
@@ -35,12 +35,12 @@ nauka vm create web-1 --org acme --project backend --env production \
 ```
 
 On bare-metal: Cloud Hypervisor starts a real VM with its own kernel.
-On VPS: gVisor starts a sandboxed container with a userspace kernel.
+On VPS: crun starts an OCI container with Linux namespace isolation.
 
 ## Security comparison
 
 - **Cloud Hypervisor (KVM)**: hardware-enforced isolation. Each VM has its own kernel, memory space, and virtual hardware. Strongest isolation possible.
-- **gVisor (runsc)**: reimplements ~200 Linux syscalls in Go. The container sees a fake kernel (Sentry) that intercepts all syscalls and makes only ~70 restricted calls to the real host kernel. Much stronger than plain containers (runc/crun).
+- **crun (OCI container)**: lightweight C-based OCI runtime using Linux namespaces (pid, net, mount, ipc, uts) and cgroups for resource limits. Each container gets its own network namespace with a veth pair, overlay filesystem, and SSH access via nsenter.
 
 ## Checking the runtime
 

--- a/layers/network/src/overview.mdx
+++ b/layers/network/src/overview.mdx
@@ -13,12 +13,14 @@ The network layer provides virtual networking on top of the WireGuard mesh. Ever
 VPC (prod-net, CIDR 10.0.0.0/16, VNI 100)
 ├── Subnet (web, 10.0.1.0/24, gateway 10.0.1.1)
 ├── Subnet (api, 10.0.2.0/24, gateway 10.0.2.1)
-└── Peering → partner-net
+├── Peering → partner-net
+└── NAT Gateway (egress, public IPv6 2a01:4f8:...:abcd)
 ```
 
 - **VPC** — an isolated L2 network backed by a VXLAN tunnel. Each VPC gets a unique VNI (VXLAN Network Identifier). Traffic between VPCs is blocked unless peered.
 - **Subnet** — an IP allocation range within a VPC. Subnets are cross-zone (a VM in any zone can use any subnet).
 - **Peering** — connects two VPCs so their VMs can communicate. CIDRs must not overlap.
+- **NAT Gateway** — gives VMs outbound internet access via a dedicated public IPv6 with NAT64, NAT66, and DNS64.
 
 ## VPC scoping
 
@@ -47,4 +49,7 @@ nauka vpc subnet create api --vpc prod-net --cidr 10.0.2.0/24
 
 # Peer two VPCs
 nauka vpc peering create --vpc prod-net --peer-vpc staging-net
+
+# Add a NAT gateway for outbound internet
+nauka vpc nat-gateway create egress --vpc prod-net --org acme
 ```

--- a/layers/network/src/vpc/natgw/overview.mdx
+++ b/layers/network/src/vpc/natgw/overview.mdx
@@ -1,0 +1,123 @@
+---
+title: NAT Gateway
+description: Outbound internet access for VMs via dedicated public IPv6 addresses, with NAT64, NAT66, and DNS64.
+sidebar:
+  order: 5
+---
+
+A NAT gateway gives VMs inside a VPC outbound internet access. Each NAT gateway gets a dedicated public IPv6 address from the hypervisor's `/64` block and provisions a full translation stack so VMs can reach both IPv4 and IPv6 destinations.
+
+## How it works
+
+VMs in a VPC have only private (RFC 1918) IPv4 addresses and ULA IPv6 addresses. They cannot reach the internet directly. A NAT gateway bridges that gap using four components:
+
+```
+VM resolves example.com
+  │
+  ▼
+DNS64 (unbound on bridge)
+  synthesizes AAAA: 64:ff9b::93.184.216.34
+  │
+  ▼
+VM sends IPv6 packet to 64:ff9b::93.184.216.34
+  │
+  ▼
+Jool NAT64 (kernel module)
+  translates IPv6 → IPv4, exits via public interface
+  │
+  ▼
+NAT66 SNAT (nftables)
+  pins NAT GW's public IPv6 as source for native IPv6 traffic
+  │
+  ▼
+NAT44 MASQUERADE (nftables)
+  fallback for direct IPv4 outbound
+```
+
+| Component | Role |
+|---|---|
+| **DNS64** (unbound) | Synthesizes AAAA records using the `64:ff9b::/96` prefix for IPv4-only domains |
+| **Jool NAT64** | Kernel module that translates `64:ff9b::` IPv6 packets to IPv4 |
+| **NAT66 SNAT** | Pins the NAT gateway's public IPv6 as the source address for all VM IPv6 traffic |
+| **NAT44 MASQUERADE** | Fallback masquerade for any direct IPv4 traffic from VPC bridges |
+
+## Creating a NAT gateway
+
+```bash
+nauka vpc nat-gateway create egress --vpc prod-net --org acme
+```
+
+```
+  Name:            egress
+  ID:              nat-01JD4X...
+  VPC:             prod-net
+  Public IPv6:     2a01:4f8:c012:abcd:a1b2:c3d4:e5f6:7890
+  Hypervisor:      hv-01JC9K...
+  State:           provisioning
+  Created:         2 seconds ago
+```
+
+The NAT gateway is provisioned on the local hypervisor. The `--hypervisor` flag is optional and defaults to the current node.
+
+## Requirements
+
+- The hypervisor must have an IPv6 block configured (`--ipv6-block` during `nauka hypervisor init`)
+- Only **one NAT gateway per VPC** is allowed
+- The Jool kernel module must be available (`modprobe jool`)
+- The `unbound` DNS resolver is installed automatically if missing
+
+## IPv6 address allocation
+
+Each NAT gateway gets a `/128` address derived deterministically from the hypervisor's `/64` block:
+
+1. The hypervisor is initialized with a public `/64` block (e.g., `2a01:4f8:c012:abcd::/64`)
+2. When a NAT gateway is created, SHA-256 of its resource ID fills the lower 64 bits (interface ID)
+3. The resulting address is unique per NAT gateway and stable across restarts
+
+Allocations are tracked in TiKV and released on deletion.
+
+## What gets provisioned
+
+When the Forge reconciler runs, it calls `ensure_nat_gateway` for each NAT gateway assigned to the local node. This sets up:
+
+1. **IP forwarding** enabled (`sysctl net.ipv4.ip_forward`, `net.ipv6.conf.all.forwarding`)
+2. **VPC routing table** with a default route via the host's gateway
+3. **Policy routing rule** so return traffic for the VPC CIDR uses the VPC table
+4. **NAT44** nftables masquerade chain (`nauka_nat4`) for IPv4 outbound
+5. **Jool NAT64** instance with `64:ff9b::/96` pool, public IPv6 assigned to the public interface
+6. **NAT66** nftables SNAT chain (`nauka_nat`) pinning the VPC bridge to the NAT gateway's public IPv6
+7. **DNS64** unbound config on the bridge gateway (listens on both IPv4 and ULA IPv6)
+8. **Host isolation fix** replaces the blanket drop rule with smart rules allowing established/related traffic, DNS replies, and NDP
+
+## Listing NAT gateways
+
+```bash
+# All NAT gateways for a VPC
+nauka vpc nat-gateway list --vpc prod-net
+
+# All NAT gateways across all VPCs
+nauka vpc nat-gateway list
+```
+
+## Getting details
+
+```bash
+nauka vpc nat-gateway get egress --vpc prod-net --org acme
+```
+
+## Deleting a NAT gateway
+
+```bash
+nauka vpc nat-gateway delete egress --vpc prod-net --org acme
+```
+
+Deletion releases the allocated IPv6 address, removes the Jool instance, and cleans up the nftables rules. The Forge will remove the remaining provisioned state on its next reconcile cycle.
+
+## Naming conventions
+
+| Resource | Name pattern | Example |
+|---|---|---|
+| Jool instance | `nk-{SHA256(vpc_id)[0:3]}` | `nk-a1b2c3` |
+| Bridge ULA IPv6 | `fd00:6e61:{hash}::1` | `fd00:6e61:c012:abcd::1` |
+| DNS64 config | `/etc/unbound/unbound.conf.d/nauka-dns64-{bridge}.conf` | `nauka-dns64-nkb-a1b2c3.conf` |
+| nftables tables | `nauka_nat4` (IPv4), `nauka_nat` (IPv6) | |

--- a/layers/state/src/overview.mdx
+++ b/layers/state/src/overview.mdx
@@ -57,7 +57,7 @@ In all of these cases, the node may not yet have connectivity to the cluster dat
 
 Once the mesh is established and TiKV is running, all shared state moves to the cluster store. This includes resources like virtual machines, VPCs, networks, subnets, users, and volumes.
 
-The cluster store is covered in detail on the [Cluster Store](/contributing/cluster) page.
+The cluster store is covered in detail on the [Cluster Store](/layers/state/cluster/) page.
 
 ## Separation of concerns
 


### PR DESCRIPTION
## Summary
- Add full NAT gateway documentation: provisioning flow, DNS64/NAT64/NAT66/NAT44 stack, IPv6 allocation, CLI usage, naming conventions
- Fix runtime docs inconsistency: gVisor (runsc) → crun (OCI container) to match actual implementation
- Fix broken internal link in state layer overview (`/contributing/cluster` → `/layers/state/cluster/`)
- Remove 4 empty cloud/ placeholder stubs (1-2 lines each, not wired into sidebar)
- Update network layer overview to include NAT gateway in architecture diagram and quick start

## Test plan
- [x] `npx astro build` passes (96 pages)
- [x] NAT gateway page renders at `/layers/network/vpc/natgw/overview/`
- [x] Broken link fixed — points to existing cluster store page