### PR TITLE
fix: transition VM state from pending to running after start

### DIFF
--- a/layers/forge/src/reconciler/vm.rs
+++ b/layers/forge/src/reconciler/vm.rs
@@ -87,6 +87,22 @@ impl super::Reconciler for VmReconciler {
                 }
             }
 
+            // If process is already running but state is pending, correct it
+            if actual_processes.contains(&vm.meta.id) {
+                if vm.state == VmState::Pending {
+                    if let Err(e) = vm_store
+                        .update_state(&vm.meta.id, VmState::Running, None, None, None)
+                        .await
+                    {
+                        tracing::error!(vm_id = vm.meta.id.as_str(), error = %e, "failed to correct VM state");
+                    } else {
+                        tracing::info!(vm_id = vm.meta.id.as_str(), "corrected state: pending -> running");
+                        result.updated += 1;
+                    }
+                }
+                continue;
+            }
+
             // Ensure process is running
             if !actual_processes.contains(&vm.meta.id) {
                 let subnet_store =
@@ -131,6 +147,14 @@ impl super::Reconciler for VmReconciler {
                             runtime = %ctx.runtime,
                             "VM process started"
                         );
+                        if vm.state == VmState::Pending {
+                            if let Err(e) = vm_store
+                                .update_state(&vm.meta.id, VmState::Running, None, None, None)
+                                .await
+                            {
+                                tracing::error!(vm_id = vm.meta.id.as_str(), error = %e, "failed to update VM state");
+                            }
+                        }
                         result.created += 1;
                     }
                     Err(e) => {

--- a/layers/forge/src/reconciler/vm.rs
+++ b/layers/forge/src/reconciler/vm.rs
@@ -96,7 +96,10 @@ impl super::Reconciler for VmReconciler {
                     {
                         tracing::error!(vm_id = vm.meta.id.as_str(), error = %e, "failed to correct VM state");
                     } else {
-                        tracing::info!(vm_id = vm.meta.id.as_str(), "corrected state: pending -> running");
+                        tracing::info!(
+                            vm_id = vm.meta.id.as_str(),
+                            "corrected state: pending -> running"
+                        );
                         result.updated += 1;
                     }
                 }


### PR DESCRIPTION
## Summary
- Forge VM reconciler started VM processes but never updated their state in TiKV, leaving all VMs stuck in `pending` forever
- Added state correction on each reconcile cycle: if process is alive but state is `pending`, transition to `running`
- Added state transition after `rt.start()` succeeds

Closes #78

## Test plan
- [x] Built and deployed to 4-node Hetzner cluster (nauka-nbg-1 through nauka-nbg-4)
- [x] Ran `nauka forge reconcile` — 4 VMs transitioned from `pending` to `running`
- [x] Verified with `nauka vm list` — all 4 VMs now show `running`

🤖 Generated with [Claude Code](https://claude.com/claude-code)