### PR TITLE
fix: set correct OutputKind for vm image pull and list

### DIFF
--- a/layers/compute/src/image/handlers.rs
+++ b/layers/compute/src/image/handlers.rs
@@ -18,9 +18,11 @@ pub fn resource_def() -> ResourceDef {
                 "name",
                 FieldDef::string("name", "Image name (e.g., ubuntu-24.04)"),
             ))
+            .with_output(OutputKind::Resource)
             .with_example("nauka vm image pull ubuntu-24.04")
         })
         .action("list", "List locally available images")
+        .op(|op| op.with_output(OutputKind::ResourceList))
         .action("delete", "Delete a local image")
         .op(|op| {
             op.with_arg(OperationArg::required(


### PR DESCRIPTION
## Summary
- `nauka vm image pull` and `nauka vm image list` produced no output due to OutputKind/OperationResponse mismatch
- Added `.with_output(OutputKind::Resource)` on `pull` and `.with_output(OutputKind::ResourceList)` on `list`

Closes #77

## Test plan
- [x] Built and deployed to 4-node Hetzner cluster
- [x] `nauka vm image list` now shows image info
- [x] `nauka vm image pull --name ubuntu-24.04` now shows image info

🤖 Generated with [Claude Code](https://claude.com/claude-code)