### PR TITLE
fix: consistent CLI output for image, vm start/stop, peering create

### DIFF
--- a/layers/compute/src/image/handlers.rs
+++ b/layers/compute/src/image/handlers.rs
@@ -30,6 +30,18 @@ pub fn resource_def() -> ResourceDef {
                 FieldDef::string("name", "Image name to delete"),
             ))
         })
+        .column("NAME", "name")
+        .column("STATUS", "status")
+        .column("SIZE", "size")
+        .empty_message("No images found. Pull one with: nauka vm image pull ubuntu-24.04")
+        .detail_section(
+            None,
+            vec![
+                DetailField::new("Name", "name"),
+                DetailField::new("Status", "status"),
+                DetailField::new("Size", "size"),
+            ],
+        )
         .done()
 }
 

--- a/layers/compute/src/vm/handlers.rs
+++ b/layers/compute/src/vm/handlers.rs
@@ -75,6 +75,7 @@ pub fn resource_def() -> ResourceDef {
                 "name",
                 FieldDef::string("name", "VM name or ID"),
             ))
+            .with_output(OutputKind::Resource)
         })
         .action("stop", "Stop a running VM")
         .op(|op| {
@@ -82,6 +83,7 @@ pub fn resource_def() -> ResourceDef {
                 "name",
                 FieldDef::string("name", "VM name or ID"),
             ))
+            .with_output(OutputKind::Resource)
         })
         .column("NAME", "name")
         .column_def(ColumnDef::new("STATE", "state").with_format(DisplayFormat::Status))

--- a/layers/network/src/vpc/peering/handlers.rs
+++ b/layers/network/src/vpc/peering/handlers.rs
@@ -16,6 +16,7 @@ pub fn resource_def() -> ResourceDef {
                 "peer-vpc",
                 FieldDef::string("peer-vpc", "VPC to peer with"),
             ))
+            .with_output(OutputKind::Resource)
         })
         .list()
         .get()


### PR DESCRIPTION
## Summary
- **image list**: now renders as table (NAME / STATUS / SIZE) instead of raw JSON
- **image pull**: now renders as detail view instead of raw JSON
- **vm start/stop**: added `OutputKind::Resource` — was silent due to Message/Resource mismatch
- **peering create**: added `OutputKind::Resource` — same mismatch

## Before / After

**`nauka vm image list` before:**
```json
{ "name": "ubuntu-24.04", "size": "105 MB", "status": "ready" }
```

**After:**
```
NAME          STATUS  SIZE
----------------------------
ubuntu-24.04  ready   105 MB
```

## Test plan
- [x] Built and deployed to 4-node Hetzner cluster
- [x] `nauka vm image list` renders as table
- [x] `nauka vm image pull` renders as detail view
- [x] `nauka vm list` and `nauka hypervisor list` still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)