### PR TITLE
feat: add `nauka vm image catalog` to list registry images

### DIFF
--- a/layers/compute/Cargo.toml
+++ b/layers/compute/Cargo.toml
@@ -20,7 +20,7 @@ anyhow.workspace = true
 thiserror.workspace = true
 tikv-client = "0.4"
 libc = "0.2"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }
 futures-util = "0.3"
 
 [dev-dependencies]

--- a/layers/compute/src/image/handlers.rs
+++ b/layers/compute/src/image/handlers.rs
@@ -23,6 +23,8 @@ pub fn resource_def() -> ResourceDef {
         })
         .action("list", "List locally available images")
         .op(|op| op.with_output(OutputKind::ResourceList))
+        .action("catalog", "List images available in the registry")
+        .op(|op| op.with_output(OutputKind::ResourceList))
         .action("delete", "Delete a local image")
         .op(|op| {
             op.with_arg(OperationArg::required(
@@ -31,14 +33,14 @@ pub fn resource_def() -> ResourceDef {
             ))
         })
         .column("NAME", "name")
-        .column("STATUS", "status")
         .column("SIZE", "size")
+        .column("ARCH", "arch")
+        .column("LOCAL", "local")
         .empty_message("No images found. Pull one with: nauka vm image pull ubuntu-24.04")
         .detail_section(
             None,
             vec![
                 DetailField::new("Name", "name"),
-                DetailField::new("Status", "status"),
                 DetailField::new("Size", "size"),
             ],
         )
@@ -58,7 +60,7 @@ pub fn handler() -> HandlerFn {
                             .get("name")
                             .ok_or_else(|| anyhow::anyhow!("--name is required"))?
                             .clone();
-                        let size = registry::pull(&name)?;
+                        let size = registry::pull(&name).await?;
                         Ok(OperationResponse::Resource(serde_json::json!({
                             "name": name,
                             "status": "ready",
@@ -73,8 +75,22 @@ pub fn handler() -> HandlerFn {
                             .map(|(name, size)| {
                                 serde_json::json!({
                                     "name": name,
-                                    "status": "ready",
                                     "size": format_size(*size),
+                                })
+                            })
+                            .collect();
+                        Ok(OperationResponse::ResourceList(items))
+                    }
+                    "catalog" => {
+                        let entries = registry::catalog().await?;
+                        let items: Vec<serde_json::Value> = entries
+                            .iter()
+                            .map(|e| {
+                                serde_json::json!({
+                                    "name": e.name,
+                                    "arch": e.arch,
+                                    "size": format_size(e.size),
+                                    "local": if e.local { "✓" } else { "✗" },
                                 })
                             })
                             .collect();

--- a/layers/compute/src/image/registry.rs
+++ b/layers/compute/src/image/registry.rs
@@ -120,6 +120,57 @@ pub fn list() -> Vec<(String, u64)> {
     .collect()
 }
 
+/// List images available in the remote registry (GitHub Releases).
+pub async fn catalog() -> anyhow::Result<Vec<CatalogEntry>> {
+    let arch = std::env::consts::ARCH;
+    let arch_name = match arch {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        _ => arch,
+    };
+
+    let url = format!("https://api.github.com/repos/{GITHUB_REPO}/releases/tags/latest");
+
+    let client = reqwest::Client::builder().user_agent("nauka").build()?;
+
+    let resp = client.get(&url).send().await?;
+    if !resp.status().is_success() {
+        anyhow::bail!("failed to fetch image catalog from registry");
+    }
+
+    let release: serde_json::Value = resp.json().await?;
+    let assets = release["assets"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("invalid registry response"))?;
+
+    let suffix = format!("-{arch_name}.tar.gz");
+    let mut entries = Vec::new();
+
+    for asset in assets {
+        let filename = asset["name"].as_str().unwrap_or_default();
+        if let Some(name) = filename.strip_suffix(&suffix) {
+            let size = asset["size"].as_u64().unwrap_or(0);
+            let local = exists(name);
+            entries.push(CatalogEntry {
+                name: name.to_string(),
+                arch: arch_name.to_string(),
+                size,
+                local,
+            });
+        }
+    }
+
+    Ok(entries)
+}
+
+/// An image available in the remote registry.
+pub struct CatalogEntry {
+    pub name: String,
+    pub arch: String,
+    pub size: u64,
+    pub local: bool,
+}
+
 /// Check if an image exists locally.
 pub fn exists(name: &str) -> bool {
     Path::new(&format!("{IMAGES_DIR}/{name}/bin/sh")).exists()


### PR DESCRIPTION
## Summary
- New command `nauka vm image catalog` lists all images available in the remote registry
- Shows name, arch, size, and `✓`/`✗` for local availability
- Uses GitHub Releases API to fetch the catalog from `sifrah/nauka-images`

## Output
```
$ nauka vm image catalog
NAME          SIZE   ARCH   LOCAL
---------------------------------
ubuntu-24.04  44 MB  amd64  ✓

$ nauka vm image delete --name ubuntu-24.04
image 'ubuntu-24.04' deleted.

$ nauka vm image catalog
NAME          SIZE   ARCH   LOCAL
---------------------------------
ubuntu-24.04  44 MB  amd64  ✗
```

## Test plan
- [x] Built and deployed to 4-node Hetzner cluster
- [x] `catalog` shows registry images with local status
- [x] `delete` + `catalog` shows `✗` after removal
- [x] `pull` + `catalog` shows `✓` after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)