### PR TITLE
fix: populate arch and local fields in image list output

### DIFF
--- a/layers/compute/src/image/handlers.rs
+++ b/layers/compute/src/image/handlers.rs
@@ -69,6 +69,11 @@ pub fn handler() -> HandlerFn {
                         })))
                     }
                     "list" => {
+                        let arch = match std::env::consts::ARCH {
+                            "x86_64" => "amd64",
+                            "aarch64" => "arm64",
+                            other => other,
+                        };
                         let images = registry::list();
                         let items: Vec<serde_json::Value> = images
                             .iter()
@@ -76,6 +81,8 @@ pub fn handler() -> HandlerFn {
                                 serde_json::json!({
                                     "name": name,
                                     "size": format_size(*size),
+                                    "arch": arch,
+                                    "local": "✓",
                                 })
                             })
                             .collect();


### PR DESCRIPTION
## Summary
- `nauka vm image list` was showing `-` for ARCH and LOCAL columns
- Now correctly shows the current arch and `✓` for all local images

## Test plan
- [x] Deployed and verified on Hetzner cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)