### PR TITLE
feat: image catalog from manifest.json with type column

### DIFF
--- a/layers/compute/src/image/handlers.rs
+++ b/layers/compute/src/image/handlers.rs
@@ -33,6 +33,7 @@ pub fn resource_def() -> ResourceDef {
             ))
         })
         .column("NAME", "name")
+        .column("TYPE", "type")
         .column("SIZE", "size")
         .column("ARCH", "arch")
         .column("LOCAL", "local")
@@ -74,12 +75,18 @@ pub fn handler() -> HandlerFn {
                             "aarch64" => "arm64",
                             other => other,
                         };
+                        let image_type = if std::path::Path::new("/dev/kvm").exists() {
+                            "vm"
+                        } else {
+                            "container"
+                        };
                         let images = registry::list();
                         let items: Vec<serde_json::Value> = images
                             .iter()
                             .map(|(name, size)| {
                                 serde_json::json!({
                                     "name": name,
+                                    "type": image_type,
                                     "size": format_size(*size),
                                     "arch": arch,
                                     "local": "✓",
@@ -95,8 +102,8 @@ pub fn handler() -> HandlerFn {
                             .map(|e| {
                                 serde_json::json!({
                                     "name": e.name,
+                                    "type": e.image_type,
                                     "arch": e.arch,
-                                    "size": format_size(e.size),
                                     "local": if e.local { "✓" } else { "✗" },
                                 })
                             })

--- a/layers/compute/src/image/registry.rs
+++ b/layers/compute/src/image/registry.rs
@@ -31,8 +31,15 @@ pub async fn pull(name: &str) -> anyhow::Result<u64> {
         return Ok(size);
     }
 
+    // Determine image type from runtime (container if gVisor, vm if KVM)
+    let image_type = if Path::new("/dev/kvm").exists() {
+        "vm"
+    } else {
+        "container"
+    };
+
     // Download from GitHub Releases
-    let asset_name = format!("{name}-{arch_name}.tar.gz");
+    let asset_name = format!("{name}-{image_type}-{arch_name}.tar.gz");
     let url = format!("https://github.com/{GITHUB_REPO}/releases/download/latest/{asset_name}");
 
     let tmp_file = format!("/tmp/nauka-image-{name}.tar.gz");
@@ -120,7 +127,7 @@ pub fn list() -> Vec<(String, u64)> {
     .collect()
 }
 
-/// List images available in the remote registry (GitHub Releases).
+/// List images available in the remote registry (from manifest.json).
 pub async fn catalog() -> anyhow::Result<Vec<CatalogEntry>> {
     let arch = std::env::consts::ARCH;
     let arch_name = match arch {
@@ -129,33 +136,48 @@ pub async fn catalog() -> anyhow::Result<Vec<CatalogEntry>> {
         _ => arch,
     };
 
-    let url = format!("https://api.github.com/repos/{GITHUB_REPO}/releases/tags/latest");
+    let url = format!("https://github.com/{GITHUB_REPO}/releases/download/latest/manifest.json");
 
-    let client = reqwest::Client::builder().user_agent("nauka").build()?;
+    let client = reqwest::Client::builder()
+        .user_agent("nauka")
+        .redirect(reqwest::redirect::Policy::limited(10))
+        .build()?;
 
     let resp = client.get(&url).send().await?;
     if !resp.status().is_success() {
         anyhow::bail!("failed to fetch image catalog from registry");
     }
 
-    let release: serde_json::Value = resp.json().await?;
-    let assets = release["assets"]
+    let manifest: serde_json::Value = resp.json().await?;
+    let images = manifest["images"]
         .as_array()
-        .ok_or_else(|| anyhow::anyhow!("invalid registry response"))?;
+        .ok_or_else(|| anyhow::anyhow!("invalid manifest format"))?;
 
-    let suffix = format!("-{arch_name}.tar.gz");
     let mut entries = Vec::new();
 
-    for asset in assets {
-        let filename = asset["name"].as_str().unwrap_or_default();
-        if let Some(name) = filename.strip_suffix(&suffix) {
-            let size = asset["size"].as_u64().unwrap_or(0);
-            let local = exists(name);
+    for image in images {
+        let name = image["name"].as_str().unwrap_or_default();
+        let image_type = image["type"].as_str().unwrap_or("container");
+        let description = image["description"].as_str().unwrap_or_default();
+        let logo = image["logo"].as_str().unwrap_or_default();
+        let archs = image["arch"]
+            .as_array()
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        // Only show images available for this architecture
+        if archs.iter().any(|a| a == arch_name) {
             entries.push(CatalogEntry {
                 name: name.to_string(),
+                image_type: image_type.to_string(),
                 arch: arch_name.to_string(),
-                size,
-                local,
+                description: description.to_string(),
+                logo: logo.to_string(),
+                local: exists(name),
             });
         }
     }
@@ -166,8 +188,10 @@ pub async fn catalog() -> anyhow::Result<Vec<CatalogEntry>> {
 /// An image available in the remote registry.
 pub struct CatalogEntry {
     pub name: String,
+    pub image_type: String,
     pub arch: String,
-    pub size: u64,
+    pub description: String,
+    pub logo: String,
     pub local: bool,
 }
 


### PR DESCRIPTION
## Summary
- `catalog` now reads `manifest.json` from the registry (published by nauka-images CI)
- Added **TYPE** column (container/vm) across all image commands
- `pull` auto-detects image type from runtime: `/dev/kvm` → vm, else container
- New asset naming convention: `{name}-{type}-{arch}.tar.gz`

## Output
```
$ nauka vm image catalog
NAME          TYPE       SIZE  ARCH   LOCAL
-------------------------------------------
ubuntu-24.04  container  -     amd64  ✓

$ nauka vm image list
NAME          TYPE       SIZE    ARCH   LOCAL
---------------------------------------------
ubuntu-24.04  container  105 MB  amd64  ✓
```

## Related
- sifrah/nauka-images#1 — manifest.json + asset rename on CI side

## Test plan
- [x] Built and deployed to 4-node Hetzner cluster
- [x] `catalog` reads manifest from registry
- [x] `list` shows TYPE column
- [x] `pull` uses new `{name}-{type}-{arch}` naming
- [x] `delete` + `pull` roundtrip works

🤖 Generated with [Claude Code](https://claude.com/claude-code)