### PR TITLE
feat: show download size in image catalog

### DIFF
--- a/layers/compute/src/image/handlers.rs
+++ b/layers/compute/src/image/handlers.rs
@@ -103,6 +103,7 @@ pub fn handler() -> HandlerFn {
                                 serde_json::json!({
                                     "name": e.name,
                                     "type": e.image_type,
+                                    "size": format_size(e.size),
                                     "arch": e.arch,
                                     "local": if e.local { "✓" } else { "✗" },
                                 })

--- a/layers/compute/src/image/registry.rs
+++ b/layers/compute/src/image/registry.rs
@@ -171,8 +171,10 @@ pub async fn catalog() -> anyhow::Result<Vec<CatalogEntry>> {
 
         // Only show images available for this architecture
         if archs.iter().any(|a| a == arch_name) {
+            let size = image["sizes"][arch_name].as_u64().unwrap_or(0);
             entries.push(CatalogEntry {
                 name: name.to_string(),
+                size,
                 image_type: image_type.to_string(),
                 arch: arch_name.to_string(),
                 description: description.to_string(),
@@ -188,6 +190,7 @@ pub async fn catalog() -> anyhow::Result<Vec<CatalogEntry>> {
 /// An image available in the remote registry.
 pub struct CatalogEntry {
     pub name: String,
+    pub size: u64,
     pub image_type: String,
     pub arch: String,
     pub description: String,


### PR DESCRIPTION
## Summary
- Read `sizes` field from manifest.json to show download sizes in catalog
- Add `size` field back to `CatalogEntry`

```
$ nauka vm image catalog
NAME          TYPE       SIZE   ARCH   LOCAL
--------------------------------------------
debian-12     container  61 MB  amd64  ✓
rocky-9       container  63 MB  amd64  ✓
ubuntu-24.04  container  44 MB  amd64  ✓
```

## Related
- sifrah/nauka-images#4 — CI now generates per-arch sizes in manifest.json

## Test plan
- [x] Deployed and verified on Hetzner cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)