### PR TITLE
feat: add `nauka hypervisor update` to modify fields post-init

### DIFF
--- a/layers/hypervisor/src/fabric/ops.rs
+++ b/layers/hypervisor/src/fabric/ops.rs
@@ -554,6 +554,66 @@ pub fn stop(db: &LayerDb) -> Result<(), NaukaError> {
     backend.stop()
 }
 
+/// Configuration for updating hypervisor fields.
+pub struct UpdateConfig {
+    pub ipv6_block: Option<String>,
+    pub ipv4_public: Option<String>,
+    pub name: Option<String>,
+}
+
+/// Update mutable hypervisor fields on a live node.
+pub fn update(db: &LayerDb, cfg: &UpdateConfig) -> Result<HypervisorIdentity, NaukaError> {
+    let mut state = FabricState::load(db)
+        .map_err(|e| NaukaError::internal(e.to_string()))?
+        .ok_or_else(|| {
+            NaukaError::precondition("not initialized. Run 'nauka hypervisor init' first.")
+        })?;
+
+    let mut changed = false;
+
+    if let Some(ref block) = cfg.ipv6_block {
+        if !block.contains('/') {
+            return Err(NaukaError::validation(
+                "ipv6-block must be a CIDR (e.g., 2a01:4f8:c012:abcd::/64)",
+            ));
+        }
+        let prefix = block.split('/').next().unwrap_or_default();
+        if prefix.parse::<std::net::Ipv6Addr>().is_err() {
+            return Err(NaukaError::validation("ipv6-block: invalid IPv6 address"));
+        }
+        state.hypervisor.ipv6_block = Some(block.clone());
+        changed = true;
+    }
+
+    if let Some(ref ip) = cfg.ipv4_public {
+        if ip.parse::<std::net::Ipv4Addr>().is_err() {
+            return Err(NaukaError::validation("ipv4-public: invalid IPv4 address"));
+        }
+        state.hypervisor.ipv4_public = Some(ip.clone());
+        changed = true;
+    }
+
+    if let Some(ref name) = cfg.name {
+        nauka_core::validate::name(name)?;
+        state.hypervisor.name = name.clone();
+        changed = true;
+    }
+
+    if !changed {
+        return Err(NaukaError::validation(
+            "no fields to update. Pass --ipv6-block, --ipv4-public, or --name",
+        ));
+    }
+
+    state
+        .save(db)
+        .map_err(|e| NaukaError::internal(e.to_string()))?;
+
+    tracing::info!(node = state.hypervisor.name.as_str(), "hypervisor updated");
+
+    Ok(state.hypervisor)
+}
+
 /// Number of removal broadcast attempts before giving up.
 const LEAVE_BROADCAST_ATTEMPTS: usize = 4;
 /// Delay between removal broadcast retries.

--- a/layers/hypervisor/src/handlers.rs
+++ b/layers/hypervisor/src/handlers.rs
@@ -149,6 +149,23 @@ pub fn resource_def() -> ResourceDef {
                 "nauka hypervisor join --target 46.224.166.60 --pin G7CCZX --region eu --zone nbg1",
             )
         })
+        .action("update", "Update hypervisor configuration")
+        .op(|op| {
+            op.with_arg(OperationArg::optional(
+                "ipv6-block",
+                FieldDef::string("ipv6-block", "Public IPv6 /64 block (e.g., 2a01:4f8:c012:abcd::/64)"),
+            ))
+            .with_arg(OperationArg::optional(
+                "ipv4-public",
+                FieldDef::string("ipv4-public", "Public IPv4 address"),
+            ))
+            .with_arg(OperationArg::optional(
+                "name",
+                FieldDef::string("name", "Node name"),
+            ))
+            .with_output(OutputKind::Resource)
+            .with_example("nauka hypervisor update --ipv6-block 2a01:4f8:c012:abcd::/64")
+        })
         .action("status", "Show hypervisor status")
         .op(|op| op.with_output(OutputKind::Resource))
         .action("start", "Start hypervisor services (fabric, storage, tikv)")
@@ -208,6 +225,7 @@ pub fn handler() -> HandlerFn {
         Box::pin(async move {
             match req.operation.as_str() {
                 "init" => handle_init(req).await,
+                "update" => handle_update(req).await,
                 "status" => handle_status().await,
                 "start" => handle_start().await,
                 "stop" => handle_stop().await,
@@ -674,6 +692,33 @@ async fn handle_peering(req: OperationRequest) -> anyhow::Result<OperationRespon
     Ok(OperationResponse::Message(format!(
         "{accepted} node(s) joined."
     )))
+}
+
+async fn handle_update(req: OperationRequest) -> anyhow::Result<OperationResponse> {
+    let db = open_db()?;
+
+    let ipv6_block = req.fields.get("ipv6-block").cloned();
+    let ipv4_public = req.fields.get("ipv4-public").cloned();
+    let name = req.fields.get("name").cloned();
+
+    let cfg = fabric::ops::UpdateConfig {
+        ipv6_block,
+        ipv4_public,
+        name,
+    };
+
+    let hv = fabric::ops::update(&db, &cfg)?;
+
+    Ok(OperationResponse::Resource(serde_json::json!({
+        "name": hv.name,
+        "id": hv.id.as_str(),
+        "region": hv.region,
+        "zone": hv.zone,
+        "mesh_ipv6": hv.mesh_ipv6.to_string(),
+        "ipv6_block": hv.ipv6_block,
+        "ipv4_public": hv.ipv4_public,
+        "state": "available",
+    })))
 }
 
 async fn handle_status() -> anyhow::Result<OperationResponse> {


### PR DESCRIPTION
## Summary
- New `nauka hypervisor update` command to modify hypervisor config without leave/re-init
- Supports `--ipv6-block`, `--ipv4-public`, `--name`
- Validates inputs (CIDR format, IPv4 format, name rules)
- Persists changes to local state

Closes #76

## Usage
```bash
nauka hypervisor update --ipv6-block 2a01:4f8:c012:abcd::/64
nauka hypervisor update --ipv4-public 49.12.233.86
nauka hypervisor update --name my-node
```

## Error handling
```
$ nauka hypervisor update
Error: no fields to update. Pass --ipv6-block, --ipv4-public, or --name

$ nauka hypervisor update --ipv6-block not-valid
Error: ipv6-block must be a CIDR (e.g., 2a01:4f8:c012:abcd::/64)
```

## Test plan
- [x] Built and deployed to 4-node Hetzner cluster
- [x] `update --ipv6-block` persists correctly
- [x] `update --ipv4-public` persists correctly
- [x] Invalid inputs rejected with clear errors
- [x] No args returns helpful error

🤖 Generated with [Claude Code](https://claude.com/claude-code)