### PR TITLE
fix: protect control plane from container OOM kills

### DIFF
--- a/layers/compute/src/runtime/gvisor.rs
+++ b/layers/compute/src/runtime/gvisor.rs
@@ -421,9 +421,11 @@ fn generate_oci_config(config: &VmRunConfig, has_tini: bool) -> String {
                     "period": 100000
                 },
                 "memory": {
-                    "limit": (config.memory_mb as i64) * 1024 * 1024
+                    "limit": (config.memory_mb as i64) * 1024 * 1024,
+                    "reservation": (config.memory_mb as i64) * 1024 * 1024 * 9 / 10
                 }
-            }
+            },
+            "oomScoreAdj": 500
         }
     })
     .to_string()

--- a/layers/hypervisor/src/controlplane/service.rs
+++ b/layers/hypervisor/src/controlplane/service.rs
@@ -233,6 +233,7 @@ Environment=TIUP_HOME={TIUP_HOME}
 Restart=on-failure
 RestartSec=5
 LimitNOFILE=1000000
+OOMScoreAdjust=-999
 
 [Install]
 WantedBy=multi-user.target
@@ -256,6 +257,7 @@ ExecStart={TIUP_HOME}/bin/tiup tikv --config={TIKV_CONF_PATH}
 Restart=on-failure
 RestartSec=5
 LimitNOFILE=1000000
+OOMScoreAdjust=-999
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- **PD/TiKV**: `OOMScoreAdjust=-999` in systemd units — kernel avoids killing them
- **Containers**: `oomScoreAdj=500` in OCI config — preferred OOM kill targets
- **Containers**: `memory.reservation` at 90% of limit — triggers reclaim before hard limit

## Verified on cluster
```
# TiKV is protected
$ cat /proc/$(pgrep tikv-server)/oom_score_adj
-999

# Container OCI config
memory.limit: 4294967296     (4 GB hard limit)
memory.reservation: 3865470566  (3.6 GB soft limit)
oomScoreAdj: 500             (high = killed first)
```

Closes #72

## Test plan
- [x] Deployed to 4-node Hetzner cluster
- [x] TiKV/PD oom_score_adj verified at -999
- [x] Container recreated with new OCI config, limits verified
- [x] Container running with tini PID 1 + correct memory limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)