### PR TITLE
fix: forge reconcile detects and restarts dead sshd in containers

### DIFF
--- a/layers/forge/src/observer/health.rs
+++ b/layers/forge/src/observer/health.rs
@@ -1,0 +1,43 @@
+//! Container health checks — verify critical services inside running containers.
+
+use std::process::Command;
+
+/// Check if sshd is running inside a container.
+pub fn is_sshd_alive(vm_id: &str) -> bool {
+    Command::new("crun")
+        .args(["exec", vm_id, "/usr/bin/pgrep", "-x", "sshd"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Restart sshd inside a container.
+pub fn restart_sshd(vm_id: &str) -> Result<(), String> {
+    // Ensure /run/sshd exists
+    let _ = Command::new("crun")
+        .args(["exec", vm_id, "/bin/mkdir", "-p", "/run/sshd"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+
+    let status = Command::new("crun")
+        .args([
+            "exec",
+            "--cap",
+            "CAP_NET_BIND_SERVICE",
+            vm_id,
+            "/usr/sbin/sshd",
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map_err(|e| format!("failed to exec sshd: {e}"))?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("sshd exited with {status}"))
+    }
+}

--- a/layers/forge/src/observer/mod.rs
+++ b/layers/forge/src/observer/mod.rs
@@ -1,4 +1,5 @@
 //! Observers — read actual system state.
 
+pub mod health;
 pub mod network;
 pub mod process;

--- a/layers/forge/src/reconciler/vm.rs
+++ b/layers/forge/src/reconciler/vm.rs
@@ -87,7 +87,7 @@ impl super::Reconciler for VmReconciler {
                 }
             }
 
-            // If process is already running but state is pending, correct it
+            // If process is already running, check health and correct state
             if actual_processes.contains(&vm.meta.id) {
                 if vm.state == VmState::Pending {
                     if let Err(e) = vm_store
@@ -103,6 +103,22 @@ impl super::Reconciler for VmReconciler {
                         result.updated += 1;
                     }
                 }
+
+                // Health check: ensure sshd is alive inside containers
+                if use_veth && !crate::observer::health::is_sshd_alive(&vm.meta.id) {
+                    match crate::observer::health::restart_sshd(&vm.meta.id) {
+                        Ok(()) => {
+                            tracing::info!(vm_id = vm.meta.id.as_str(), "restarted sshd");
+                            result.updated += 1;
+                        }
+                        Err(e) => {
+                            tracing::error!(vm_id = vm.meta.id.as_str(), error = %e, "failed to restart sshd");
+                            result.failed += 1;
+                            result.errors.push(format!("sshd {}: {e}", vm.meta.id));
+                        }
+                    }
+                }
+
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- New health observer (`forge/src/observer/health.rs`) checks sshd liveness via `crun exec pgrep`
- VM reconciler restarts sshd via `crun exec --cap CAP_NET_BIND_SERVICE` if dead
- Reports restarts in reconcile output (`updated` count)

Closes #69

## Verified on cluster
```bash
# Kill sshd
crun exec --cap CAP_KILL vm-xxx /bin/sh -c 'kill $(pgrep sshd)'

# sshd is dead
crun exec vm-xxx /usr/bin/pgrep sshd  # exit code 1

# Reconcile detects and restarts
nauka forge reconcile
# vm: 4 desired, 4 actual — updated:1

# sshd is back
crun exec vm-xxx /usr/bin/pgrep -a sshd
# 37 sshd: /usr/sbin/sshd [listener] 0 of 10-100 startups
```

## Test plan
- [x] Deployed to 4-node Hetzner cluster
- [x] Killed sshd inside container → reconcile restarted it
- [x] Verified sshd alive after reconcile

🤖 Generated with [Claude Code](https://claude.com/claude-code)