### PR TITLE
fix: forge auto-adjusts max-replicas=3 when 3+ TiKV stores active

### DIFF
--- a/layers/forge/src/daemon.rs
+++ b/layers/forge/src/daemon.rs
@@ -82,6 +82,18 @@ async fn run_cycle(cycle: u64) -> anyhow::Result<Vec<crate::types::ReconcileResu
         cycle,
     };
 
+    // Ensure replication is configured correctly.
+    // On every cycle, check if max-replicas matches the number of active stores (capped at 3).
+    let pd_url = format!(
+        "http://[{}]:{}",
+        state.hypervisor.mesh_ipv6,
+        controlplane::PD_CLIENT_PORT
+    );
+    let active_stores = controlplane::service::count_active_stores(&pd_url);
+    if active_stores >= 3 {
+        let _ = controlplane::service::adjust_max_replicas(&pd_url, 3);
+    }
+
     tracing::debug!(
         cycle,
         node = ctx.node_name.as_str(),


### PR DESCRIPTION
## Summary
The join flow sets max-replicas during join, but the new TiKV store isn't registered yet at that point — leaving max-replicas=1. The forge daemon now checks and corrects this on every reconcile cycle.

Closes #58

## Verified on cluster
```
# Before forge fix:
max-replicas: 1  (dangerous — no replication!)

# After first forge cycle:
adjusting max-replicas current=1 target=3

# After:
max-replicas: 3  (data replicated across 3 nodes)
```

## Test plan
- [x] Deployed to 4-node Hetzner cluster
- [x] Verified max-replicas was stuck at 1 before the fix
- [x] Forge corrected to max-replicas=3 on first cycle
- [x] Confirmed in logs: `adjusting max-replicas current=1 target=3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)