### PR TITLE
fix: improve error messages for join failures

### DIFF
--- a/layers/hypervisor/src/fabric/peering_client.rs
+++ b/layers/hypervisor/src/fabric/peering_client.rs
@@ -24,9 +24,25 @@ pub async fn join(target: &str, request: JoinRequest) -> Result<JoinResponse, Na
     };
 
     // TCP connect
-    let tcp_stream = TcpStream::connect(addr)
-        .await
-        .map_err(|e| NaukaError::network(format!("failed to connect to {addr}: {e}")))?;
+    let tcp_stream = TcpStream::connect(addr).await.map_err(|e| {
+        if e.kind() == std::io::ErrorKind::ConnectionRefused {
+            NaukaError::network(format!(
+                "could not reach the peering listener at {addr} (connection refused).\n\n  \
+                 The target node may not be in peering mode. Run:\n    \
+                 nauka hypervisor peering\n  \
+                 on the target node before joining."
+            ))
+        } else if e.kind() == std::io::ErrorKind::TimedOut {
+            NaukaError::network(format!(
+                "connection to {addr} timed out.\n\n  \
+                 Check that the target IP is correct and that port {} is reachable\n  \
+                 (firewall, security group).",
+                addr.port()
+            ))
+        } else {
+            NaukaError::network(format!("failed to connect to {addr}: {e}"))
+        }
+    })?;
 
     // TLS handshake (TOFU — accept any cert, PIN provides auth)
     let tls_config = super::tls::client_config();
@@ -47,8 +63,13 @@ pub async fn join(target: &str, request: JoinRequest) -> Result<JoinResponse, Na
 
     if !response.accepted {
         let reason = response.reason.unwrap_or_else(|| "unknown".to_string());
+        let hint = if reason.contains("PIN") || reason.contains("pin") {
+            "\n\n  Check the PIN displayed on the target node during:\n    nauka hypervisor peering"
+        } else {
+            ""
+        };
         return Err(NaukaError::permission_denied(format!(
-            "join rejected: {reason}"
+            "join rejected: {reason}{hint}"
         )));
     }
 


### PR DESCRIPTION
## Summary
User-friendly error messages for the 3 most common join failures:

**Connection refused** (peering not active):
```
Error: could not reach the peering listener at 49.12.233.86:51821 (connection refused).

  The target node may not be in peering mode. Run:
    nauka hypervisor peering
  on the target node before joining.
```

**Invalid PIN**:
```
Error: join rejected: invalid PIN

  Check the PIN displayed on the target node during:
    nauka hypervisor peering
```

**Timeout** (firewall/wrong IP):
```
Error: connection to 49.12.233.86:51821 timed out.

  Check that the target IP is correct and that port 51821 is reachable
  (firewall, security group).
```

Closes #14

## Test plan
- [x] Unit tests pass (2/2 peering_client tests)
- [x] Tested connection refused on Hetzner cluster
- [x] Tested invalid PIN on Hetzner cluster
- [x] Cluster restored after testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)