### PR TITLE
fix: hypervisor start recreates deleted WireGuard interface

### DIFF
--- a/layers/hypervisor/src/fabric/ops.rs
+++ b/layers/hypervisor/src/fabric/ops.rs
@@ -535,6 +535,15 @@ pub fn start(db: &LayerDb) -> Result<(), NaukaError> {
         })?;
 
     let backend = super::backend::create_backend(state.network_mode);
+
+    // If the interface is missing (e.g., `ip link del nauka0`), stop the
+    // service (which may think it's still active) and restart it from config.
+    if !backend.is_up() {
+        tracing::info!("interface missing — recreating from saved state");
+        let _ = backend.stop(); // clear stale "active (exited)" state
+        return backend.start();
+    }
+
     if backend.is_active() {
         return Ok(()); // already running, idempotent
     }


### PR DESCRIPTION
## Summary
`nauka hypervisor start` now detects a missing `nauka0` interface and recreates it by stopping the stale systemd service (which thinks it's still "active (exited)") and restarting it.

Closes #55

## Root cause
systemd marks `nauka-wg` as `active (exited)` after wg-quick runs successfully. If the interface is later deleted (`ip link del nauka0`), the service still appears active. The old code checked `is_active()` and returned early.

## Fix
Check `is_up()` (interface exists) first. If missing, stop the stale service and restart it.

## Verified on cluster
```
ip link del nauka0                    # simulate interface loss
nauka hypervisor start                # recreates interface
ip link show nauka0                   # ✓ UP
wg show nauka0 | grep peer | wc -l   # ✓ 3 peers
nauka hypervisor status               # ✓ available
```

## Test plan
- [x] Deployed to 4-node Hetzner cluster
- [x] Deleted interface → start recovered it with all peers
- [x] Idempotent — start on healthy node is still a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)