### PR TITLE
fix: hypervisor start restores IPv6 after interface down/up

### DIFF
--- a/layers/hypervisor/src/fabric/ops.rs
+++ b/layers/hypervisor/src/fabric/ops.rs
@@ -536,11 +536,21 @@ pub fn start(db: &LayerDb) -> Result<(), NaukaError> {
 
     let backend = super::backend::create_backend(state.network_mode);
 
-    // If the interface is missing (e.g., `ip link del nauka0`), stop the
-    // service (which may think it's still active) and restart it from config.
-    if !backend.is_up() {
+    // If the interface is missing (e.g., `ip link del nauka0`), or exists
+    // but lost its IPv6 address (e.g., `ip link set nauka0 down && up`),
+    // do a full service restart to restore the complete mesh config.
+    let needs_restart = if !backend.is_up() {
         tracing::info!("interface missing — recreating from saved state");
-        let _ = backend.stop(); // clear stale "active (exited)" state
+        true
+    } else if !has_mesh_ipv6(&state.hypervisor.mesh_ipv6) {
+        tracing::info!("mesh IPv6 address missing — restarting service");
+        true
+    } else {
+        false
+    };
+
+    if needs_restart {
+        let _ = backend.stop();
         return backend.start();
     }
 
@@ -548,6 +558,19 @@ pub fn start(db: &LayerDb) -> Result<(), NaukaError> {
         return Ok(()); // already running, idempotent
     }
     backend.start()
+}
+
+/// Check if the expected mesh IPv6 address is assigned to nauka0.
+fn has_mesh_ipv6(expected: &std::net::Ipv6Addr) -> bool {
+    let output = match std::process::Command::new("ip")
+        .args(["-6", "addr", "show", "dev", "nauka0"])
+        .output()
+    {
+        Ok(o) => o,
+        Err(_) => return false,
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout.contains(&expected.to_string())
 }
 
 /// Stop the fabric network service.


### PR DESCRIPTION
## Summary
`nauka hypervisor start` now detects when the interface exists but its mesh IPv6 address is missing (e.g., after `ip link set nauka0 down && up`) and does a full service restart to restore it.

Combined with #55 (missing interface), `nauka hypervisor start` now handles:
- Interface deleted → recreated
- Interface down/up → IPv6 restored  
- Service stopped → started
- Already healthy → no-op

Closes #56

## Verified on cluster
```bash
# Remove IPv6 by down/up
ip link set nauka0 down && ip link set nauka0 up
ip -6 addr show dev nauka0 | grep fd   # empty — no IPv6

# Start restores it
nauka hypervisor start
ip -6 addr show dev nauka0 | grep fd
# inet6 fda0:2ab9:943d:68aa:e14d:8793:71f3:328a/128 scope global ✓
# peers: 3, state: available
```

## Test plan
- [x] Deployed to 4-node Hetzner cluster
- [x] Interface down/up → start restored IPv6 and peers
- [x] Idempotent — start on healthy node is still a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)