### PR TITLE
fix: forge detects and regenerates corrupted OCI config.json

### DIFF
--- a/layers/compute/src/runtime/gvisor.rs
+++ b/layers/compute/src/runtime/gvisor.rs
@@ -346,7 +346,7 @@ impl Runtime for GVisorRuntime {
 }
 
 /// Generate an OCI runtime spec (config.json) for the container.
-fn generate_oci_config(config: &VmRunConfig, has_tini: bool) -> String {
+pub fn generate_oci_config(config: &VmRunConfig, has_tini: bool) -> String {
     let args: Vec<&str> = if has_tini {
         vec!["/usr/bin/tini", "--", "/bin/sh", "/nauka-init.sh"]
     } else {

--- a/layers/forge/src/reconciler/vm.rs
+++ b/layers/forge/src/reconciler/vm.rs
@@ -104,6 +104,61 @@ impl super::Reconciler for VmReconciler {
                     }
                 }
 
+                // Validate OCI config.json — regenerate if corrupted
+                if use_veth {
+                    let config_path = format!("/run/nauka/vms/{}/bundle/config.json", vm.meta.id);
+                    let config_valid = std::fs::read_to_string(&config_path)
+                        .ok()
+                        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+                        .and_then(|v| v["process"]["args"].as_array().cloned())
+                        .is_some();
+
+                    if !config_valid {
+                        let rootfs_dir = format!("/run/nauka/vms/{}/bundle/rootfs", vm.meta.id);
+                        let has_tini = std::path::Path::new(&rootfs_dir)
+                            .join("usr/bin/tini")
+                            .exists();
+                        let subnet_store =
+                            nauka_network::vpc::subnet::store::SubnetStore::new(ctx.db.clone());
+                        let subnet = subnet_store.get(vm.subnet_id.as_str(), None, None).await?;
+                        let (gateway, cidr) = match &subnet {
+                            Some(s) => (s.gateway.clone(), s.cidr.clone()),
+                            None => ("0.0.0.0".to_string(), "0.0.0.0/0".to_string()),
+                        };
+                        let vpc_store = nauka_network::vpc::store::VpcStore::new(ctx.db.clone());
+                        let vpc_cidr = vpc_store
+                            .get(vm.vpc_id.as_str(), None)
+                            .await?
+                            .map(|v| v.cidr);
+                        let run_config = VmRunConfig {
+                            vm_id: vm.meta.id.clone(),
+                            vm_name: vm.meta.name.clone(),
+                            vcpus: vm.vcpus,
+                            memory_mb: vm.memory_mb,
+                            disk_gb: vm.disk_gb,
+                            image: vm.image.clone(),
+                            tap_name: provision::veth_guest_name(&vm.meta.id),
+                            private_ip: vm.private_ip.clone().unwrap_or_default(),
+                            gateway,
+                            subnet_cidr: cidr,
+                            vpc_cidr,
+                        };
+                        let oci = nauka_compute::runtime::gvisor::generate_oci_config(
+                            &run_config,
+                            has_tini,
+                        );
+                        if let Err(e) = std::fs::write(&config_path, oci) {
+                            tracing::error!(vm_id = vm.meta.id.as_str(), error = %e, "failed to regenerate config.json");
+                        } else {
+                            tracing::info!(
+                                vm_id = vm.meta.id.as_str(),
+                                "regenerated corrupted config.json"
+                            );
+                            result.updated += 1;
+                        }
+                    }
+                }
+
                 // Health check: ensure sshd is alive inside containers
                 if use_veth && !crate::observer::health::is_sshd_alive(&vm.meta.id) {
                     match crate::observer::health::restart_sshd(&vm.meta.id) {


### PR DESCRIPTION
## Summary
The forge VM reconciler now validates config.json for running containers on each cycle. If corrupted or missing, it regenerates the full OCI spec from TiKV state.

Closes #71

## Verified on cluster
```bash
# Corrupt config
echo '{}' > /run/nauka/vms/VM_ID/bundle/config.json

# Reconcile detects and fixes
nauka forge reconcile
# vm: 5 desired, 5 actual — updated:1

# Config restored with tini, memory limits, etc.
args: ['/usr/bin/tini', '--', '/bin/sh', '/nauka-init.sh']
memory: {'limit': 4294967296, 'reservation': 3865470566}
```

Also works for deleted config.json (file missing entirely).

## Test plan
- [x] Corrupted config.json (echo '{}') → regenerated
- [x] Deleted config.json (rm) → regenerated
- [x] Valid config.json → no change (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)