### PR TITLE
fix: forge detects missing base image and auto-pulls it

### DIFF
--- a/layers/forge/src/reconciler/vm.rs
+++ b/layers/forge/src/reconciler/vm.rs
@@ -159,6 +159,30 @@ impl super::Reconciler for VmReconciler {
                     }
                 }
 
+                // Verify base image exists — re-pull if deleted
+                if !nauka_compute::image::registry::exists(&vm.image) {
+                    tracing::warn!(
+                        vm_id = vm.meta.id.as_str(),
+                        image = vm.image.as_str(),
+                        "base image missing — pulling"
+                    );
+                    match nauka_compute::image::registry::pull(&vm.image).await {
+                        Ok(_) => {
+                            tracing::info!(
+                                vm_id = vm.meta.id.as_str(),
+                                image = vm.image.as_str(),
+                                "base image restored"
+                            );
+                            result.updated += 1;
+                        }
+                        Err(e) => {
+                            tracing::error!(vm_id = vm.meta.id.as_str(), image = vm.image.as_str(), error = %e, "failed to pull base image");
+                            result.failed += 1;
+                            result.errors.push(format!("image {}: {e}", vm.image));
+                        }
+                    }
+                }
+
                 // Health check: ensure sshd is alive inside containers
                 if use_veth && !crate::observer::health::is_sshd_alive(&vm.meta.id) {
                     match crate::observer::health::restart_sshd(&vm.meta.id) {


### PR DESCRIPTION
## Summary
The forge VM reconciler now checks that the base image exists on disk for each running VM. If deleted, it auto-pulls it from the registry.

Closes #70

## Verified on cluster
```bash
rm -rf /opt/nauka/images/ubuntu-24.04
nauka forge reconcile
# vm: 5 desired, 5 actual — updated:1  (re-pulled)
ls /opt/nauka/images/ubuntu-24.04/bin/sh
# /opt/nauka/images/ubuntu-24.04/bin/sh ✓
```

## Test plan
- [x] Deleted base image → reconcile auto-pulled it
- [x] Image present → no action (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)