### PR TITLE
fix: forge detects and recreates missing VXLAN interfaces

### DIFF
--- a/layers/forge/src/observer/network.rs
+++ b/layers/forge/src/observer/network.rs
@@ -27,6 +27,11 @@ pub fn list_bridges() -> Vec<String> {
         .collect()
 }
 
+/// Check if any network interface exists by name.
+pub fn iface_exists(name: &str) -> bool {
+    bridge_exists(name)
+}
+
 /// Check if a specific bridge interface exists.
 pub fn bridge_exists(name: &str) -> bool {
     Command::new("ip")

--- a/layers/forge/src/reconciler/vpc.rs
+++ b/layers/forge/src/reconciler/vpc.rs
@@ -46,14 +46,25 @@ impl super::Reconciler for VpcReconciler {
         let actual_bridges = crate::observer::network::list_bridges();
         result.actual = actual_bridges.len();
 
-        // 4. Create missing bridges
+        // 4. Create missing bridges + verify VXLAN interfaces
         for (vpc_id, vni) in &needed_vpcs {
             let expected_bridge = provision::bridge_name(vpc_id);
-            if !actual_bridges.iter().any(|b| b == &expected_bridge) {
+            let expected_vxlan = provision::vxlan_name(vpc_id);
+            let bridge_missing = !actual_bridges.iter().any(|b| b == &expected_bridge);
+            let vxlan_missing = !crate::observer::network::iface_exists(&expected_vxlan);
+
+            if bridge_missing || vxlan_missing {
+                if vxlan_missing && !bridge_missing {
+                    tracing::info!(
+                        vpc_id,
+                        vxlan = expected_vxlan.as_str(),
+                        "VXLAN interface missing — recreating"
+                    );
+                }
                 match provision::ensure_bridge(vpc_id, *vni, &ctx.mesh_ipv6) {
                     Ok(()) => result.created += 1,
                     Err(e) => {
-                        tracing::error!(vpc_id, error = %e, "failed to create bridge");
+                        tracing::error!(vpc_id, error = %e, "failed to create bridge/vxlan");
                         result.failed += 1;
                         result.errors.push(format!("vpc {vpc_id}: {e}"));
                     }


### PR DESCRIPTION
## Summary
The VPC reconciler now verifies VXLAN interfaces (`nkx-*`) exist alongside bridges. If a VXLAN is deleted, it's recreated and reattached to its bridge on the next reconcile cycle.

Closes #62

## Verified on cluster
```bash
# Delete VXLAN
ip link del nkx-b216ed

# Reconcile recreates it
nauka forge reconcile
# vpc: 2 desired, 2 actual — created:1

# VXLAN restored, attached to bridge
nkx-b216ed: master nkb-b216ed state UNKNOWN ✓
```

## Test plan
- [x] Deleted VXLAN interface → reconcile recreated it
- [x] VXLAN reattached to correct bridge
- [x] Both VXLANs present → no action (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)