### PR TITLE
fix: forge injects recreated veths into container network namespace

### DIFF
--- a/layers/forge/src/observer/process.rs
+++ b/layers/forge/src/observer/process.rs
@@ -33,3 +33,15 @@ pub fn list_vms() -> Vec<String> {
     }
     vms
 }
+
+/// Get the PID of a running VM by its ID.
+pub fn get_pid(vm_id: &str) -> Option<u32> {
+    let pid_path = PathBuf::from(VM_RUN_DIR).join(vm_id).join("pid");
+    let pid_str = std::fs::read_to_string(&pid_path).ok()?;
+    let pid: i32 = pid_str.trim().parse().ok()?;
+    if unsafe { libc::kill(pid, 0) == 0 } {
+        Some(pid as u32)
+    } else {
+        None
+    }
+}

--- a/layers/forge/src/reconciler/vm.rs
+++ b/layers/forge/src/reconciler/vm.rs
@@ -66,12 +66,58 @@ impl super::Reconciler for VmReconciler {
             if use_veth {
                 let expected = provision::veth_host_name(&vm.meta.id);
                 let actual = provision::list_veths();
-                if !actual.iter().any(|v| v == &expected) {
+                let veth_was_missing = !actual.iter().any(|v| v == &expected);
+                if veth_was_missing {
                     if let Err(e) = provision::ensure_veth(&vm.meta.id, &bridge) {
                         tracing::error!(vm_id = vm.meta.id.as_str(), error = %e, "failed to create veth");
                         result.failed += 1;
                         result.errors.push(format!("veth {}: {e}", vm.meta.id));
                         continue;
+                    }
+
+                    // If container is running, inject the new veth into its netns
+                    if actual_processes.contains(&vm.meta.id) {
+                        if let Some(pid) = crate::observer::process::get_pid(&vm.meta.id) {
+                            let ip = vm.private_ip.as_deref().unwrap_or("0.0.0.0");
+                            let mac =
+                                nauka_network::vpc::provision::mac_from_ip(ip).unwrap_or_default();
+                            let subnet_store =
+                                nauka_network::vpc::subnet::store::SubnetStore::new(ctx.db.clone());
+                            let gateway = subnet_store
+                                .get(vm.subnet_id.as_str(), None, None)
+                                .await?
+                                .map(|s| s.gateway.clone())
+                                .unwrap_or_else(|| "0.0.0.0".to_string());
+                            let vpc_store =
+                                nauka_network::vpc::store::VpcStore::new(ctx.db.clone());
+                            let vpc_cidr = vpc_store
+                                .get(vm.vpc_id.as_str(), None)
+                                .await?
+                                .map(|v| v.cidr);
+                            match provision::setup_container_net(
+                                &vm.meta.id,
+                                pid,
+                                ip,
+                                &gateway,
+                                &mac,
+                                vpc_cidr.as_deref(),
+                            ) {
+                                Ok(()) => {
+                                    tracing::info!(
+                                        vm_id = vm.meta.id.as_str(),
+                                        "veth injected into container netns"
+                                    );
+                                    result.updated += 1;
+                                }
+                                Err(e) => {
+                                    tracing::error!(vm_id = vm.meta.id.as_str(), error = %e, "failed to inject veth");
+                                    result.failed += 1;
+                                    result
+                                        .errors
+                                        .push(format!("veth inject {}: {e}", vm.meta.id));
+                                }
+                            }
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
## Summary
When the reconciler recreates a veth pair for a running container, it now moves the guest side into the container's network namespace and configures IP, MAC, and routes — restoring connectivity without restarting the container.

Closes #65

## Verified on cluster
```bash
# Delete host veth
ip link del nkh-cc3eb5

# eth0 gone inside container
nsenter --net --target=71475 ip addr show eth0
# Device "eth0" does not exist.

# Reconcile restores it
nauka forge reconcile
# vm: updated:1

# eth0 back with correct IP
nsenter --net --target=71475 ip addr show eth0
# 45: eth0@if46: UP
# inet 10.0.1.5/24 ✓
# link/ether 02:00:0a:00:01:05 ✓
```

## Test plan
- [x] Deleted veth → container lost eth0
- [x] Reconcile recreated veth and injected into netns
- [x] IP, MAC, and routes restored correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)