### PR TITLE
fix: forge veth reconciliation and @ifN parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,12 +1467,14 @@ name = "nauka-compute"
 version = "2.0.0"
 dependencies = [
  "anyhow",
+ "futures-util",
  "libc",
  "nauka-core",
  "nauka-hypervisor",
  "nauka-network",
  "nauka-org",
  "nauka-state",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
@@ -2199,12 +2201,14 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.26.4",
+ "tokio-util",
  "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -3298,6 +3302,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/layers/compute/src/vm/provision.rs
+++ b/layers/compute/src/vm/provision.rs
@@ -254,7 +254,9 @@ pub fn list_veths() -> Vec<String> {
     stdout
         .lines()
         .filter_map(|line| {
-            let name = line.split(':').nth(1)?.trim();
+            let raw = line.split(':').nth(1)?.trim();
+            // Strip the @ifN suffix that appears when the peer is in another netns
+            let name = raw.split('@').next().unwrap_or(raw);
             if name.starts_with("nkh-") {
                 Some(name.to_string())
             } else {
@@ -275,7 +277,8 @@ pub fn list_taps() -> Vec<String> {
     stdout
         .lines()
         .filter_map(|line| {
-            let name = line.split(':').nth(1)?.trim();
+            let raw = line.split(':').nth(1)?.trim();
+            let name = raw.split('@').next().unwrap_or(raw);
             if name.starts_with("nkt-") {
                 Some(name.to_string())
             } else {

--- a/layers/forge/src/observer/network.rs
+++ b/layers/forge/src/observer/network.rs
@@ -16,8 +16,9 @@ pub fn list_bridges() -> Vec<String> {
     stdout
         .lines()
         .filter_map(|line| {
-            // Format: "N: nkb-abc123: <...>"
-            let name = line.split(':').nth(1)?.trim();
+            // Format: "N: nkb-abc123: <...>" or "N: nkb-abc123@if1: <...>"
+            let raw = line.split(':').nth(1)?.trim();
+            let name = raw.split('@').next().unwrap_or(raw);
             if name.starts_with("nkb-") {
                 Some(name.to_string())
             } else {

--- a/layers/network/src/vpc/provision.rs
+++ b/layers/network/src/vpc/provision.rs
@@ -55,7 +55,8 @@ pub fn cleanup_all() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     for line in stdout.lines() {
-        if let Some(name) = line.split(':').nth(1).map(|s| s.trim()) {
+        if let Some(raw) = line.split(':').nth(1).map(|s| s.trim()) {
+            let name = raw.split('@').next().unwrap_or(raw);
             if name.starts_with("nkb-") || name.starts_with("nkx-") || name.starts_with("nkt-") {
                 tracing::info!(iface = name, "cleaning up stale interface");
                 let _ = Command::new("ip")
@@ -386,8 +387,9 @@ pub fn list_active_bridges() -> Vec<String> {
     stdout
         .lines()
         .filter_map(|line| {
-            // Format: "N: nkb-abc123: <...>"
-            let name = line.split(':').nth(1)?.trim();
+            // Format: "N: nkb-abc123: <...>" or "N: nkb-abc123@if1: <...>"
+            let raw = line.split(':').nth(1)?.trim();
+            let name = raw.split('@').next().unwrap_or(raw);
             if name.starts_with("nkb-") {
                 Some(name.to_string())
             } else {


### PR DESCRIPTION
## Summary
- When veths are deleted while containers are running, the forge now recreates them and re-injects the guest side into the container's network namespace (CM-025/CM-030)
- Fixes `list_veths()` and all interface-listing functions that parsed `ip -o link show` output without stripping the `@ifN` suffix — this caused the reconciler to falsely detect missing veths on every cycle

## Test plan
- [x] Deployed to 4-node Hetzner cluster (nauka-nbg-1 through nauka-nbg-4)
- [x] CM-025: Delete single veth → forge recreates + reinjects in one cycle, ping restored
- [x] CM-030: Delete all 9 nk interfaces → forge rebuilds bridges, VXLAN, veths + reinjects all 5 VMs in one cycle
- [x] No spurious "Cannot find device" errors in forge logs after fix

Closes #61 (CM-025, CM-030)

🤖 Generated with [Claude Code](https://claude.com/claude-code)