### PR TITLE
fix: API returns proper HTTP status codes for semantic errors

### DIFF
--- a/layers/core/src/api/error_response.rs
+++ b/layers/core/src/api/error_response.rs
@@ -132,6 +132,17 @@ mod tests {
     }
 
     #[test]
+    fn api_error_has_dependents() {
+        let err = ApiError(NaukaError::has_dependents(
+            "vpc",
+            "web",
+            "vpc 'web' has 2 subnet(s). Delete them first.",
+        ));
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[test]
     fn api_error_internal() {
         let err = ApiError(NaukaError::internal("oops"));
         let response = err.into_response();

--- a/layers/core/src/api/route_gen.rs
+++ b/layers/core/src/api/route_gen.rs
@@ -260,6 +260,43 @@ fn build_base_path(prefix: &str, plural: &str, parents: &[crate::resource::Paren
     format!("{path}/{plural}")
 }
 
+/// Classify an anyhow::Error into a properly-typed NaukaError.
+///
+/// First tries to downcast to NaukaError (preserving the original code).
+/// Falls back to message-based classification so that handler errors
+/// produced via `anyhow::bail!` get the correct HTTP status.
+fn classify_anyhow(err: anyhow::Error) -> NaukaError {
+    // If the handler already returned a typed NaukaError, use it directly.
+    if let Some(nauka_err) = err.downcast_ref::<NaukaError>() {
+        return nauka_err.clone();
+    }
+
+    let msg = err.to_string();
+
+    // "already exists" → 409
+    if msg.contains("already exists") {
+        return NaukaError::new(crate::error::ErrorCode::ResourceAlreadyExists, msg);
+    }
+
+    // "not found" → 404
+    if msg.contains("not found") {
+        return NaukaError::new(crate::error::ErrorCode::ResourceNotFound, msg);
+    }
+
+    // "has N …. Delete them first" → 422
+    if msg.contains("Delete them first") {
+        return NaukaError::new(crate::error::ErrorCode::HasDependents, msg);
+    }
+
+    // CIDR / validation errors → 400
+    if msg.contains("CIDR ") || msg.contains("CIDRs ") || msg.contains("must be") {
+        return NaukaError::validation(msg);
+    }
+
+    // Default: 500
+    NaukaError::internal(msg)
+}
+
 /// Handle an operation with scope values pre-populated.
 async fn handle_scoped(
     reg: &ResourceRegistration,
@@ -286,7 +323,7 @@ async fn handle_scoped(
 
     let response = (reg.handler)(request)
         .await
-        .map_err(|e: anyhow::Error| ApiError(NaukaError::internal(e.to_string())))?;
+        .map_err(|e: anyhow::Error| ApiError(classify_anyhow(e)))?;
 
     match response {
         OperationResponse::Resource(v) => {
@@ -636,5 +673,72 @@ mod tests {
         };
         let json = serde_json::to_string(&ri).unwrap();
         assert!(json.contains("GET"));
+    }
+
+    // ── classify_anyhow tests ──
+
+    #[test]
+    fn classify_already_exists() {
+        let err = anyhow::anyhow!("org 'acme' already exists");
+        let classified = classify_anyhow(err);
+        assert_eq!(classified.code, crate::error::ErrorCode::ResourceAlreadyExists);
+        assert_eq!(classified.http_status(), 409);
+    }
+
+    #[test]
+    fn classify_not_found() {
+        let err = anyhow::anyhow!("vpc 'web' not found");
+        let classified = classify_anyhow(err);
+        assert_eq!(classified.code, crate::error::ErrorCode::ResourceNotFound);
+        assert_eq!(classified.http_status(), 404);
+    }
+
+    #[test]
+    fn classify_has_dependents() {
+        let err = anyhow::anyhow!("vpc 'web' has 2 subnet(s). Delete them first.");
+        let classified = classify_anyhow(err);
+        assert_eq!(classified.code, crate::error::ErrorCode::HasDependents);
+        assert_eq!(classified.http_status(), 422);
+    }
+
+    #[test]
+    fn classify_cidr_validation() {
+        let err = anyhow::anyhow!("CIDR must be a private range (10.0.0.0/8, 172.16.0.0/12, or 192.168.0.0/16)");
+        let classified = classify_anyhow(err);
+        assert_eq!(classified.code, crate::error::ErrorCode::ValidationError);
+        assert_eq!(classified.http_status(), 400);
+    }
+
+    #[test]
+    fn classify_cidr_overlap() {
+        let err = anyhow::anyhow!("VPC CIDRs overlap: 10.0.0.0/16 and 10.0.0.0/24");
+        let classified = classify_anyhow(err);
+        assert_eq!(classified.code, crate::error::ErrorCode::ValidationError);
+        assert_eq!(classified.http_status(), 400);
+    }
+
+    #[test]
+    fn classify_must_be_validation() {
+        let err = anyhow::anyhow!("vm must be stopped or pending to delete (current state: running)");
+        let classified = classify_anyhow(err);
+        assert_eq!(classified.code, crate::error::ErrorCode::ValidationError);
+        assert_eq!(classified.http_status(), 400);
+    }
+
+    #[test]
+    fn classify_downcast_nauka_error() {
+        let nauka_err = NaukaError::not_found("vpc", "web");
+        let err = anyhow::Error::new(nauka_err);
+        let classified = classify_anyhow(err);
+        assert_eq!(classified.code, crate::error::ErrorCode::ResourceNotFound);
+        assert_eq!(classified.http_status(), 404);
+    }
+
+    #[test]
+    fn classify_unknown_defaults_to_500() {
+        let err = anyhow::anyhow!("something unexpected happened");
+        let classified = classify_anyhow(err);
+        assert_eq!(classified.code, crate::error::ErrorCode::InternalError);
+        assert_eq!(classified.http_status(), 500);
     }
 }

--- a/layers/core/src/api/route_gen.rs
+++ b/layers/core/src/api/route_gen.rs
@@ -681,7 +681,10 @@ mod tests {
     fn classify_already_exists() {
         let err = anyhow::anyhow!("org 'acme' already exists");
         let classified = classify_anyhow(err);
-        assert_eq!(classified.code, crate::error::ErrorCode::ResourceAlreadyExists);
+        assert_eq!(
+            classified.code,
+            crate::error::ErrorCode::ResourceAlreadyExists
+        );
         assert_eq!(classified.http_status(), 409);
     }
 
@@ -703,7 +706,9 @@ mod tests {
 
     #[test]
     fn classify_cidr_validation() {
-        let err = anyhow::anyhow!("CIDR must be a private range (10.0.0.0/8, 172.16.0.0/12, or 192.168.0.0/16)");
+        let err = anyhow::anyhow!(
+            "CIDR must be a private range (10.0.0.0/8, 172.16.0.0/12, or 192.168.0.0/16)"
+        );
         let classified = classify_anyhow(err);
         assert_eq!(classified.code, crate::error::ErrorCode::ValidationError);
         assert_eq!(classified.http_status(), 400);
@@ -719,7 +724,8 @@ mod tests {
 
     #[test]
     fn classify_must_be_validation() {
-        let err = anyhow::anyhow!("vm must be stopped or pending to delete (current state: running)");
+        let err =
+            anyhow::anyhow!("vm must be stopped or pending to delete (current state: running)");
         let classified = classify_anyhow(err);
         assert_eq!(classified.code, crate::error::ErrorCode::ValidationError);
         assert_eq!(classified.http_status(), 400);

--- a/layers/core/src/error.rs
+++ b/layers/core/src/error.rs
@@ -44,6 +44,7 @@ pub enum ErrorCode {
     PreconditionFailed,
     AmbiguousName,
     RateLimited,
+    HasDependents,
 
     // ── Server errors (5xx) ──
     InternalError,
@@ -69,6 +70,7 @@ impl ErrorCode {
             Self::PreconditionFailed => 412,
             Self::AmbiguousName => 400,
             Self::RateLimited => 429,
+            Self::HasDependents => 422,
             Self::InternalError => 500,
             Self::NotImplemented => 501,
             Self::DaemonUnreachable => 503,
@@ -108,6 +110,7 @@ impl ErrorCode {
             Self::PreconditionFailed => "PRECONDITION_FAILED",
             Self::AmbiguousName => "AMBIGUOUS_NAME",
             Self::RateLimited => "RATE_LIMITED",
+            Self::HasDependents => "HAS_DEPENDENTS",
             Self::InternalError => "INTERNAL_ERROR",
             Self::NotImplemented => "NOT_IMPLEMENTED",
             Self::DaemonUnreachable => "DAEMON_UNREACHABLE",
@@ -257,6 +260,12 @@ impl NaukaError {
         Self::new(ErrorCode::PreconditionFailed, message)
     }
 
+    pub fn has_dependents(kind: &str, name: &str, message: impl Into<String>) -> Self {
+        Self::new(ErrorCode::HasDependents, message)
+            .with_context("resource_kind", kind)
+            .with_context("resource_name", name)
+    }
+
     pub fn internal(message: impl Into<String>) -> Self {
         Self::new(ErrorCode::InternalError, message)
     }
@@ -373,6 +382,7 @@ mod tests {
         assert_eq!(ErrorCode::ValidationError.http_status(), 400);
         assert_eq!(ErrorCode::PermissionDenied.http_status(), 403);
         assert_eq!(ErrorCode::RateLimited.http_status(), 429);
+        assert_eq!(ErrorCode::HasDependents.http_status(), 422);
         assert_eq!(ErrorCode::InternalError.http_status(), 500);
         assert_eq!(ErrorCode::NotImplemented.http_status(), 501);
         assert_eq!(ErrorCode::DaemonUnreachable.http_status(), 503);
@@ -387,6 +397,7 @@ mod tests {
         assert!(ErrorCode::DaemonUnreachable.is_retryable());
         assert!(!ErrorCode::ResourceNotFound.is_retryable());
         assert!(!ErrorCode::ValidationError.is_retryable());
+        assert!(!ErrorCode::HasDependents.is_retryable());
         assert!(!ErrorCode::InternalError.is_retryable());
     }
 
@@ -479,6 +490,14 @@ mod tests {
         assert_eq!(err.code, ErrorCode::AmbiguousName);
         assert!(err.message.contains("vpc-01AAA"));
         assert!(err.message.contains("disambiguate"));
+    }
+
+    #[test]
+    fn has_dependents() {
+        let err = NaukaError::has_dependents("vpc", "web", "vpc 'web' has 2 subnet(s). Delete them first.");
+        assert_eq!(err.code, ErrorCode::HasDependents);
+        assert_eq!(err.http_status(), 422);
+        assert!(!err.is_retryable());
     }
 
     #[test]

--- a/layers/core/src/error.rs
+++ b/layers/core/src/error.rs
@@ -494,7 +494,11 @@ mod tests {
 
     #[test]
     fn has_dependents() {
-        let err = NaukaError::has_dependents("vpc", "web", "vpc 'web' has 2 subnet(s). Delete them first.");
+        let err = NaukaError::has_dependents(
+            "vpc",
+            "web",
+            "vpc 'web' has 2 subnet(s). Delete them first.",
+        );
         assert_eq!(err.code, ErrorCode::HasDependents);
         assert_eq!(err.http_status(), 422);
         assert!(!err.is_retryable());


### PR DESCRIPTION
## Summary
- Fixes #117: API was returning 500 Internal Server Error for all handler errors because `anyhow::Error` was unconditionally mapped to `NaukaError::internal()`
- Adds `classify_anyhow()` function in `route_gen.rs` that first tries to downcast to `NaukaError`, then falls back to message-based classification
- Adds `HasDependents` error code (HTTP 422) for dependency constraint violations ("Delete them first")

## Error mapping
| Pattern | HTTP Status | Error Code |
|---------|------------|------------|
| "already exists" | 409 Conflict | `RESOURCE_ALREADY_EXISTS` |
| "not found" | 404 Not Found | `RESOURCE_NOT_FOUND` |
| "Delete them first" | 422 Unprocessable Entity | `HAS_DEPENDENTS` |
| CIDR / "must be" | 400 Bad Request | `VALIDATION_ERROR` |
| Everything else | 500 Internal Server Error | `INTERNAL_ERROR` |

## Test plan
- [x] All 329 nauka-core unit tests pass
- [x] 8 new tests for `classify_anyhow()` covering each error category
- [x] New tests for `HasDependents` error code in error.rs and error_response.rs
- [x] `cargo clippy` clean
- [ ] Deploy to test VM and verify HTTP status codes with curl

🤖 Generated with [Claude Code](https://claude.com/claude-code)