### PR TITLE
fix: concurrent writes to shared ID registry lose data

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-musl]
+linker = "x86_64-linux-musl-gcc"

--- a/layers/compute/src/vm/store.rs
+++ b/layers/compute/src/vm/store.rs
@@ -6,7 +6,9 @@ use super::types::{Vm, VmState};
 
 const NS_VM: &str = "vm";
 const NS_VM_IDX: &str = "vm-idx";
-const REG_VMS: (&str, &str) = ("_reg", "vm-ids");
+const REG_V2_NS: &str = "_reg_v2";
+const REG_V2_PREFIX: &str = "vm/";
+const REG_V1: (&str, &str) = ("_reg", "vm-ids");
 
 pub struct VmStore {
     db: ClusterDb,
@@ -247,20 +249,34 @@ impl VmStore {
 }
 
 async fn load_ids(db: &ClusterDb) -> anyhow::Result<Vec<String>> {
-    let ids: Option<Vec<String>> = db.get(REG_VMS.0, REG_VMS.1).await?;
-    Ok(ids.unwrap_or_default())
+    let keys = db.scan_keys(REG_V2_NS, REG_V2_PREFIX).await?;
+    let mut ids: Vec<String> = keys
+        .into_iter()
+        .filter_map(|k| k.strip_prefix(REG_V2_PREFIX).map(|s| s.to_string()))
+        .collect();
+
+    if let Some(v1_ids) = db.get::<Vec<String>>(REG_V1.0, REG_V1.1).await? {
+        for old_id in v1_ids {
+            if !ids.contains(&old_id) {
+                let key = format!("{REG_V2_PREFIX}{old_id}");
+                db.put(REG_V2_NS, &key, &true).await?;
+                ids.push(old_id);
+            }
+        }
+        db.delete(REG_V1.0, REG_V1.1).await?;
+    }
+
+    Ok(ids)
 }
 
 async fn add_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let mut ids = load_ids(db).await?;
-    ids.push(id.to_string());
-    db.put(REG_VMS.0, REG_VMS.1, &ids).await?;
+    let key = format!("{REG_V2_PREFIX}{id}");
+    db.put(REG_V2_NS, &key, &true).await?;
     Ok(())
 }
 
 async fn remove_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let mut ids = load_ids(db).await?;
-    ids.retain(|i| i != id);
-    db.put(REG_VMS.0, REG_VMS.1, &ids).await?;
+    let key = format!("{REG_V2_PREFIX}{id}");
+    db.delete(REG_V2_NS, &key).await?;
     Ok(())
 }

--- a/layers/hypervisor/src/controlplane/store.rs
+++ b/layers/hypervisor/src/controlplane/store.rs
@@ -133,6 +133,42 @@ impl ClusterDb {
         Ok(results)
     }
 
+    /// Scan all keys under a namespace/prefix and return just the key suffixes.
+    ///
+    /// For example, `scan_keys("_reg_v2", "org/")` returns `["org/id1", "org/id2", ...]`.
+    /// Strip the prefix yourself to get just the IDs.
+    pub async fn scan_keys(
+        &self,
+        namespace: &str,
+        prefix: &str,
+    ) -> Result<Vec<String>, NaukaError> {
+        let full_prefix = format!("{namespace}/{prefix}");
+        let end_key = prefix_end(&full_prefix);
+
+        let pairs = self
+            .client
+            .scan(full_prefix.into_bytes()..end_key.into_bytes(), 10000)
+            .await
+            .map_err(|e| NaukaError::internal(format!("TiKV scan failed: {e}")))?;
+
+        let ns_prefix = format!("{namespace}/");
+        let mut keys = Vec::new();
+        for pair in pairs {
+            let key_bytes: Vec<u8> = Vec::from(pair.key().clone());
+            let key_str = String::from_utf8(key_bytes).unwrap_or_default();
+            if !key_str.starts_with(&ns_prefix) {
+                continue;
+            }
+            let short_key = key_str
+                .strip_prefix(&ns_prefix)
+                .unwrap_or(&key_str)
+                .to_string();
+            keys.push(short_key);
+        }
+
+        Ok(keys)
+    }
+
     /// Check if a key exists.
     pub async fn exists(&self, namespace: &str, key: &str) -> Result<bool, NaukaError> {
         let full_key = format!("{namespace}/{key}");

--- a/layers/network/src/vpc/natgw/store.rs
+++ b/layers/network/src/vpc/natgw/store.rs
@@ -7,7 +7,9 @@ use super::types::{NatGw, NatGwState};
 
 const NS_NATGW: &str = "natgw";
 const NS_NATGW_IDX: &str = "natgw-idx";
-const REG_NATGWS: (&str, &str) = ("_reg", "natgw-ids");
+const REG_V2_NS: &str = "_reg_v2";
+const REG_V2_PREFIX: &str = "natgw/";
+const REG_V1: (&str, &str) = ("_reg", "natgw-ids");
 
 pub struct NatGwStore {
     db: ClusterDb,
@@ -152,20 +154,34 @@ impl NatGwStore {
 }
 
 async fn load_ids(db: &ClusterDb) -> anyhow::Result<Vec<String>> {
-    let ids: Option<Vec<String>> = db.get(REG_NATGWS.0, REG_NATGWS.1).await?;
-    Ok(ids.unwrap_or_default())
+    let keys = db.scan_keys(REG_V2_NS, REG_V2_PREFIX).await?;
+    let mut ids: Vec<String> = keys
+        .into_iter()
+        .filter_map(|k| k.strip_prefix(REG_V2_PREFIX).map(|s| s.to_string()))
+        .collect();
+
+    if let Some(v1_ids) = db.get::<Vec<String>>(REG_V1.0, REG_V1.1).await? {
+        for old_id in v1_ids {
+            if !ids.contains(&old_id) {
+                let key = format!("{REG_V2_PREFIX}{old_id}");
+                db.put(REG_V2_NS, &key, &true).await?;
+                ids.push(old_id);
+            }
+        }
+        db.delete(REG_V1.0, REG_V1.1).await?;
+    }
+
+    Ok(ids)
 }
 
 async fn add_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let mut ids = load_ids(db).await?;
-    ids.push(id.to_string());
-    db.put(REG_NATGWS.0, REG_NATGWS.1, &ids).await?;
+    let key = format!("{REG_V2_PREFIX}{id}");
+    db.put(REG_V2_NS, &key, &true).await?;
     Ok(())
 }
 
 async fn remove_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let mut ids = load_ids(db).await?;
-    ids.retain(|i| i != id);
-    db.put(REG_NATGWS.0, REG_NATGWS.1, &ids).await?;
+    let key = format!("{REG_V2_PREFIX}{id}");
+    db.delete(REG_V2_NS, &key).await?;
     Ok(())
 }

--- a/layers/network/src/vpc/peering/store.rs
+++ b/layers/network/src/vpc/peering/store.rs
@@ -6,7 +6,9 @@ use super::types::{PeeringState, VpcPeering};
 
 const NS_PEER: &str = "vpcpeer";
 const NS_PEER_IDX: &str = "vpcpeer-idx";
-const REG_PEERS: (&str, &str) = ("_reg", "vpcpeer-ids");
+const REG_V2_NS: &str = "_reg_v2";
+const REG_V2_PREFIX: &str = "vpcpeer/";
+const REG_V1: (&str, &str) = ("_reg", "vpcpeer-ids");
 
 pub struct PeeringStore {
     db: ClusterDb,
@@ -132,20 +134,34 @@ impl PeeringStore {
 }
 
 async fn load_ids(db: &ClusterDb) -> anyhow::Result<Vec<String>> {
-    let ids: Option<Vec<String>> = db.get(REG_PEERS.0, REG_PEERS.1).await?;
-    Ok(ids.unwrap_or_default())
+    let keys = db.scan_keys(REG_V2_NS, REG_V2_PREFIX).await?;
+    let mut ids: Vec<String> = keys
+        .into_iter()
+        .filter_map(|k| k.strip_prefix(REG_V2_PREFIX).map(|s| s.to_string()))
+        .collect();
+
+    if let Some(v1_ids) = db.get::<Vec<String>>(REG_V1.0, REG_V1.1).await? {
+        for old_id in v1_ids {
+            if !ids.contains(&old_id) {
+                let key = format!("{REG_V2_PREFIX}{old_id}");
+                db.put(REG_V2_NS, &key, &true).await?;
+                ids.push(old_id);
+            }
+        }
+        db.delete(REG_V1.0, REG_V1.1).await?;
+    }
+
+    Ok(ids)
 }
 
 async fn add_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let mut ids = load_ids(db).await?;
-    ids.push(id.to_string());
-    db.put(REG_PEERS.0, REG_PEERS.1, &ids).await?;
+    let key = format!("{REG_V2_PREFIX}{id}");
+    db.put(REG_V2_NS, &key, &true).await?;
     Ok(())
 }
 
 async fn remove_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let mut ids = load_ids(db).await?;
-    ids.retain(|i| i != id);
-    db.put(REG_PEERS.0, REG_PEERS.1, &ids).await?;
+    let key = format!("{REG_V2_PREFIX}{id}");
+    db.delete(REG_V2_NS, &key).await?;
     Ok(())
 }

--- a/layers/network/src/vpc/store.rs
+++ b/layers/network/src/vpc/store.rs
@@ -6,7 +6,10 @@ use super::types::Vpc;
 
 const NS_VPC: &str = "vpc";
 const NS_VPC_IDX: &str = "vpc-idx";
-const REG_VPCS: (&str, &str) = ("_reg", "vpc-ids");
+const REG_V2_NS: &str = "_reg_v2";
+const REG_V2_PREFIX: &str = "vpc/";
+/// Legacy v1 registry key — read during migration, never written.
+const REG_V1: (&str, &str) = ("_reg", "vpc-ids");
 const VNI_COUNTER: (&str, &str) = ("_reg", "vni-counter");
 const VNI_START: u32 = 100;
 
@@ -148,20 +151,34 @@ impl VpcStore {
 }
 
 async fn load_ids(db: &ClusterDb) -> anyhow::Result<Vec<String>> {
-    let ids: Option<Vec<String>> = db.get(REG_VPCS.0, REG_VPCS.1).await?;
-    Ok(ids.unwrap_or_default())
+    let keys = db.scan_keys(REG_V2_NS, REG_V2_PREFIX).await?;
+    let mut ids: Vec<String> = keys
+        .into_iter()
+        .filter_map(|k| k.strip_prefix(REG_V2_PREFIX).map(|s| s.to_string()))
+        .collect();
+
+    if let Some(v1_ids) = db.get::<Vec<String>>(REG_V1.0, REG_V1.1).await? {
+        for old_id in v1_ids {
+            if !ids.contains(&old_id) {
+                let key = format!("{REG_V2_PREFIX}{old_id}");
+                db.put(REG_V2_NS, &key, &true).await?;
+                ids.push(old_id);
+            }
+        }
+        db.delete(REG_V1.0, REG_V1.1).await?;
+    }
+
+    Ok(ids)
 }
 
 async fn add_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let mut ids = load_ids(db).await?;
-    ids.push(id.to_string());
-    db.put(REG_VPCS.0, REG_VPCS.1, &ids).await?;
+    let key = format!("{REG_V2_PREFIX}{id}");
+    db.put(REG_V2_NS, &key, &true).await?;
     Ok(())
 }
 
 async fn remove_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let mut ids = load_ids(db).await?;
-    ids.retain(|i| i != id);
-    db.put(REG_VPCS.0, REG_VPCS.1, &ids).await?;
+    let key = format!("{REG_V2_PREFIX}{id}");
+    db.delete(REG_V2_NS, &key).await?;
     Ok(())
 }

--- a/layers/network/src/vpc/subnet/store.rs
+++ b/layers/network/src/vpc/subnet/store.rs
@@ -6,7 +6,9 @@ use super::types::Subnet;
 
 const NS_SUB: &str = "sub";
 const NS_SUB_IDX: &str = "sub-idx";
-const REG_SUBS: (&str, &str) = ("_reg", "sub-ids");
+const REG_V2_NS: &str = "_reg_v2";
+const REG_V2_PREFIX: &str = "sub/";
+const REG_V1: (&str, &str) = ("_reg", "sub-ids");
 
 pub struct SubnetStore {
     db: ClusterDb,
@@ -128,20 +130,34 @@ impl SubnetStore {
 }
 
 async fn load_ids(db: &ClusterDb) -> anyhow::Result<Vec<String>> {
-    let ids: Option<Vec<String>> = db.get(REG_SUBS.0, REG_SUBS.1).await?;
-    Ok(ids.unwrap_or_default())
+    let keys = db.scan_keys(REG_V2_NS, REG_V2_PREFIX).await?;
+    let mut ids: Vec<String> = keys
+        .into_iter()
+        .filter_map(|k| k.strip_prefix(REG_V2_PREFIX).map(|s| s.to_string()))
+        .collect();
+
+    if let Some(v1_ids) = db.get::<Vec<String>>(REG_V1.0, REG_V1.1).await? {
+        for old_id in v1_ids {
+            if !ids.contains(&old_id) {
+                let key = format!("{REG_V2_PREFIX}{old_id}");
+                db.put(REG_V2_NS, &key, &true).await?;
+                ids.push(old_id);
+            }
+        }
+        db.delete(REG_V1.0, REG_V1.1).await?;
+    }
+
+    Ok(ids)
 }
 
 async fn add_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let mut ids = load_ids(db).await?;
-    ids.push(id.to_string());
-    db.put(REG_SUBS.0, REG_SUBS.1, &ids).await?;
+    let key = format!("{REG_V2_PREFIX}{id}");
+    db.put(REG_V2_NS, &key, &true).await?;
     Ok(())
 }
 
 async fn remove_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let mut ids = load_ids(db).await?;
-    ids.retain(|i| i != id);
-    db.put(REG_SUBS.0, REG_SUBS.1, &ids).await?;
+    let key = format!("{REG_V2_PREFIX}{id}");
+    db.delete(REG_V2_NS, &key).await?;
     Ok(())
 }

--- a/layers/org/src/project/env/store.rs
+++ b/layers/org/src/project/env/store.rs
@@ -9,7 +9,9 @@ use crate::project;
 
 const NS_ENV: &str = "env";
 const NS_ENV_IDX: &str = "env-idx";
-const REG_ENVS: (&str, &str) = ("_reg", "env-ids");
+const REG_V2_NS: &str = "_reg_v2";
+const REG_V2_PREFIX: &str = "env/";
+const REG_V1: (&str, &str) = ("_reg", "env-ids");
 
 pub struct EnvStore {
     db: ClusterDb,
@@ -136,20 +138,34 @@ impl EnvStore {
 }
 
 async fn load_ids(db: &ClusterDb) -> anyhow::Result<Vec<String>> {
-    let ids: Option<Vec<String>> = db.get(REG_ENVS.0, REG_ENVS.1).await?;
-    Ok(ids.unwrap_or_default())
+    let keys = db.scan_keys(REG_V2_NS, REG_V2_PREFIX).await?;
+    let mut ids: Vec<String> = keys
+        .into_iter()
+        .filter_map(|k| k.strip_prefix(REG_V2_PREFIX).map(|s| s.to_string()))
+        .collect();
+
+    if let Some(v1_ids) = db.get::<Vec<String>>(REG_V1.0, REG_V1.1).await? {
+        for old_id in v1_ids {
+            if !ids.contains(&old_id) {
+                let key = format!("{REG_V2_PREFIX}{old_id}");
+                db.put(REG_V2_NS, &key, &true).await?;
+                ids.push(old_id);
+            }
+        }
+        db.delete(REG_V1.0, REG_V1.1).await?;
+    }
+
+    Ok(ids)
 }
 
 async fn add_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let mut ids = load_ids(db).await?;
-    ids.push(id.to_string());
-    db.put(REG_ENVS.0, REG_ENVS.1, &ids).await?;
+    let key = format!("{REG_V2_PREFIX}{id}");
+    db.put(REG_V2_NS, &key, &true).await?;
     Ok(())
 }
 
 async fn remove_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let mut ids = load_ids(db).await?;
-    ids.retain(|i| i != id);
-    db.put(REG_ENVS.0, REG_ENVS.1, &ids).await?;
+    let key = format!("{REG_V2_PREFIX}{id}");
+    db.delete(REG_V2_NS, &key).await?;
     Ok(())
 }

--- a/layers/org/src/project/store.rs
+++ b/layers/org/src/project/store.rs
@@ -8,7 +8,9 @@ use super::types::Project;
 
 const NS_PROJ: &str = "proj";
 const NS_PROJ_IDX: &str = "proj-idx";
-const REG_PROJECTS: (&str, &str) = ("_reg", "proj-ids");
+const REG_V2_NS: &str = "_reg_v2";
+const REG_V2_PREFIX: &str = "proj/";
+const REG_V1: (&str, &str) = ("_reg", "proj-ids");
 
 pub struct ProjectStore {
     db: ClusterDb,
@@ -114,20 +116,34 @@ impl ProjectStore {
 }
 
 async fn load_ids(db: &ClusterDb) -> anyhow::Result<Vec<String>> {
-    let ids: Option<Vec<String>> = db.get(REG_PROJECTS.0, REG_PROJECTS.1).await?;
-    Ok(ids.unwrap_or_default())
+    let keys = db.scan_keys(REG_V2_NS, REG_V2_PREFIX).await?;
+    let mut ids: Vec<String> = keys
+        .into_iter()
+        .filter_map(|k| k.strip_prefix(REG_V2_PREFIX).map(|s| s.to_string()))
+        .collect();
+
+    if let Some(v1_ids) = db.get::<Vec<String>>(REG_V1.0, REG_V1.1).await? {
+        for old_id in v1_ids {
+            if !ids.contains(&old_id) {
+                let key = format!("{REG_V2_PREFIX}{old_id}");
+                db.put(REG_V2_NS, &key, &true).await?;
+                ids.push(old_id);
+            }
+        }
+        db.delete(REG_V1.0, REG_V1.1).await?;
+    }
+
+    Ok(ids)
 }
 
 async fn add_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let mut ids = load_ids(db).await?;
-    ids.push(id.to_string());
-    db.put(REG_PROJECTS.0, REG_PROJECTS.1, &ids).await?;
+    let key = format!("{REG_V2_PREFIX}{id}");
+    db.put(REG_V2_NS, &key, &true).await?;
     Ok(())
 }
 
 async fn remove_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let mut ids = load_ids(db).await?;
-    ids.retain(|i| i != id);
-    db.put(REG_PROJECTS.0, REG_PROJECTS.1, &ids).await?;
+    let key = format!("{REG_V2_PREFIX}{id}");
+    db.delete(REG_V2_NS, &key).await?;
     Ok(())
 }

--- a/layers/org/src/store.rs
+++ b/layers/org/src/store.rs
@@ -8,7 +8,10 @@ use crate::types::Org;
 
 const NS_ORG: &str = "org";
 const NS_ORG_IDX: &str = "org-idx";
-const REG_ORGS: (&str, &str) = ("_reg", "org-ids");
+const REG_V2_NS: &str = "_reg_v2";
+const REG_V2_PREFIX: &str = "org/";
+/// Legacy v1 registry key — read during migration, never written.
+const REG_V1: (&str, &str) = ("_reg", "org-ids");
 
 pub struct OrgStore {
     db: ClusterDb,
@@ -88,20 +91,38 @@ impl OrgStore {
 }
 
 async fn load_ids(db: &ClusterDb) -> anyhow::Result<Vec<String>> {
-    let ids: Option<Vec<String>> = db.get(REG_ORGS.0, REG_ORGS.1).await?;
-    Ok(ids.unwrap_or_default())
+    // Primary: per-key scan (race-free)
+    let keys = db.scan_keys(REG_V2_NS, REG_V2_PREFIX).await?;
+    let mut ids: Vec<String> = keys
+        .into_iter()
+        .filter_map(|k| k.strip_prefix(REG_V2_PREFIX).map(|s| s.to_string()))
+        .collect();
+
+    // Backwards compat: merge any IDs from the legacy v1 list that aren't in v2 yet
+    if let Some(v1_ids) = db.get::<Vec<String>>(REG_V1.0, REG_V1.1).await? {
+        for old_id in v1_ids {
+            if !ids.contains(&old_id) {
+                // Migrate to v2 on the fly
+                let key = format!("{REG_V2_PREFIX}{old_id}");
+                db.put(REG_V2_NS, &key, &true).await?;
+                ids.push(old_id);
+            }
+        }
+        // Clean up legacy key after full migration
+        db.delete(REG_V1.0, REG_V1.1).await?;
+    }
+
+    Ok(ids)
 }
 
 async fn add_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let mut ids = load_ids(db).await?;
-    ids.push(id.to_string());
-    db.put(REG_ORGS.0, REG_ORGS.1, &ids).await?;
+    let key = format!("{REG_V2_PREFIX}{id}");
+    db.put(REG_V2_NS, &key, &true).await?;
     Ok(())
 }
 
 async fn remove_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let mut ids = load_ids(db).await?;
-    ids.retain(|i| i != id);
-    db.put(REG_ORGS.0, REG_ORGS.1, &ids).await?;
+    let key = format!("{REG_V2_PREFIX}{id}");
+    db.delete(REG_V2_NS, &key).await?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Replaces the shared list key (`_reg/xxx-ids`) with per-resource keys (`_reg_v2/type/{id} = true`) across all 8 resource stores (org, project, env, vpc, subnet, natgw, peering, vm)
- Adds `scan_keys()` method to `ClusterDb` for efficient prefix-based key enumeration
- Includes backwards-compatible migration: on first `list()` call, legacy v1 keys are promoted to v2 format and the old key is deleted

## Root cause
The old `add_id()` did read-modify-write on a single shared key. Under concurrent writes, only the last writer's version persisted -- other IDs were silently lost. Resources existed but never appeared in `list`.

## Fix
Each resource ID is now stored as its own key (`_reg_v2/org/{id}`, `_reg_v2/vpc/{id}`, etc.). `add_id` is a single `put`, `remove_id` is a single `delete`, and `load_ids` does a prefix scan. No read-modify-write, no race.

## Test plan
- [x] `cargo build --release --target x86_64-unknown-linux-musl` succeeds
- [x] `cargo test` passes (113/113 in hypervisor, pre-existing `disk_free_check` failure unrelated)
- [x] Deployed to Hetzner test VM (178.104.132.55)
- [x] Created 50 orgs concurrently via curl -- all 50 appear in list
- [x] Existing data (141 orgs) still visible after upgrade (v1 migration works)

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)