### PR TITLE
fix: subnet CIDR overlap check crosses org boundaries

### DIFF
--- a/layers/network/src/vpc/subnet/store.rs
+++ b/layers/network/src/vpc/subnet/store.rs
@@ -34,7 +34,7 @@ impl SubnetStore {
         let subnet_net = crate::validate::subnet_within_vpc(cidr, &vpc.cidr)?;
 
         // Check overlap with existing subnets
-        let existing_subs = self.list(Some(&vpc.meta.name), None).await?;
+        let existing_subs = self.list(Some(&vpc.meta.id), None).await?;
         let existing_cidrs: Vec<String> = existing_subs.iter().map(|s| s.cidr.clone()).collect();
         crate::validate::no_overlap(&subnet_net, &existing_cidrs)?;
 


### PR DESCRIPTION
## Summary
- Fixed `SubnetStore::create()` in `layers/network/src/vpc/subnet/store.rs` to pass `vpc.meta.id` instead of `vpc.meta.name` when checking for CIDR overlap
- The `list()` method already supports filtering by ID (`s.vpc_id.as_str() == name`), so passing the unique VPC ID correctly scopes the overlap check to the specific VPC instance rather than all VPCs sharing the same name across orgs

## Test plan
Verified on Hetzner test VM (178.104.141.22):
- [x] Created two orgs (`alpha`, `beta`) with identically-named VPCs (`net`, CIDR `10.0.0.0/16`)
- [x] Creating subnet `web` (`10.0.1.0/24`) in `alpha/net` succeeds
- [x] Creating subnet `web` (`10.0.1.0/24`) in `beta/net` succeeds (was failing before fix)
- [x] Creating subnet `api` (`10.0.1.0/24`) in `alpha/net` correctly fails with overlap error
- [x] `cargo build` and `cargo test -p nauka-network` pass (25 tests)

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)