### PR TITLE
fix: reconciler skips orphaned VMs whose org was deleted (#114)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,6 +1544,7 @@ dependencies = [
  "nauka-core",
  "nauka-hypervisor",
  "nauka-network",
+ "nauka-org",
  "nauka-state",
  "serde",
  "serde_json",

--- a/layers/forge/Cargo.toml
+++ b/layers/forge/Cargo.toml
@@ -12,6 +12,7 @@ nauka-state = { path = "../state" }
 nauka-hypervisor = { path = "../hypervisor" }
 nauka-compute = { path = "../compute" }
 nauka-network = { path = "../network" }
+nauka-org = { path = "../org" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/layers/forge/src/reconciler/vm.rs
+++ b/layers/forge/src/reconciler/vm.rs
@@ -45,11 +45,24 @@ impl super::Reconciler for VmReconciler {
             })
             .collect();
 
-        // VMs that should be running (pending = needs starting, running = should be alive)
-        let should_exist: Vec<_> = local_vms
-            .iter()
-            .filter(|vm| vm.state == VmState::Pending || vm.state == VmState::Running)
-            .collect();
+        // VMs that should be running (pending = needs starting, running = should be alive).
+        // Skip orphaned VMs whose org no longer exists (cascading orphan).
+        let org_store = nauka_org::store::OrgStore::new(ctx.db.clone());
+        let mut should_exist: Vec<_> = Vec::new();
+        for vm in &local_vms {
+            if vm.state != VmState::Pending && vm.state != VmState::Running {
+                continue;
+            }
+            if org_store.get(vm.org_id.as_str()).await?.is_none() {
+                tracing::warn!(
+                    vm_id = vm.meta.id.as_str(),
+                    org_id = vm.org_id.as_str(),
+                    "skipping orphaned VM (org deleted)"
+                );
+                continue;
+            }
+            should_exist.push(vm);
+        }
 
         result.desired = should_exist.len();
 


### PR DESCRIPTION
## Summary
- Reconciler checks if VM's org exists before including it in the desired set
- Orphaned VMs (org deleted) are logged and skipped
- Prevents 25+ containers from being recreated every reconcile cycle

## Before
```
vm: 25 desired, 0 actual — created:25
```
Every cycle recreates containers for VMs whose org no longer exists.

## After
```
vm: 1 desired, 1 actual — in sync
```
Only VMs with valid orgs are reconciled.

## Test plan
- [x] Delete all orgs, run `nauka forge reconcile` — orphaned VMs not recreated
- [x] Second reconcile shows `in sync` — stable

Fixes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)