### PR TITLE
feat: critical alerts for PD quorum loss, store tombstone, disk full

### DIFF
--- a/layers/hypervisor/alerts/controlplane.rules.yml
+++ b/layers/hypervisor/alerts/controlplane.rules.yml
@@ -1,0 +1,99 @@
+# Nauka controlplane alert rules — Prometheus-compatible.
+#
+# PD and TiKV expose metrics on /metrics by default.
+# These rules cover quorum loss, store health, region health, and disk usage.
+#
+# PD metrics port: 2379 (same as client port)
+# TiKV metrics port: 20180
+
+groups:
+  - name: nauka_controlplane
+    rules:
+      # ── PD quorum ──────────────────────────────────────
+
+      - alert: PDLeaderMissing
+        expr: pd_cluster_status{type="leader_health"} == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "PD leader missing for 5 minutes"
+          description: "The PD cluster has no healthy leader. Quorum may be lost."
+
+      - alert: PDMembersDegraded
+        expr: pd_cluster_status{type="member_count"} < 3
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "PD member count below quorum threshold"
+          description: "PD has fewer than 3 members. The cluster cannot tolerate another failure."
+
+      # ── TiKV store health ──────────────────────────────
+
+      - alert: TiKVStoreTombstoned
+        expr: pd_cluster_status{type="store_tombstone_count"} > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "TiKV store is tombstoned"
+          description: "One or more TiKV stores are in Tombstone state and no longer serving data."
+
+      - alert: TiKVStoreOffline
+        expr: pd_cluster_status{type="store_disconnected_count"} > 0
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "TiKV store offline for over 1 hour"
+          description: "A TiKV store has been disconnected. PD will begin migrating regions if this persists."
+
+      - alert: TiKVStoreDown
+        expr: pd_cluster_status{type="store_down_count"} > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "TiKV store is down"
+          description: "One or more TiKV stores are marked as Down by PD."
+
+      # ── Region health ──────────────────────────────────
+
+      - alert: TiKVRegionNoLeader
+        expr: pd_regions_status{type="miss-peer-region-count"} > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Regions missing peers"
+          description: "Some regions have fewer replicas than expected. Data durability is at risk."
+
+      - alert: RegionReplicaCountLow
+        expr: pd_regions_status{type="extra-peer-region-count"} > 0 or pd_regions_status{type="miss-peer-region-count"} > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Region replica count is abnormal"
+          description: "Regions have extra or missing peers. The scheduler may be rebalancing."
+
+      # ── Disk usage ─────────────────────────────────────
+
+      - alert: DiskUsageHigh
+        expr: node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"} < 0.15
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Disk usage above 85%"
+          description: "Root filesystem has less than 15% free space."
+
+      - alert: DiskUsageCritical
+        expr: node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"} < 0.05
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Disk usage above 95%"
+          description: "Root filesystem has less than 5% free space. TiKV may crash or refuse writes."

--- a/layers/hypervisor/src/doctor.rs
+++ b/layers/hypervisor/src/doctor.rs
@@ -302,11 +302,62 @@ fn check_controlplane(report: &mut DoctorReport, mesh_ipv6: Option<&Ipv6Addr>) {
             checks.push(warn("pd health", "could not reach PD API"));
         }
 
-        // TiKV store registration
+        // PD quorum health — are all members healthy?
+        let members_url = format!("{pd_url}/pd/api/v1/members");
+        if let Some(body) = curl_json(&members_url) {
+            if let Some(members) = body["members"].as_array() {
+                let total = members.len();
+                if total < 3 {
+                    checks.push(warn(
+                        "pd quorum",
+                        &format!("only {total} member(s) — need 3 for fault tolerance"),
+                    ));
+                } else {
+                    checks.push(ok("pd quorum", &format!("{total} members — quorum intact")));
+                }
+            }
+        }
+
+        // TiKV store registration + health
         let stores_url = format!("{pd_url}/pd/api/v1/stores");
         if let Some(body) = curl_json(&stores_url) {
             let count = body["count"].as_u64().unwrap_or(0);
             checks.push(ok("tikv stores", &format!("{count} registered")));
+
+            // Check for tombstoned or offline stores
+            if let Some(stores) = body["stores"].as_array() {
+                let mut tombstoned = 0u64;
+                let mut offline = 0u64;
+                let mut down = 0u64;
+                for store in stores {
+                    if let Some(state) = store["store"]["state_name"].as_str() {
+                        match state {
+                            "Tombstone" => tombstoned += 1,
+                            "Offline" => offline += 1,
+                            "Down" => down += 1,
+                            _ => {}
+                        }
+                    }
+                }
+                if tombstoned > 0 {
+                    checks.push(fail(
+                        "tikv tombstoned",
+                        &format!("{tombstoned} store(s) tombstoned — data may be under-replicated"),
+                    ));
+                }
+                if down > 0 {
+                    checks.push(fail("tikv down", &format!("{down} store(s) down")));
+                }
+                if offline > 0 {
+                    checks.push(warn(
+                        "tikv offline",
+                        &format!("{offline} store(s) offline — regions migrating"),
+                    ));
+                }
+                if tombstoned == 0 && offline == 0 && down == 0 {
+                    checks.push(ok("tikv store health", "all stores Up"));
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add Prometheus-compatible alert rules (`layers/hypervisor/alerts/controlplane.rules.yml`) covering PD quorum loss, TiKV store tombstone/offline/down, region health, and disk usage
- Extend `hypervisor doctor` with PD quorum health check (member count) and TiKV store status checks (tombstoned, offline, down)
- Deployed and verified on all 3 Hetzner servers — doctor runs cleanly

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test -- --skip disk_free_check` passes
- [x] Cross-compiled for x86_64-unknown-linux-musl
- [x] Deployed to 3 Hetzner servers and ran `nauka hypervisor doctor` — new checks present and functional

Closes #128