### PR TITLE
fix: enable WAL fsync for durable TiKV writes

### DIFF
--- a/layers/hypervisor/src/controlplane/service.rs
+++ b/layers/hypervisor/src/controlplane/service.rs
@@ -197,6 +197,8 @@ filename = "/var/log/nauka/tikv.log"
 max-size = 50
 
 [raftstore]
+# Fsync WAL on every write — prevents data loss on crash
+sync-log = true
 # Reduce resource usage for small clusters
 capacity = "0"
 "#,


### PR DESCRIPTION
## Summary
- Adds `sync-log = true` to TiKV's `[raftstore]` config section, ensuring the WAL is fsynced on every write
- Eliminates the ~100ms-1s data loss window on crash that exists with TiKV's default group-commit behavior

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test -- --skip disk_free_check` passes (all tests green)
- [x] Cross-compiled and deployed to Hetzner servers
- [x] Verified existing `generate_tikv_conf` unit tests pass with the new config line

Closes #126