### PR TITLE
feat: expose Prometheus metrics for PD and TiKV

### DIFF
--- a/layers/hypervisor/src/controlplane/mod.rs
+++ b/layers/hypervisor/src/controlplane/mod.rs
@@ -18,6 +18,7 @@ pub mod store;
 pub const PD_CLIENT_PORT: u16 = 2379;
 pub const PD_PEER_PORT: u16 = 2380;
 pub const TIKV_PORT: u16 = 20160;
+pub const TIKV_STATUS_PORT: u16 = 20180;
 
 pub use store::ClusterDb;
 

--- a/layers/hypervisor/src/controlplane/service.rs
+++ b/layers/hypervisor/src/controlplane/service.rs
@@ -182,6 +182,7 @@ pub fn generate_tikv_conf(cfg: &TikvConfig) -> String {
 [server]
 addr = "[{ip}]:{tikv_port}"
 advertise-addr = "[{ip}]:{tikv_port}"
+status-addr = "[{ip}]:{status_port}"
 
 [storage]
 data-dir = "{TIKV_DATA_DIR}"
@@ -202,6 +203,7 @@ capacity = "0"
 "#,
         ip = cfg.mesh_ipv6,
         tikv_port = super::TIKV_PORT,
+        status_port = super::TIKV_STATUS_PORT,
         pd_list = pd_endpoints.join(", "),
     )
 }


### PR DESCRIPTION
## Summary
- Add `status-addr` (port 20180) to TiKV config generation, enabling the `/metrics` endpoint for Prometheus scraping
- PD already exposes `/metrics` on its client port (2379) by default, no config change needed
- Add `TIKV_STATUS_PORT` constant to `controlplane/mod.rs`

## Verified on Hetzner
- PD: `curl http://[mesh_ipv6]:2379/metrics` returns Prometheus format output
- TiKV: `curl http://[mesh_ipv6]:20180/metrics` returns ~620KB of Prometheus metrics

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test -- --skip disk_free_check` passes
- [x] Cross-compiled with `cargo build --release --target x86_64-unknown-linux-musl`
- [x] Deployed to Hetzner servers and confirmed both endpoints return Prometheus metrics

Closes #127