### PR TITLE
feat: add gRPC keepalive for TiKV-PD connection

### DIFF
--- a/layers/hypervisor/src/controlplane/service.rs
+++ b/layers/hypervisor/src/controlplane/service.rs
@@ -183,6 +183,8 @@ pub fn generate_tikv_conf(cfg: &TikvConfig) -> String {
 addr = "[{ip}]:{tikv_port}"
 advertise-addr = "[{ip}]:{tikv_port}"
 status-addr = "[{ip}]:{status_port}"
+grpc-keepalive-time = "15s"
+grpc-keepalive-timeout = "30s"
 
 [storage]
 data-dir = "{TIKV_DATA_DIR}"


### PR DESCRIPTION
## Summary
- Add `grpc-keepalive-time = "15s"` and `grpc-keepalive-timeout = "30s"` to the TiKV `[server]` config section
- When WireGuard flaps, TiKV will detect broken PD connections within 45s and reconnect instead of silently timing out

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test -- --skip disk_free_check` passes
- [x] Cross-compiled for `x86_64-unknown-linux-musl`
- [x] Deployed to 3 Hetzner servers, left and rejoined to regenerate config
- [x] Verified `grep keepalive /etc/nauka/tikv.toml` shows both settings

Closes #129