### PR TITLE
feat: extract TiKV/PD versions and add upgrade-check command

### DIFF
--- a/layers/hypervisor/src/controlplane/mod.rs
+++ b/layers/hypervisor/src/controlplane/mod.rs
@@ -15,6 +15,10 @@ pub mod ops;
 pub mod service;
 pub mod store;
 
+/// Expected component versions (used by upgrade-check and doctor).
+pub const PD_VERSION: &str = "v8.5.5";
+pub const TIKV_VERSION: &str = "v8.5.5";
+
 /// Default ports (on mesh IPv6).
 pub const PD_CLIENT_PORT: u16 = 2379;
 pub const PD_PEER_PORT: u16 = 2380;

--- a/layers/hypervisor/src/controlplane/service.rs
+++ b/layers/hypervisor/src/controlplane/service.rs
@@ -638,8 +638,8 @@ pub fn recover_pd_quorum(mesh_ipv6: &std::net::Ipv6Addr) -> bool {
     let _ = run_systemctl(&["stop", PD_SERVICE]);
 
     // Run pd-server --force-new-cluster briefly to rewrite etcd state
-    const PD_BINARY: &str = "/opt/nauka/tiup/components/pd/v8.5.5/pd-server";
-    let child = Command::new(PD_BINARY)
+    let pd_binary = format!("{TIUP_HOME}/components/pd/{}/pd-server", super::PD_VERSION);
+    let child = Command::new(&pd_binary)
         .args(["--config", PD_CONF_PATH, "--force-new-cluster"])
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -944,6 +944,31 @@ pub fn wait_regions_healthy(pd_url: &str, timeout_secs: u64) -> Result<(), Nauka
     // Not fatal — best effort
     tracing::warn!("timed out waiting for region leaders, proceeding anyway");
     Ok(())
+}
+
+/// Detect installed PD version by scanning the TiUP components directory.
+///
+/// Returns `Some("v8.5.5")` if a versioned directory exists, `None` otherwise.
+pub fn installed_pd_version() -> Option<String> {
+    installed_component_version("pd")
+}
+
+/// Detect installed TiKV version by scanning the TiUP components directory.
+pub fn installed_tikv_version() -> Option<String> {
+    installed_component_version("tikv")
+}
+
+fn installed_component_version(component: &str) -> Option<String> {
+    let dir = format!("{TIUP_HOME}/components/{component}");
+    let entries = std::fs::read_dir(&dir).ok()?;
+    // Find the first directory matching v<digits>
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with('v') && entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            return Some(name);
+        }
+    }
+    None
 }
 
 /// Uninstall everything — stop services, remove configs, data.

--- a/layers/hypervisor/src/doctor.rs
+++ b/layers/hypervisor/src/doctor.rs
@@ -266,6 +266,37 @@ fn check_controlplane(report: &mut DoctorReport, mesh_ipv6: Option<&Ipv6Addr>) {
         checks.push(fail("tikv service", "not installed"));
     }
 
+    // Version checks — compare installed vs expected
+    match controlplane::service::installed_pd_version() {
+        Some(ref v) if v == controlplane::PD_VERSION => {
+            checks.push(ok("pd version", &format!("{v} (expected)")));
+        }
+        Some(ref v) => {
+            checks.push(warn(
+                "pd version",
+                &format!("{v} (expected {})", controlplane::PD_VERSION),
+            ));
+        }
+        None => {
+            checks.push(skip("pd version", "not installed"));
+        }
+    }
+
+    match controlplane::service::installed_tikv_version() {
+        Some(ref v) if v == controlplane::TIKV_VERSION => {
+            checks.push(ok("tikv version", &format!("{v} (expected)")));
+        }
+        Some(ref v) => {
+            checks.push(warn(
+                "tikv version",
+                &format!("{v} (expected {})", controlplane::TIKV_VERSION),
+            ));
+        }
+        None => {
+            checks.push(skip("tikv version", "not installed"));
+        }
+    }
+
     // PD health + leader
     if let Some(ip) = mesh_ipv6 {
         let pd_url = format!("http://[{}]:{}", ip, controlplane::PD_CLIENT_PORT);

--- a/layers/hypervisor/src/handlers.rs
+++ b/layers/hypervisor/src/handlers.rs
@@ -201,6 +201,11 @@ pub fn resource_def() -> ResourceDef {
             op.with_output(OutputKind::Message)
                 .with_example("nauka hypervisor backup-list")
         })
+        .action("upgrade-check", "Check TiKV/PD versions and upgrade readiness")
+        .op(|op| {
+            op.with_output(OutputKind::Message)
+                .with_example("nauka hypervisor upgrade-check")
+        })
         .action("doctor", "Diagnose hypervisor health")
         .action("announce-listen", "Run the announce listener (internal)")
         .op(|op| {
@@ -257,6 +262,7 @@ pub fn handler() -> HandlerFn {
                 "peering" => handle_peering(req).await,
                 "backup" => handle_backup().await,
                 "backup-list" => handle_backup_list().await,
+                "upgrade-check" => handle_upgrade_check().await,
                 "doctor" => handle_doctor().await,
                 "announce-listen" => handle_announce_listen(req).await,
                 "drain" => Ok(OperationResponse::Message("drain: not yet implemented".into())),
@@ -960,6 +966,77 @@ async fn handle_backup_list() -> anyhow::Result<OperationResponse> {
     }
 
     Ok(OperationResponse::Message(lines.join("\n")))
+}
+
+async fn handle_upgrade_check() -> anyhow::Result<OperationResponse> {
+    let mut lines = Vec::new();
+
+    lines.push("  Component versions:".to_string());
+    lines.push(String::new());
+
+    // Expected versions
+    let expected_pd = controlplane::PD_VERSION;
+    let expected_tikv = controlplane::TIKV_VERSION;
+
+    // Installed versions
+    let installed_pd = controlplane::service::installed_pd_version();
+    let installed_tikv = controlplane::service::installed_tikv_version();
+
+    let pd_match = installed_pd.as_deref() == Some(expected_pd);
+    let tikv_match = installed_tikv.as_deref() == Some(expected_tikv);
+
+    let pd_installed = installed_pd.as_deref().unwrap_or("not installed");
+    let tikv_installed = installed_tikv.as_deref().unwrap_or("not installed");
+
+    let pd_icon = if pd_match {
+        "\x1b[32m✓\x1b[0m"
+    } else {
+        "\x1b[33m!\x1b[0m"
+    };
+    let tikv_icon = if tikv_match {
+        "\x1b[32m✓\x1b[0m"
+    } else {
+        "\x1b[33m!\x1b[0m"
+    };
+
+    lines.push(format!(
+        "    {pd_icon} PD     installed: {pd_installed:<12} expected: {expected_pd}"
+    ));
+    lines.push(format!(
+        "    {tikv_icon} TiKV   installed: {tikv_installed:<12} expected: {expected_tikv}"
+    ));
+
+    // Service status
+    lines.push(String::new());
+    lines.push("  Service status:".to_string());
+    lines.push(String::new());
+
+    let pd_active = controlplane::service::pd_is_active();
+    let tikv_active = controlplane::service::tikv_is_active();
+    lines.push(format!(
+        "    PD:   {}",
+        if pd_active { "running" } else { "stopped" }
+    ));
+    lines.push(format!(
+        "    TiKV: {}",
+        if tikv_active { "running" } else { "stopped" }
+    ));
+
+    // Verdict
+    lines.push(String::new());
+    if pd_match && tikv_match {
+        lines.push(
+            "  \x1b[32mAll components at expected versions. No upgrade needed.\x1b[0m".to_string(),
+        );
+    } else {
+        lines
+            .push("  \x1b[33mVersion mismatch detected. Upgrade may be needed.\x1b[0m".to_string());
+        lines.push("  Rolling upgrade orchestration is not yet implemented.".to_string());
+    }
+
+    let output = lines.join("\n");
+    eprintln!("{output}");
+    Ok(OperationResponse::None)
 }
 
 async fn handle_doctor() -> anyhow::Result<OperationResponse> {


### PR DESCRIPTION
## Summary
- Extract `PD_VERSION` and `TIKV_VERSION` constants to `controlplane/mod.rs`, replacing the hardcoded `v8.5.5` path in `service.rs`
- Add `installed_pd_version()` / `installed_tikv_version()` helpers that scan the TiUP components directory
- Add version mismatch checks to `nauka hypervisor doctor` (WARN when installed differs from expected)
- Add `nauka hypervisor upgrade-check` command showing installed vs expected versions and service status

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes clean
- [x] `cargo test -- --skip disk_free_check` passes (all 458+ tests)
- [x] Cross-compiled for x86_64-unknown-linux-musl
- [x] Deployed to 3 Hetzner servers and verified:
  - `nauka hypervisor upgrade-check` shows correct version info
  - `nauka hypervisor doctor` shows version check lines

Closes #135