### PR TITLE
fix: make leave idempotent with verified region drain

### DIFF
--- a/layers/hypervisor/src/controlplane/ops.rs
+++ b/layers/hypervisor/src/controlplane/ops.rs
@@ -307,30 +307,61 @@ pub fn restart() -> Result<(), NaukaError> {
 }
 
 /// Uninstall the control plane. Deregisters TiKV store, adjusts replicas,
-/// waits for region migration, then removes PD member.
+/// waits for region drain, then removes PD member.
+///
+/// **Idempotent**: each step checks whether it has already been completed
+/// (e.g., store already tombstoned, PD member already removed) and skips
+/// accordingly. Safe to call again after a crash mid-leave.
 pub fn leave_with_mesh(mesh_ipv6: &Ipv6Addr) -> Result<(), NaukaError> {
     let pd_url = format!("http://[{}]:{}", mesh_ipv6, super::PD_CLIENT_PORT);
+    let our_addr = format!("[{}]:{}", mesh_ipv6, super::TIKV_PORT);
 
-    // 1. Deregister TiKV store (marks it as Tombstone in PD)
-    let _ = service::deregister_store(mesh_ipv6);
+    // 1. Find our store ID (if still registered). If already gone, skip drain.
+    let store_id = service::find_store_id_via_pd(&our_addr, &pd_url);
 
-    // 2. Count remaining active stores (excluding the one we just deregistered)
-    //    and adjust max-replicas so Raft can still form quorums
-    let active = service::count_active_stores(&pd_url);
-    let remaining = if active > 0 { active - 1 } else { 0 };
-    if remaining > 0 {
-        let target = remaining.min(MAX_PD_MEMBERS);
-        let _ = service::adjust_max_replicas(&pd_url, target);
-        // 3. Wait for PD to migrate region peers off the dead store
-        let _ = service::wait_regions_healthy(&pd_url, 30);
+    if let Some(sid) = store_id {
+        // 2. Deregister TiKV store (marks it as Offline → PD starts draining)
+        tracing::info!(store_id = sid, "deregistering TiKV store");
+        let _ = service::deregister_store(mesh_ipv6);
+
+        // 3. Adjust max-replicas so Raft can still form quorums after we leave
+        let active = service::count_active_stores(&pd_url);
+        let remaining = if active > 0 { active - 1 } else { 0 };
+        if remaining > 0 {
+            let target = remaining.min(MAX_PD_MEMBERS);
+            let _ = service::adjust_max_replicas(&pd_url, target);
+        }
+
+        // 4. Wait for regions to drain off this store (5 min, poll every 5s)
+        let _ = service::wait_store_regions_drained(&pd_url, sid, 300);
+    } else {
+        tracing::info!("store already deregistered or not found, skipping drain");
     }
 
-    // 4. Deregister PD member — try local first, then remote peers
+    // 5. Deregister PD member — idempotent: skip if already removed
+    deregister_pd_member_idempotent(mesh_ipv6, &pd_url);
+
+    service::uninstall()
+}
+
+/// Deregister PD member with idempotent handling.
+/// Tries local PD first, then falls back to remote peers.
+/// If the member is already gone, treats as success.
+fn deregister_pd_member_idempotent(mesh_ipv6: &Ipv6Addr, pd_url: &str) {
+    // Check if our PD member even exists before trying to remove it
+    if !service::pd_member_exists(mesh_ipv6, pd_url) {
+        // Try remote PDs — maybe local PD is already down
+        let found_remotely = try_remote_pd_member_check(mesh_ipv6);
+        if !found_remotely {
+            tracing::info!("PD member already removed, skipping deregistration");
+            return;
+        }
+    }
+
     let local_ok = service::deregister_pd_member(mesh_ipv6).is_ok() && service::pd_is_active();
 
     if !local_ok {
         // Local PD is down — try to deregister via a remote PD.
-        // Load peer list from fabric state to find other PD endpoints.
         if let Ok(db) = nauka_state::LocalDb::open("hypervisor") {
             if let Some(state) = crate::fabric::state::FabricState::load(&db).ok().flatten() {
                 for peer in &state.peers.peers {
@@ -342,8 +373,21 @@ pub fn leave_with_mesh(mesh_ipv6: &Ipv6Addr) -> Result<(), NaukaError> {
             }
         }
     }
+}
 
-    service::uninstall()
+/// Check if our PD member exists via any remote peer's PD.
+fn try_remote_pd_member_check(mesh_ipv6: &Ipv6Addr) -> bool {
+    if let Ok(db) = nauka_state::LocalDb::open("hypervisor") {
+        if let Some(state) = crate::fabric::state::FabricState::load(&db).ok().flatten() {
+            for peer in &state.peers.peers {
+                let remote_url = format!("http://[{}]:{}", peer.mesh_ipv6, super::PD_CLIENT_PORT);
+                if service::pd_member_exists(mesh_ipv6, &remote_url) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
 }
 
 /// Uninstall without deregistration (fallback).

--- a/layers/hypervisor/src/controlplane/service.rs
+++ b/layers/hypervisor/src/controlplane/service.rs
@@ -973,6 +973,126 @@ fn installed_component_version(component: &str) -> Option<String> {
     None
 }
 
+/// Find the store ID for this node's TiKV store in PD.
+/// Returns `None` if the store is not found or already tombstoned.
+pub fn find_store_id(mesh_ipv6: &std::net::Ipv6Addr) -> Option<u64> {
+    let our_addr = format!("[{}]:{}", mesh_ipv6, super::TIKV_PORT);
+    let pd_url = format!("http://[{}]:{}", mesh_ipv6, super::PD_CLIENT_PORT);
+    find_store_id_via_pd(&our_addr, &pd_url)
+}
+
+/// Find the store ID for a given address via a PD endpoint.
+/// Only returns stores in Up or Disconnected state (not Tombstone).
+pub fn find_store_id_via_pd(our_addr: &str, pd_url: &str) -> Option<u64> {
+    // Query stores in all states: 0=Up, 1=Disconnected, 2=Offline
+    let stores_url = format!("{pd_url}/pd/api/v1/stores?state=0&state=1&state=2");
+    let output = Command::new("curl")
+        .args(["-sf", "--max-time", "5", &stores_url])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let body: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+    body["stores"].as_array().and_then(|stores| {
+        stores.iter().find_map(|s| {
+            let addr = s["store"]["address"].as_str().unwrap_or("");
+            let id = s["store"]["id"].as_u64().unwrap_or(0);
+            if addr == our_addr && id > 0 {
+                Some(id)
+            } else {
+                None
+            }
+        })
+    })
+}
+
+/// Wait for all regions to drain off a specific store.
+/// Polls PD every 5s with progress logging. Returns Ok(()) when the store
+/// has 0 regions or is no longer visible (already tombstoned).
+pub fn wait_store_regions_drained(
+    pd_url: &str,
+    store_id: u64,
+    timeout_secs: u64,
+) -> Result<(), NaukaError> {
+    let url = format!("{pd_url}/pd/api/v1/regions/store/{store_id}");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
+    let mut last_count: Option<usize> = None;
+
+    while std::time::Instant::now() < deadline {
+        let region_count = match Command::new("curl")
+            .args(["-sf", "--max-time", "5", &url])
+            .output()
+        {
+            Ok(output) if output.status.success() => {
+                match serde_json::from_slice::<serde_json::Value>(&output.stdout) {
+                    Ok(body) => body["regions"].as_array().map(|r| r.len()).unwrap_or(0),
+                    Err(_) => 0,
+                }
+            }
+            // Store not found (404) means already gone — success
+            _ => 0,
+        };
+
+        if region_count == 0 {
+            tracing::info!(store_id, "all regions drained from store");
+            return Ok(());
+        }
+
+        // Log progress when count changes
+        if last_count != Some(region_count) {
+            tracing::info!(
+                store_id,
+                region_count,
+                "draining regions: {} remaining...",
+                region_count
+            );
+            last_count = Some(region_count);
+        }
+
+        std::thread::sleep(std::time::Duration::from_secs(5));
+    }
+
+    tracing::warn!(
+        store_id,
+        "timed out waiting for region drain, proceeding anyway"
+    );
+    Ok(())
+}
+
+/// Check if a PD member with our IP exists in the cluster.
+pub fn pd_member_exists(mesh_ipv6: &std::net::Ipv6Addr, pd_url: &str) -> bool {
+    let members_url = format!("{pd_url}/pd/api/v1/members");
+    let output = match Command::new("curl")
+        .args(["-sf", "--max-time", "5", &members_url])
+        .output()
+    {
+        Ok(o) if o.status.success() => o,
+        _ => return false,
+    };
+
+    let body: serde_json::Value = match serde_json::from_slice(&output.stdout) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+
+    let our_ip = mesh_ipv6.to_string();
+    body["members"]
+        .as_array()
+        .map(|members| {
+            members.iter().any(|m| {
+                m["peer_urls"]
+                    .as_array()
+                    .map(|urls| {
+                        urls.iter()
+                            .any(|u| u.as_str().unwrap_or("").contains(&our_ip))
+                    })
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false)
+}
+
 /// Uninstall everything — stop services, remove configs, data.
 pub fn uninstall() -> Result<(), NaukaError> {
     let _ = run_systemctl(&["disable", "--now", TIKV_SERVICE]);


### PR DESCRIPTION
## Summary
- Replace the 30s `wait_regions_healthy` timeout with per-store region drain tracking: polls `PD /regions/store/{id}` every 5s (up to 5 min) with progress logging ("draining regions: 15 remaining...")
- Make `leave_with_mesh()` fully idempotent: each step checks if already completed (store tombstoned, PD member removed) and skips accordingly — safe to re-run after a crash mid-leave
- Add `find_store_id_via_pd()`, `wait_store_regions_drained()`, and `pd_member_exists()` helper functions to `service.rs`

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test -p nauka-hypervisor` — 121 tests pass
- [x] Cross-compiled for `x86_64-unknown-linux-musl`
- [x] Deployed to 3-node Hetzner cluster
- [x] `nauka hypervisor leave` on node 3 — verified progress logging (5 → 1 → 0 regions)
- [x] Second `nauka hypervisor leave` on same node — completes without errors (idempotent)

Closes #131