### PR TITLE
feat: implement maintenance mode (drain/enable)

### DIFF
--- a/layers/hypervisor/src/fabric/announce.rs
+++ b/layers/hypervisor/src/fabric/announce.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use nauka_core::error::NaukaError;
 
 use super::peer::Peer;
-use super::peering::{PeerAnnounce, PeerInfo, PeerRemove};
+use super::peering::{PeerAnnounce, PeerInfo, PeerRemove, StateChange};
 use super::peering_server::{read_json, write_json};
 use super::service;
 
@@ -26,6 +26,8 @@ pub enum AnnounceMessage {
     Announce(PeerAnnounce),
     #[serde(rename = "remove")]
     Remove(PeerRemove),
+    #[serde(rename = "state_change")]
+    StateChange(StateChange),
 }
 
 /// Default announce port offset from WireGuard port.
@@ -177,6 +179,65 @@ pub async fn broadcast_peer_remove(
     (successes, failures)
 }
 
+/// Broadcast a state change (drain/enable) to all peers in parallel (best-effort).
+/// Returns (successes, failures).
+pub async fn broadcast_state_change(
+    change: &StateChange,
+    existing_peers: &[Peer],
+) -> (usize, usize) {
+    let msg = AnnounceMessage::StateChange(change.clone());
+
+    let reachable: Vec<_> = existing_peers
+        .iter()
+        .filter(|p| p.status != super::peer::PeerStatus::Unreachable)
+        .collect();
+
+    let mut handles = Vec::with_capacity(reachable.len());
+    for peer in &reachable {
+        let addr = format!(
+            "[{}]:{}",
+            peer.mesh_ipv6,
+            peer.wg_port + ANNOUNCE_PORT_OFFSET
+        );
+        let peer_name = peer.name.clone();
+        let node_name = change.name.clone();
+        let new_state = change.node_state;
+        let msg = msg.clone();
+        handles.push(tokio::spawn(async move {
+            match send_message(&addr, &msg).await {
+                Ok(()) => {
+                    tracing::info!(
+                        peer = %peer_name,
+                        node = %node_name,
+                        state = %new_state,
+                        "sent state change"
+                    );
+                    true
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        peer = %peer_name,
+                        error = %e,
+                        "failed to send state change"
+                    );
+                    false
+                }
+            }
+        }));
+    }
+
+    let mut successes = 0;
+    let mut failures = 0;
+    for handle in handles {
+        match handle.await {
+            Ok(true) => successes += 1,
+            _ => failures += 1,
+        }
+    }
+
+    (successes, failures)
+}
+
 /// Listen for peer announcements and apply them (over TLS).
 ///
 /// Runs on wg_port + 2. When an announcement arrives:
@@ -244,6 +305,7 @@ async fn handle_message(
     match msg {
         AnnounceMessage::Announce(announce) => handle_peer_announce(announce, db).await,
         AnnounceMessage::Remove(remove) => handle_peer_remove(remove, db),
+        AnnounceMessage::StateChange(change) => handle_state_change(change, db),
     }
 }
 
@@ -287,6 +349,42 @@ fn handle_peer_remove(remove: PeerRemove, db: &nauka_state::LayerDb) -> Result<S
         Ok(format!("removed {}", removed.name))
     } else {
         Ok(format!("{} not found, skipped", remove.name))
+    }
+}
+
+/// Handle a StateChange — update a peer's scheduling state.
+fn handle_state_change(
+    change: StateChange,
+    db: &nauka_state::LayerDb,
+) -> Result<String, NaukaError> {
+    super::peering_server::validate_peer_field(&change.name, "name")?;
+
+    let mut state = super::state::FabricState::load(db)
+        .map_err(|e| NaukaError::internal(e.to_string()))?
+        .ok_or_else(|| NaukaError::precondition("not initialized"))?;
+
+    // Find the peer by name or public key and update its node_state
+    let found = state
+        .peers
+        .peers
+        .iter_mut()
+        .find(|p| p.name == change.name || p.wg_public_key == change.wg_public_key);
+
+    if let Some(peer) = found {
+        peer.node_state = change.node_state;
+        tracing::info!(
+            peer = %change.name,
+            state = %change.node_state,
+            "updated peer scheduling state"
+        );
+
+        state
+            .save(db)
+            .map_err(|e| NaukaError::internal(e.to_string()))?;
+
+        Ok(format!("{} → {}", change.name, change.node_state))
+    } else {
+        Ok(format!("{} not found, skipped", change.name))
     }
 }
 

--- a/layers/hypervisor/src/fabric/health.rs
+++ b/layers/hypervisor/src/fabric/health.rs
@@ -246,6 +246,7 @@ mod tests {
             secret: secret.to_string(),
             peers: super::super::peer::PeerList::new(),
             network_mode: super::super::backend::NetworkMode::default(),
+            node_state: super::super::state::NodeState::default(),
         };
         state.save(&db).unwrap();
 
@@ -293,6 +294,7 @@ mod tests {
             secret: secret.to_string(),
             peers,
             network_mode: super::super::backend::NetworkMode::default(),
+            node_state: super::super::state::NodeState::default(),
         };
         state.save(&db).unwrap();
 

--- a/layers/hypervisor/src/fabric/ops.rs
+++ b/layers/hypervisor/src/fabric/ops.rs
@@ -89,6 +89,7 @@ pub fn init(
         secret: secret_str.clone(),
         peers: PeerList::new(),
         network_mode: cfg.network_mode,
+        node_state: super::state::NodeState::default(),
     };
     state
         .save(db)
@@ -447,6 +448,7 @@ pub async fn join(
         secret: secret_str,
         peers,
         network_mode: cfg.network_mode,
+        node_state: super::state::NodeState::default(),
     };
     state
         .save(db)
@@ -490,12 +492,16 @@ pub fn status(db: &LayerDb) -> Result<StatusResult, NaukaError> {
     let svc_active = service::is_active();
     let wg_up = wg::interface_exists();
 
-    let fabric_state = if svc_active && wg_up {
-        "available"
-    } else if svc_installed {
-        "stopped"
+    let fabric_state = if !svc_active || !wg_up {
+        if svc_installed {
+            "stopped"
+        } else {
+            "not installed"
+        }
+    } else if state.node_state == super::state::NodeState::Draining {
+        "draining"
     } else {
-        "not installed"
+        "available"
     };
 
     let (wg_port, wg_peer_count, rx, tx) = if wg_up {
@@ -644,6 +650,90 @@ pub fn update(db: &LayerDb, cfg: &UpdateConfig) -> Result<HypervisorIdentity, Na
     tracing::info!(node = state.hypervisor.name.as_str(), "hypervisor updated");
 
     Ok(state.hypervisor)
+}
+
+/// Set node scheduling state to draining (maintenance mode).
+/// Persists the state and broadcasts the change to all peers.
+pub async fn drain(db: &LayerDb) -> Result<(), NaukaError> {
+    let mut state = FabricState::load(db)
+        .map_err(|e| NaukaError::internal(e.to_string()))?
+        .ok_or_else(|| {
+            NaukaError::precondition("not initialized. Run 'nauka hypervisor init' first.")
+        })?;
+
+    if state.node_state == super::state::NodeState::Draining {
+        return Err(NaukaError::conflict(
+            "hypervisor",
+            &state.hypervisor.name,
+            "already draining",
+        ));
+    }
+
+    state.node_state = super::state::NodeState::Draining;
+    state
+        .save(db)
+        .map_err(|e| NaukaError::internal(e.to_string()))?;
+
+    tracing::info!(
+        node = state.hypervisor.name.as_str(),
+        "node set to draining"
+    );
+
+    // Broadcast state change to peers (best-effort)
+    if !state.peers.is_empty() {
+        let change = super::peering::StateChange {
+            name: state.hypervisor.name.clone(),
+            wg_public_key: state.hypervisor.wg_public_key.clone(),
+            node_state: super::state::NodeState::Draining,
+        };
+        let peers: Vec<_> = state.peers.peers.clone();
+        let (ok, fail) = super::announce::broadcast_state_change(&change, &peers).await;
+        tracing::info!(successes = ok, failures = fail, "drain broadcast complete");
+    }
+
+    Ok(())
+}
+
+/// Set node scheduling state back to available (exit maintenance mode).
+/// Persists the state and broadcasts the change to all peers.
+pub async fn enable(db: &LayerDb) -> Result<(), NaukaError> {
+    let mut state = FabricState::load(db)
+        .map_err(|e| NaukaError::internal(e.to_string()))?
+        .ok_or_else(|| {
+            NaukaError::precondition("not initialized. Run 'nauka hypervisor init' first.")
+        })?;
+
+    if state.node_state == super::state::NodeState::Available {
+        return Err(NaukaError::conflict(
+            "hypervisor",
+            &state.hypervisor.name,
+            "already available",
+        ));
+    }
+
+    state.node_state = super::state::NodeState::Available;
+    state
+        .save(db)
+        .map_err(|e| NaukaError::internal(e.to_string()))?;
+
+    tracing::info!(
+        node = state.hypervisor.name.as_str(),
+        "node set to available"
+    );
+
+    // Broadcast state change to peers (best-effort)
+    if !state.peers.is_empty() {
+        let change = super::peering::StateChange {
+            name: state.hypervisor.name.clone(),
+            wg_public_key: state.hypervisor.wg_public_key.clone(),
+            node_state: super::state::NodeState::Available,
+        };
+        let peers: Vec<_> = state.peers.peers.clone();
+        let (ok, fail) = super::announce::broadcast_state_change(&change, &peers).await;
+        tracing::info!(successes = ok, failures = fail, "enable broadcast complete");
+    }
+
+    Ok(())
 }
 
 /// Number of removal broadcast attempts before giving up.

--- a/layers/hypervisor/src/fabric/peer.rs
+++ b/layers/hypervisor/src/fabric/peer.rs
@@ -6,6 +6,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use nauka_core::id::NodeId;
 use serde::{Deserialize, Serialize};
 
+use super::state::NodeState;
+
 fn default_wg_port() -> u16 {
     51820
 }
@@ -36,6 +38,9 @@ pub struct Peer {
     pub last_handshake: u64,
     /// When this peer was added.
     pub added_at: u64,
+    /// Scheduling state (available or draining).
+    #[serde(default)]
+    pub node_state: NodeState,
 }
 
 /// Peer connection status.
@@ -75,6 +80,7 @@ impl Peer {
             status: PeerStatus::Active,
             last_handshake: 0,
             added_at: now,
+            node_state: NodeState::default(),
         }
     }
 

--- a/layers/hypervisor/src/fabric/peering.rs
+++ b/layers/hypervisor/src/fabric/peering.rs
@@ -84,6 +84,17 @@ pub struct PeerRemove {
     pub wg_public_key: String,
 }
 
+/// Node state change — broadcast when a node enters/exits maintenance mode.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StateChange {
+    /// Name of the node whose state changed.
+    pub name: String,
+    /// WireGuard public key (identifies the node).
+    pub wg_public_key: String,
+    /// New scheduling state ("available" or "draining").
+    pub node_state: super::state::NodeState,
+}
+
 impl JoinResponse {
     /// Create an accepted response.
     pub fn accepted(

--- a/layers/hypervisor/src/fabric/state.rs
+++ b/layers/hypervisor/src/fabric/state.rs
@@ -3,12 +3,34 @@
 //! The fabric state is the complete snapshot of a node's mesh membership:
 //! mesh identity, node identity, secret, and list of peers.
 
+use std::fmt;
+
 use nauka_state::LayerDb;
 use serde::{Deserialize, Serialize};
 
 use super::backend::NetworkMode;
 use super::mesh::{HypervisorIdentity, MeshIdentity};
 use super::peer::PeerList;
+
+/// Scheduling state of a node (maintenance mode).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NodeState {
+    /// Normal operation — accepts new VM placements.
+    #[default]
+    Available,
+    /// Draining — no new VMs; existing VMs continue until migrated.
+    Draining,
+}
+
+impl fmt::Display for NodeState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Available => write!(f, "available"),
+            Self::Draining => write!(f, "draining"),
+        }
+    }
+}
 
 /// Complete fabric state for a node.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -24,6 +46,9 @@ pub struct FabricState {
     /// Network backend mode.
     #[serde(default)]
     pub network_mode: NetworkMode,
+    /// Scheduling state (available or draining).
+    #[serde(default)]
+    pub node_state: NodeState,
 }
 
 const STATE_TABLE: &str = "fabric";
@@ -85,6 +110,7 @@ mod tests {
             secret: secret.to_string(),
             peers: PeerList::new(),
             network_mode: super::super::backend::NetworkMode::default(),
+            node_state: NodeState::default(),
         }
     }
 

--- a/layers/hypervisor/src/handlers.rs
+++ b/layers/hypervisor/src/handlers.rs
@@ -259,8 +259,8 @@ pub fn handler() -> HandlerFn {
                 "backup-list" => handle_backup_list().await,
                 "doctor" => handle_doctor().await,
                 "announce-listen" => handle_announce_listen(req).await,
-                "drain" => Ok(OperationResponse::Message("drain: not yet implemented".into())),
-                "enable" => Ok(OperationResponse::Message("enable: not yet implemented".into())),
+                "drain" => handle_drain().await,
+                "enable" => handle_enable().await,
                 other => Ok(OperationResponse::Message(format!("unknown: {other}"))),
             }
         })
@@ -873,6 +873,22 @@ async fn handle_start() -> anyhow::Result<OperationResponse> {
     Ok(OperationResponse::Message("all services started.".into()))
 }
 
+async fn handle_drain() -> anyhow::Result<OperationResponse> {
+    let db = open_db()?;
+    fabric::ops::drain(&db).await?;
+    Ok(OperationResponse::Message(
+        "node set to draining — no new VMs will be scheduled.".into(),
+    ))
+}
+
+async fn handle_enable() -> anyhow::Result<OperationResponse> {
+    let db = open_db()?;
+    fabric::ops::enable(&db).await?;
+    Ok(OperationResponse::Message(
+        "node set to available — ready for VM scheduling.".into(),
+    ))
+}
+
 async fn handle_announce_listen(req: OperationRequest) -> anyhow::Result<OperationResponse> {
     let port: u16 = req
         .fields
@@ -1023,7 +1039,13 @@ async fn handle_list() -> anyhow::Result<OperationResponse> {
     };
 
     let backend = fabric::backend::create_backend(state.network_mode);
-    let self_state = if backend.is_up() { "available" } else { "down" };
+    let self_state = if !backend.is_up() {
+        "down"
+    } else if state.node_state == fabric::state::NodeState::Draining {
+        "draining"
+    } else {
+        "available"
+    };
 
     let mut items = vec![serde_json::json!({
         "name": state.hypervisor.name,
@@ -1068,7 +1090,7 @@ async fn handle_get(req: OperationRequest) -> anyhow::Result<OperationResponse> 
             "region": state.hypervisor.region,
             "zone": state.hypervisor.zone,
             "mesh_ipv6": state.hypervisor.mesh_ipv6.to_string(),
-            "state": if backend.is_up() { "available" } else { "down" },
+            "state": if !backend.is_up() { "down" } else if state.node_state == fabric::state::NodeState::Draining { "draining" } else { "available" },
         })));
     }
 
@@ -1089,7 +1111,13 @@ async fn handle_get(req: OperationRequest) -> anyhow::Result<OperationResponse> 
 /// Map peer status to user-facing label.
 fn peer_state_label(peer: &fabric::peer::Peer) -> &'static str {
     match peer.status {
-        fabric::peer::PeerStatus::Active => "available",
+        fabric::peer::PeerStatus::Active => {
+            if peer.node_state == fabric::state::NodeState::Draining {
+                "draining"
+            } else {
+                "available"
+            }
+        }
         fabric::peer::PeerStatus::Unreachable => "unreachable",
         fabric::peer::PeerStatus::Removed => "removed",
     }

--- a/layers/hypervisor/tests/e2e/peering_test.rs
+++ b/layers/hypervisor/tests/e2e/peering_test.rs
@@ -47,6 +47,7 @@ fn init_node(db: &LocalDb, name: &str) -> (FabricState, String) {
         secret: secret_str,
         peers: PeerList::new(),
         network_mode: NetworkMode::Mock,
+        node_state: nauka_hypervisor::fabric::NodeState::default(),
     };
     state.save(db).unwrap();
 


### PR DESCRIPTION
## Summary
- Implement `nauka hypervisor drain` and `nauka hypervisor enable` commands for safe rolling upgrades
- Add `NodeState` enum (available/draining) persisted in redb via `FabricState.node_state`
- Add `StateChange` announce message type to broadcast state changes to all mesh peers
- State visible in `nauka hypervisor list` (STATE column), `nauka hypervisor status`, and `nauka hypervisor get`

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test -- --skip disk_free_check` passes (578 tests)
- [x] Cross-compiled and deployed to 3 Hetzner servers
- [x] `nauka hypervisor drain -y` sets local state to "draining"
- [x] `nauka hypervisor list` on remote peer shows "draining" for drained node
- [x] `nauka hypervisor enable` restores state to "available"
- [x] `nauka hypervisor list` on remote peer shows "available" after enable
- [x] Backward compatible: `#[serde(default)]` on new fields

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)