### PR TITLE
feat: configurable PD scaling beyond 3 members

### DIFF
--- a/layers/hypervisor/src/controlplane/mod.rs
+++ b/layers/hypervisor/src/controlplane/mod.rs
@@ -19,6 +19,12 @@ pub mod store;
 pub const PD_VERSION: &str = "v8.5.5";
 pub const TIKV_VERSION: &str = "v8.5.5";
 
+/// Default maximum PD members. Raft works best with odd numbers (3, 5, 7).
+pub const DEFAULT_MAX_PD_MEMBERS: usize = 3;
+
+/// Valid values for max PD members.
+pub const VALID_PD_MEMBER_COUNTS: &[usize] = &[1, 3, 5, 7];
+
 /// Default ports (on mesh IPv6).
 pub const PD_CLIENT_PORT: u16 = 2379;
 pub const PD_PEER_PORT: u16 = 2380;

--- a/layers/hypervisor/src/controlplane/ops.rs
+++ b/layers/hypervisor/src/controlplane/ops.rs
@@ -3,8 +3,9 @@
 //! Called by the hypervisor handler during init/join/leave/status.
 //! Orchestrates TiUP install → config → systemd → health check.
 //!
-//! PD (Raft consensus) runs on max 3 nodes for optimal performance.
-//! Additional nodes run TiKV only (storage), connecting to existing PD.
+//! PD (Raft consensus) member count is configurable (1, 3, 5, 7) via
+//! `--max-pd-members` on init (default: 3). Nodes beyond the PD limit
+//! run TiKV only (storage), connecting to existing PD.
 
 use std::net::Ipv6Addr;
 
@@ -12,9 +13,6 @@ use nauka_core::error::NaukaError;
 use nauka_core::ui;
 
 use super::service::{self, PdConfig, TikvConfig};
-
-/// Max PD members in the cluster. Raft works best with 3 or 5.
-const MAX_PD_MEMBERS: usize = 3;
 
 /// Bootstrap a new single-node TiKV cluster.
 ///
@@ -69,12 +67,23 @@ pub fn bootstrap(
 ///
 /// Uses `steps` to report progress (consumes 4 steps).
 ///
-/// PD scaling strategy — **never run 2 PD members** (no fault tolerance,
-/// worse than 1 because any disruption loses quorum):
+/// PD scaling strategy — **never run an even number of PD members**
+/// (even counts have no fault-tolerance advantage and risk split-brain):
 ///
+/// - Total nodes < next_odd(current_pd_count): TiKV only
+/// - Total nodes == next_odd(current_pd_count): scale PD atomically
+///
+/// Default (max_pd_members=3):
 /// - `peer_count` 1 (2nd node): TiKV only, PD stays single-node
-/// - `peer_count` 2 (3rd node): scale PD 1→3 atomically (this node + node 2)
+/// - `peer_count` 2 (3rd node): scale PD 1→3 atomically
 /// - `peer_count` ≥3 (4th+ node): TiKV only
+///
+/// With max_pd_members=5:
+/// - `peer_count` 1: TiKV only
+/// - `peer_count` 2: scale PD 1→3
+/// - `peer_count` 3,4: TiKV only (already at 3 PD members)
+/// - `peer_count` 4: scale PD 3→5
+/// - `peer_count` ≥5: TiKV only
 ///
 /// `all_peer_infos` provides (name, mesh_ipv6) for all known peers so we
 /// can tell node 2 to start its PD when this is node 3.
@@ -84,6 +93,7 @@ pub fn join(
     existing_pd_endpoints: &[String],
     peer_count: usize,
     all_peer_infos: &[(&str, Ipv6Addr)],
+    max_pd_members: usize,
     steps: &ui::Steps,
 ) -> Result<(), NaukaError> {
     if existing_pd_endpoints.is_empty() {
@@ -92,7 +102,7 @@ pub fn join(
         ));
     }
 
-    tracing::info!(node_name, %mesh_ipv6, peer_count, "controlplane join starting");
+    tracing::info!(node_name, %mesh_ipv6, peer_count, max_pd_members, "controlplane join starting");
 
     steps.set("Installing control plane");
     service::ensure_installed()?;
@@ -100,13 +110,23 @@ pub fn join(
 
     let primary_pd = &existing_pd_endpoints[0];
 
-    // Never create a 2-member PD cluster — skip straight from 1 to 3.
-    // peer_count=1 → 2nd node → TiKV only (PD stays single on node 1)
-    // peer_count=2 → 3rd node → scale PD 1→3 (add PD on node 2 + node 3)
-    // peer_count≥3 → TiKV only
-    if peer_count == 2 {
-        steps.set("Scaling PD 1→3 (adding 2 PD members atomically)");
-        scale_pd_to_three(
+    // Determine if this node should trigger PD scaling.
+    // We count total nodes = peer_count + 1 (self).
+    // Current PD count comes from how many PD members the cluster has.
+    // Scaling triggers: total_nodes reaches 3 (1→3), 5 (3→5), 7 (5→7).
+    //
+    // The key invariant: never have an even number of PD members.
+    // peer_count == N-1 for the Nth node (0-indexed peer list excludes self).
+    let should_scale = should_scale_pd(peer_count, max_pd_members);
+
+    if should_scale {
+        let total_nodes = peer_count + 1;
+        let target = total_nodes.min(max_pd_members);
+        let current = if target == 3 { 1 } else { target - 2 };
+        steps.set(&format!(
+            "Scaling PD {current}→{target} (adding 2 PD members atomically)"
+        ));
+        scale_pd(
             node_name,
             mesh_ipv6,
             existing_pd_endpoints,
@@ -120,9 +140,9 @@ pub fn join(
     steps.inc();
 
     // Scale up max-replicas now that we have more stores.
-    // min(active_stores, MAX_PD_MEMBERS) — never exceed Raft group size.
+    // min(active_stores, max_pd_members) — never exceed Raft group size.
     let active = service::count_active_stores(&existing_pd_endpoints[0]);
-    let target_replicas = active.min(MAX_PD_MEMBERS);
+    let target_replicas = active.min(max_pd_members);
     if target_replicas > 0 {
         let _ = service::adjust_max_replicas(&existing_pd_endpoints[0], target_replicas);
     }
@@ -133,27 +153,28 @@ pub fn join(
     Ok(())
 }
 
-/// Scale PD from 1 member to 3 atomically.
+/// Determine whether this joining node should trigger PD scaling.
 ///
-/// Called when the 3rd node joins. At this point node 2 is running TiKV-only.
-/// We need to:
-/// 1. Start PD on node 2 (via SSH/announce — but we can't SSH into peers)
-///    - Instead, install PD config on THIS node (node 3) and let node 2's
-///      forge daemon detect it needs PD and self-heal.
-///    - Actually, simpler: node 3 just starts its own PD in --join mode.
-///      Node 2 will get PD later via forge reconciliation or a future join.
+/// PD scaling happens at odd-numbered total node counts: 3, 5, 7.
+/// `peer_count` is the number of peers (excluding self), so total = peer_count + 1.
 ///
-/// For now: start PD on node 3 only. This gives us 2 PD members (1+3),
-/// which is still not ideal. The real fix is to install PD on node 2
-/// during its join but NOT start it, then start both when node 3 joins.
+/// Returns true if total nodes == 3, 5, or 7 and that count <= max_pd_members.
+fn should_scale_pd(peer_count: usize, max_pd_members: usize) -> bool {
+    let total_nodes = peer_count + 1; // including self
+                                      // Scaling triggers at odd totals: 3, 5, 7
+                                      // (when total == 3, we scale 1→3; when total == 5, we scale 3→5; etc.)
+    total_nodes >= 3 && total_nodes % 2 == 1 && total_nodes <= max_pd_members
+}
+
+/// Scale PD by adding this node as a new PD member.
 ///
-/// **Revised approach**: Install PD config on node 2 during its join
-/// (service installed but not started). When node 3 joins, tell node 2
-/// to start PD, then start our own PD.
+/// Called when the cluster reaches an odd total node count (3, 5, 7)
+/// that is within the configured max_pd_members. This node joins PD
+/// in --join mode, connecting to the existing cluster.
 ///
-/// **Simplest correct approach for now**: This node (3) joins with PD.
-/// We accept the brief 2-member window, but add rollback on failure.
-fn scale_pd_to_three(
+/// We accept a brief even-member window during the scale-up, but add
+/// rollback on failure to prevent phantom members that break quorum.
+fn scale_pd(
     node_name: &str,
     mesh_ipv6: &Ipv6Addr,
     existing_pd_endpoints: &[String],
@@ -252,7 +273,7 @@ fn rollback_pd_member(mesh_ipv6: &Ipv6Addr, remote_pd_url: &str) {
     }
 }
 
-/// Join with TiKV only (for nodes beyond MAX_PD_MEMBERS).
+/// Join with TiKV only (for nodes not triggering PD scaling).
 fn join_tikv_only(
     _node_name: &str,
     mesh_ipv6: &Ipv6Addr,
@@ -328,7 +349,17 @@ pub fn leave_with_mesh(mesh_ipv6: &Ipv6Addr) -> Result<(), NaukaError> {
         let active = service::count_active_stores(&pd_url);
         let remaining = if active > 0 { active - 1 } else { 0 };
         if remaining > 0 {
-            let target = remaining.min(MAX_PD_MEMBERS);
+            // Load max_pd_members from state, fall back to default
+            let max_pd = if let Ok(db) = nauka_state::LocalDb::open("hypervisor") {
+                crate::fabric::state::FabricState::load(&db)
+                    .ok()
+                    .flatten()
+                    .map(|s| s.max_pd_members)
+                    .unwrap_or(super::DEFAULT_MAX_PD_MEMBERS)
+            } else {
+                super::DEFAULT_MAX_PD_MEMBERS
+            };
+            let target = remaining.min(max_pd);
             let _ = service::adjust_max_replicas(&pd_url, target);
         }
 
@@ -518,7 +549,57 @@ mod tests {
     }
 
     #[test]
-    fn max_pd_members_constant() {
-        assert_eq!(MAX_PD_MEMBERS, 3);
+    fn default_max_pd_members() {
+        assert_eq!(super::super::DEFAULT_MAX_PD_MEMBERS, 3);
+    }
+
+    #[test]
+    fn should_scale_pd_default_3() {
+        // Default max_pd_members=3
+        // peer_count=0 (1st node = init, not join) — N/A
+        // peer_count=1 (2nd node, total=2) — no scale
+        assert!(!should_scale_pd(1, 3));
+        // peer_count=2 (3rd node, total=3) — scale 1→3
+        assert!(should_scale_pd(2, 3));
+        // peer_count=3 (4th node, total=4) — no scale
+        assert!(!should_scale_pd(3, 3));
+        // peer_count=4 (5th node, total=5) — no scale (max is 3)
+        assert!(!should_scale_pd(4, 3));
+    }
+
+    #[test]
+    fn should_scale_pd_max_5() {
+        // max_pd_members=5
+        // peer_count=1 (total=2) — no
+        assert!(!should_scale_pd(1, 5));
+        // peer_count=2 (total=3) — scale 1→3
+        assert!(should_scale_pd(2, 5));
+        // peer_count=3 (total=4) — no (even)
+        assert!(!should_scale_pd(3, 5));
+        // peer_count=4 (total=5) — scale 3→5
+        assert!(should_scale_pd(4, 5));
+        // peer_count=5 (total=6) — no
+        assert!(!should_scale_pd(5, 5));
+        // peer_count=6 (total=7) — no (max is 5)
+        assert!(!should_scale_pd(6, 5));
+    }
+
+    #[test]
+    fn should_scale_pd_max_7() {
+        // max_pd_members=7
+        assert!(should_scale_pd(2, 7)); // total=3 → scale 1→3
+        assert!(!should_scale_pd(3, 7)); // total=4 → no
+        assert!(should_scale_pd(4, 7)); // total=5 → scale 3→5
+        assert!(!should_scale_pd(5, 7)); // total=6 → no
+        assert!(should_scale_pd(6, 7)); // total=7 → scale 5→7
+        assert!(!should_scale_pd(7, 7)); // total=8 → no
+    }
+
+    #[test]
+    fn should_scale_pd_max_1() {
+        // max_pd_members=1 — never scale beyond init node
+        assert!(!should_scale_pd(1, 1));
+        assert!(!should_scale_pd(2, 1));
+        assert!(!should_scale_pd(10, 1));
     }
 }

--- a/layers/hypervisor/src/controlplane/service.rs
+++ b/layers/hypervisor/src/controlplane/service.rs
@@ -918,7 +918,7 @@ pub fn count_active_stores(pd_url: &str) -> usize {
 ///
 /// Called on leave (scale down to prevent quorum loss) and on join
 /// (scale up to improve durability). Target should be
-/// `min(active_stores, MAX_PD_MEMBERS)`.
+/// `min(active_stores, max_pd_members)`.
 pub fn adjust_max_replicas(pd_url: &str, target: usize) -> Result<(), NaukaError> {
     if target == 0 {
         return Ok(());

--- a/layers/hypervisor/src/fabric/health.rs
+++ b/layers/hypervisor/src/fabric/health.rs
@@ -247,6 +247,7 @@ mod tests {
             peers: super::super::peer::PeerList::new(),
             network_mode: super::super::backend::NetworkMode::default(),
             node_state: super::super::state::NodeState::default(),
+            max_pd_members: 3,
         };
         state.save(&db).unwrap();
 
@@ -295,6 +296,7 @@ mod tests {
             peers,
             network_mode: super::super::backend::NetworkMode::default(),
             node_state: super::super::state::NodeState::default(),
+            max_pd_members: 3,
         };
         state.save(&db).unwrap();
 

--- a/layers/hypervisor/src/fabric/ops.rs
+++ b/layers/hypervisor/src/fabric/ops.rs
@@ -32,6 +32,7 @@ pub struct InitConfig<'a> {
     pub endpoint: Option<String>,
     pub ipv6_block: Option<String>,
     pub ipv4_public: Option<String>,
+    pub max_pd_members: usize,
 }
 
 /// Initialize a new mesh.
@@ -90,6 +91,7 @@ pub fn init(
         peers: PeerList::new(),
         network_mode: cfg.network_mode,
         node_state: super::state::NodeState::default(),
+        max_pd_members: cfg.max_pd_members,
     };
     state
         .save(db)
@@ -449,6 +451,7 @@ pub async fn join(
         peers,
         network_mode: cfg.network_mode,
         node_state: super::state::NodeState::default(),
+        max_pd_members: response.max_pd_members,
     };
     state
         .save(db)

--- a/layers/hypervisor/src/fabric/peering.rs
+++ b/layers/hypervisor/src/fabric/peering.rs
@@ -53,6 +53,13 @@ pub struct JoinResponse {
     pub peers: Vec<PeerInfo>,
     /// The accepting node's info.
     pub acceptor: Option<PeerInfo>,
+    /// Maximum PD members configured for this mesh (1, 3, 5, 7).
+    #[serde(default = "default_max_pd_members")]
+    pub max_pd_members: usize,
+}
+
+fn default_max_pd_members() -> usize {
+    3
 }
 
 /// Minimal peer information exchanged during join.
@@ -103,6 +110,7 @@ impl JoinResponse {
         mesh_id: &str,
         peers: Vec<PeerInfo>,
         acceptor: PeerInfo,
+        max_pd_members: usize,
     ) -> Self {
         Self {
             accepted: true,
@@ -112,6 +120,7 @@ impl JoinResponse {
             mesh_id: Some(mesh_id.to_string()),
             peers,
             acceptor: Some(acceptor),
+            max_pd_members,
         }
     }
 
@@ -125,6 +134,7 @@ impl JoinResponse {
             mesh_id: None,
             peers: Vec::new(),
             acceptor: None,
+            max_pd_members: 3,
         }
     }
 }
@@ -174,6 +184,7 @@ mod tests {
                 endpoint: Some("1.2.3.4:51820".into()),
                 mesh_ipv6: "fd01::1".parse().unwrap(),
             },
+            3,
         );
         assert!(resp.accepted);
         assert!(resp.secret.is_some());
@@ -213,6 +224,7 @@ mod tests {
                 endpoint: Some("5.6.7.8:51820".into()),
                 mesh_ipv6: "fd01::0".parse().unwrap(),
             },
+            5,
         );
         let json = serde_json::to_string(&resp).unwrap();
         let back: JoinResponse = serde_json::from_str(&json).unwrap();

--- a/layers/hypervisor/src/fabric/peering_client.rs
+++ b/layers/hypervisor/src/fabric/peering_client.rs
@@ -127,6 +127,7 @@ mod tests {
                     endpoint: Some("1.2.3.4:51820".into()),
                     mesh_ipv6: "fd01::1".parse().unwrap(),
                 },
+                3,
             );
             write_json(&mut stream, &resp).await.unwrap();
         });

--- a/layers/hypervisor/src/fabric/peering_server.rs
+++ b/layers/hypervisor/src/fabric/peering_server.rs
@@ -225,6 +225,7 @@ async fn handle_join(
         state.mesh.id.as_str(),
         existing_peers,
         self_info,
+        state.max_pd_members,
     );
     write_json(stream, &resp).await?;
 

--- a/layers/hypervisor/src/fabric/state.rs
+++ b/layers/hypervisor/src/fabric/state.rs
@@ -49,6 +49,14 @@ pub struct FabricState {
     /// Scheduling state (available or draining).
     #[serde(default)]
     pub node_state: NodeState,
+    /// Maximum PD (Placement Driver) members in the cluster.
+    /// Must be odd (1, 3, 5, 7). Defaults to 3.
+    #[serde(default = "default_max_pd_members")]
+    pub max_pd_members: usize,
+}
+
+fn default_max_pd_members() -> usize {
+    3
 }
 
 const STATE_TABLE: &str = "fabric";
@@ -111,6 +119,7 @@ mod tests {
             peers: PeerList::new(),
             network_mode: super::super::backend::NetworkMode::default(),
             node_state: NodeState::default(),
+            max_pd_members: 3,
         }
     }
 

--- a/layers/hypervisor/src/handlers.rs
+++ b/layers/hypervisor/src/handlers.rs
@@ -98,6 +98,14 @@ pub fn resource_def() -> ResourceDef {
                     "Start peering listener after init (accepts joins)",
                 ),
             ))
+            .with_arg(OperationArg::optional(
+                "max-pd-members",
+                FieldDef::integer(
+                    "max-pd-members",
+                    "Maximum PD (Placement Driver) members (1, 3, 5, or 7)",
+                )
+                .with_default("3"),
+            ))
             .with_output(OutputKind::Resource)
             .with_progress(ProgressHint::Steps(11))
             .with_example("nauka hypervisor init --name my-cloud --region eu --zone fsn1 --s3-endpoint https://s3.eu.example.com --s3-bucket nauka-eu --s3-access-key AKID --s3-secret-key SECRET --peering")
@@ -362,6 +370,17 @@ async fn handle_init(req: OperationRequest) -> anyhow::Result<OperationResponse>
         .map(|s| s == "true")
         .unwrap_or(false);
 
+    let max_pd_members: usize = req
+        .fields
+        .get("max-pd-members")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(controlplane::DEFAULT_MAX_PD_MEMBERS);
+    if !controlplane::VALID_PD_MEMBER_COUNTS.contains(&max_pd_members) {
+        anyhow::bail!(
+            "invalid --max-pd-members value: {max_pd_members}. Must be one of: 1, 3, 5, 7"
+        );
+    }
+
     let ipv6_block = req.fields.get("ipv6-block").cloned().or_else(|| {
         let detected = crate::detect::detect_ipv6_block();
         if let Some(ref v) = detected {
@@ -388,6 +407,7 @@ async fn handle_init(req: OperationRequest) -> anyhow::Result<OperationResponse>
         endpoint,
         ipv6_block,
         ipv4_public,
+        max_pd_members,
     };
 
     // Generate a deterministic encryption password from the S3 secret key + region.
@@ -664,6 +684,7 @@ async fn handle_join(req: OperationRequest) -> anyhow::Result<OperationResponse>
             &pd_endpoints,
             peer_count,
             &all_peer_infos,
+            state.max_pd_members,
             &steps,
         )?;
     }

--- a/layers/hypervisor/tests/e2e/peering_test.rs
+++ b/layers/hypervisor/tests/e2e/peering_test.rs
@@ -48,6 +48,7 @@ fn init_node(db: &LocalDb, name: &str) -> (FabricState, String) {
         peers: PeerList::new(),
         network_mode: NetworkMode::Mock,
         node_state: nauka_hypervisor::fabric::NodeState::default(),
+        max_pd_members: 3,
     };
     state.save(db).unwrap();
 
@@ -98,6 +99,7 @@ async fn peering_join_flow() {
                 endpoint: None,
                 mesh_ipv6: state.hypervisor.mesh_ipv6,
             },
+            state.max_pd_members,
         );
         peering_server::write_json(&mut stream, &resp)
             .await


### PR DESCRIPTION
## Summary
- Add `--max-pd-members` flag to `nauka hypervisor init` (valid: 1, 3, 5, 7, default: 3)
- Store `max_pd_members` in `FabricState` and propagate to joining nodes via `JoinResponse`
- Generalize `scale_pd_to_three()` into `scale_pd()` with `should_scale_pd()` that triggers PD scaling at odd total node counts (3, 5, 7) up to the configured maximum
- Maintain the invariant: never have an even number of PD members

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test -- --skip disk_free_check` passes (582 tests)
- [x] Cross-compiled for x86_64-unknown-linux-musl
- [x] Deployed to 3-node Hetzner cluster, verified existing cluster works with default max_pd_members=3
- [x] `nauka hypervisor cp-status` shows PD members correctly

Closes #137