### PR TITLE
feat: add trace IDs to CLI operations and peering protocol

### DIFF
--- a/layers/core/src/logging.rs
+++ b/layers/core/src/logging.rs
@@ -27,11 +27,34 @@
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use rand::RngCore;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter};
 
 use crate::config::LoggingConfig;
+
+// ═══════════════════════════════════════════════════
+// Trace ID generation
+// ═══════════════════════════════════════════════════
+
+/// Generate a random 16-character hex trace ID for correlating log lines
+/// across a single CLI operation or across nodes via the peering protocol.
+///
+/// ```
+/// let id = nauka_core::logging::generate_trace_id();
+/// assert_eq!(id.len(), 16);
+/// assert!(id.chars().all(|c| c.is_ascii_hexdigit()));
+/// ```
+pub fn generate_trace_id() -> String {
+    let mut buf = [0u8; 8];
+    rand::thread_rng().fill_bytes(&mut buf);
+    buf.iter().fold(String::with_capacity(16), |mut s, b| {
+        use std::fmt::Write;
+        let _ = write!(s, "{b:02x}");
+        s
+    })
+}
 
 // ═══════════════════════════════════════════════════
 // 7. Log metrics — atomic counters
@@ -453,5 +476,20 @@ mod tests {
         install_panic_hook();
         // Restore default to not affect other tests
         let _ = std::panic::take_hook();
+    }
+
+    // Trace ID generation
+    #[test]
+    fn trace_id_is_16_hex_chars() {
+        let id = generate_trace_id();
+        assert_eq!(id.len(), 16);
+        assert!(id.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn trace_id_is_unique() {
+        let a = generate_trace_id();
+        let b = generate_trace_id();
+        assert_ne!(a, b);
     }
 }

--- a/layers/core/src/resource/dispatch.rs
+++ b/layers/core/src/resource/dispatch.rs
@@ -13,16 +13,28 @@ use super::ResourceDef;
 /// Dispatch a parsed CLI invocation to the appropriate resource handler.
 ///
 /// Pipeline:
-/// 1. Extract raw values from clap matches
-/// 2. Validate constraints → produce ValidatedRequest
-/// 3. Handle confirmation prompt
-/// 4. Call handler
-/// 5. Render output
+/// 1. Generate trace ID and open a tracing span
+/// 2. Extract raw values from clap matches
+/// 3. Validate constraints → produce ValidatedRequest
+/// 4. Handle confirmation prompt
+/// 5. Call handler
+/// 6. Render output
 pub async fn dispatch(
     reg: &ResourceRegistration,
     op_name: &str,
     matches: &ArgMatches,
 ) -> anyhow::Result<()> {
+    let trace_id = crate::logging::generate_trace_id();
+    let _span = tracing::info_span!(
+        "dispatch",
+        trace_id = %trace_id,
+        resource = reg.def.identity.kind,
+        op = op_name,
+    )
+    .entered();
+
+    tracing::info!("operation started");
+
     // Check if op_name is a child resource (e.g., "project" under "org")
     if let Some(child) = reg
         .children

--- a/layers/hypervisor/src/fabric/ops.rs
+++ b/layers/hypervisor/src/fabric/ops.rs
@@ -318,6 +318,9 @@ pub async fn join(
     // We need a temporary keypair to send in the request
     let (wg_private, wg_public) = nauka_core::crypto::generate_wg_keypair();
 
+    let trace_id = nauka_core::logging::generate_trace_id();
+    tracing::info!(trace_id = %trace_id, target = cfg.target, "sending join request");
+
     let request = super::peering::JoinRequest {
         name: cfg.node_name.to_string(),
         region: cfg.region.to_string(),
@@ -326,6 +329,7 @@ pub async fn join(
         wg_port: cfg.port,
         endpoint: None, // will be discovered by the target
         pin: cfg.pin.map(|s| s.to_string()),
+        trace_id: Some(trace_id),
     };
 
     // TCP peering exchange

--- a/layers/hypervisor/src/fabric/peering.rs
+++ b/layers/hypervisor/src/fabric/peering.rs
@@ -31,6 +31,9 @@ pub struct JoinRequest {
     pub endpoint: Option<String>,
     /// PIN for auto-accept (if provided).
     pub pin: Option<String>,
+    /// Trace ID for distributed log correlation.
+    #[serde(default)]
+    pub trace_id: Option<String>,
 }
 
 /// A join response sent by the target node.
@@ -151,11 +154,13 @@ mod tests {
             wg_port: 51820,
             endpoint: Some("1.2.3.4:51820".into()),
             pin: Some("4829".into()),
+            trace_id: Some("abcdef0123456789".into()),
         };
         let json = serde_json::to_string(&req).unwrap();
         let back: JoinRequest = serde_json::from_str(&json).unwrap();
         assert_eq!(back.name, "node-2");
         assert_eq!(back.pin, Some("4829".into()));
+        assert_eq!(back.trace_id, Some("abcdef0123456789".into()));
     }
 
     #[test]
@@ -269,5 +274,14 @@ mod tests {
         };
         assert_eq!(p.name, "n1");
         assert!(p.endpoint.is_none());
+    }
+
+    #[test]
+    fn join_request_backward_compat_no_trace_id() {
+        // Old clients won't send trace_id — serde(default) should handle it
+        let json = r#"{"name":"old-node","region":"eu","zone":"fsn1","wg_public_key":"k","wg_port":51820,"endpoint":null,"pin":null}"#;
+        let req: JoinRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.name, "old-node");
+        assert!(req.trace_id.is_none());
     }
 }

--- a/layers/hypervisor/src/fabric/peering_client.rs
+++ b/layers/hypervisor/src/fabric/peering_client.rs
@@ -92,6 +92,7 @@ mod tests {
                 wg_port: 51820,
                 endpoint: None,
                 pin: None,
+                trace_id: None,
             },
         )
         .await;
@@ -139,6 +140,7 @@ mod tests {
             wg_port: 51820,
             endpoint: None,
             pin: Some("1234".into()),
+            trace_id: Some("test_trace_1234ab".into()),
         };
 
         let resp = join(&addr.to_string(), req).await.unwrap();

--- a/layers/hypervisor/src/fabric/peering_server.rs
+++ b/layers/hypervisor/src/fabric/peering_server.rs
@@ -160,6 +160,11 @@ async fn handle_join(
 ) -> Result<String, NaukaError> {
     let mut req = read_json::<JoinRequest>(stream).await?;
 
+    // Log trace ID from the joining node for distributed correlation
+    if let Some(ref tid) = req.trace_id {
+        tracing::info!(trace_id = %tid, peer = %peer_addr, joiner = %req.name, "received join request with trace context");
+    }
+
     // Validate peer-provided fields against injection (newlines, control chars)
     validate_peer_field(&req.name, "name")?;
     validate_peer_field(&req.region, "region")?;
@@ -430,6 +435,7 @@ mod tests {
             wg_port: 51820,
             endpoint: None,
             pin: Some("1234".into()),
+            trace_id: None,
         };
         write_json(&mut client, &req).await.unwrap();
 

--- a/layers/hypervisor/tests/e2e/peering_test.rs
+++ b/layers/hypervisor/tests/e2e/peering_test.rs
@@ -113,6 +113,7 @@ async fn peering_join_flow() {
         wg_port: 51820,
         endpoint: None,
         pin: Some(pin.clone()),
+        trace_id: Some("e2e_test_trace_01".into()),
     };
 
     let resp = peering_client::join(&peering_addr.to_string(), join_req)
@@ -173,6 +174,7 @@ async fn peering_wrong_pin_rejected() {
         wg_port: 51820,
         endpoint: None,
         pin: Some("0000".into()), // wrong PIN
+        trace_id: None,
     };
 
     let result = peering_client::join(&addr.to_string(), req).await;


### PR DESCRIPTION
## Summary
- Add `generate_trace_id()` to `nauka-core::logging` producing random 16-char hex IDs
- Wrap every CLI dispatch in a `tracing::info_span!` with `trace_id`, `resource`, and `op` fields so all logs for an operation share the same trace ID
- Add optional `trace_id` field to `JoinRequest` (with `#[serde(default)]` for backward compatibility) so the joining node's trace context propagates to the accepting node
- Log the received trace_id on the peering server side for cross-node correlation

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test -- --skip disk_free_check` passes (490+ tests, 0 failures)
- [x] `cargo build --release --target x86_64-unknown-linux-musl` cross-compiles
- [x] Deployed to 3 Hetzner servers and verified `trace_id` appears in `/var/log/nauka/` file logs
- [x] Backward compat test: old JoinRequest JSON (no trace_id field) deserializes correctly

Closes #139