### PR TITLE
test: add unit tests for forge reconcilers pd.rs and store.rs

### DIFF
--- a/layers/forge/src/reconciler/pd.rs
+++ b/layers/forge/src/reconciler/pd.rs
@@ -125,7 +125,8 @@ pub fn cleanup_zombie_members(mesh_ipv6: &Ipv6Addr) -> usize {
     };
     let tracker = guard.get_or_insert_with(HashMap::new);
 
-    let zombies = update_tracker_and_find_zombies(tracker, &current_unhealthy, now, ZOMBIE_THRESHOLD);
+    let zombies =
+        update_tracker_and_find_zombies(tracker, &current_unhealthy, now, ZOMBIE_THRESHOLD);
 
     // Log members still waiting
     for (&id, name) in &current_unhealthy {
@@ -196,7 +197,10 @@ mod tests {
         // Simulate 1 minute later — still below 5-min threshold
         let later = now + Duration::from_secs(60);
         let zombies = update_tracker_and_find_zombies(&mut tracker, &unhealthy, later, threshold);
-        assert!(zombies.is_empty(), "member unhealthy for 1 min should not be cleaned");
+        assert!(
+            zombies.is_empty(),
+            "member unhealthy for 1 min should not be cleaned"
+        );
     }
 
     #[test]
@@ -239,7 +243,10 @@ mod tests {
         // Member recovers — remove from unhealthy set
         let healthy: HashMap<u64, String> = HashMap::new();
         let _ = update_tracker_and_find_zombies(&mut tracker, &healthy, t1, threshold);
-        assert!(!tracker.contains_key(&7), "recovered member should be removed from tracker");
+        assert!(
+            !tracker.contains_key(&7),
+            "recovered member should be removed from tracker"
+        );
 
         // Member becomes unhealthy again at t=3min
         let t2 = now + Duration::from_secs(3 * 60 + 1);
@@ -248,7 +255,10 @@ mod tests {
         // 3 more minutes (total 6 min from start, but only 3 from re-appearance)
         let t3 = now + Duration::from_secs(6 * 60 + 1);
         let zombies = update_tracker_and_find_zombies(&mut tracker, &unhealthy, t3, threshold);
-        assert!(zombies.is_empty(), "timer should have reset; only 3 min since re-appearance");
+        assert!(
+            zombies.is_empty(),
+            "timer should have reset; only 3 min since re-appearance"
+        );
 
         // 5 more minutes from re-appearance — now exceeds threshold
         let t4 = t2 + Duration::from_secs(5 * 60);
@@ -261,12 +271,24 @@ mod tests {
         let start = Instant::now();
 
         // Exactly at threshold — should cleanup
-        assert!(should_cleanup_member(start, start + Duration::from_secs(300), Duration::from_secs(300)));
+        assert!(should_cleanup_member(
+            start,
+            start + Duration::from_secs(300),
+            Duration::from_secs(300)
+        ));
 
         // 1 second before threshold — should not
-        assert!(!should_cleanup_member(start, start + Duration::from_secs(299), Duration::from_secs(300)));
+        assert!(!should_cleanup_member(
+            start,
+            start + Duration::from_secs(299),
+            Duration::from_secs(300)
+        ));
 
         // Well past threshold — should cleanup
-        assert!(should_cleanup_member(start, start + Duration::from_secs(600), Duration::from_secs(300)));
+        assert!(should_cleanup_member(
+            start,
+            start + Duration::from_secs(600),
+            Duration::from_secs(300)
+        ));
     }
 }

--- a/layers/forge/src/reconciler/pd.rs
+++ b/layers/forge/src/reconciler/pd.rs
@@ -15,6 +15,46 @@ use std::time::{Duration, Instant};
 /// How long a member must be continuously unhealthy before removal.
 const ZOMBIE_THRESHOLD: Duration = Duration::from_secs(5 * 60);
 
+/// Pure logic: returns true if a member first seen at `first_seen` has exceeded
+/// the zombie `threshold` relative to `now`.
+fn should_cleanup_member(first_seen: Instant, now: Instant, threshold: Duration) -> bool {
+    now.duration_since(first_seen) >= threshold
+}
+
+/// Pure logic: update the tracking map with the current set of unhealthy member IDs.
+///
+/// - Members that are no longer unhealthy are removed (health recovered).
+/// - Newly-unhealthy members are inserted with timestamp `now`.
+///
+/// Returns the list of (member_id, name) pairs that have exceeded the threshold.
+fn update_tracker_and_find_zombies(
+    tracker: &mut HashMap<u64, Instant>,
+    current_unhealthy: &HashMap<u64, String>,
+    now: Instant,
+    threshold: Duration,
+) -> Vec<(u64, String)> {
+    // Remove entries for members that recovered (no longer in current_unhealthy)
+    tracker.retain(|id, _| current_unhealthy.contains_key(id));
+
+    // Insert newly-unhealthy members
+    for &id in current_unhealthy.keys() {
+        tracker.entry(id).or_insert(now);
+    }
+
+    // Collect members that exceeded the threshold
+    current_unhealthy
+        .iter()
+        .filter_map(|(&id, name)| {
+            let first_seen = tracker.get(&id)?;
+            if should_cleanup_member(*first_seen, now, threshold) {
+                Some((id, name.clone()))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
 /// Tracks when each unhealthy member was first seen.
 static UNHEALTHY_SINCE: Mutex<Option<HashMap<u64, Instant>>> = Mutex::new(None);
 
@@ -85,22 +125,12 @@ pub fn cleanup_zombie_members(mesh_ipv6: &Ipv6Addr) -> usize {
     };
     let tracker = guard.get_or_insert_with(HashMap::new);
 
-    // Remove entries for members that are now healthy or gone
-    tracker.retain(|id, _| current_unhealthy.contains_key(id));
+    let zombies = update_tracker_and_find_zombies(tracker, &current_unhealthy, now, ZOMBIE_THRESHOLD);
 
-    // Add newly-unhealthy members
-    for &id in current_unhealthy.keys() {
-        tracker.entry(id).or_insert(now);
-    }
-
-    // Find members that exceeded the threshold
-    let zombies: Vec<(u64, String)> = current_unhealthy
-        .iter()
-        .filter_map(|(&id, name)| {
-            let first_seen = tracker.get(&id)?;
-            if now.duration_since(*first_seen) >= ZOMBIE_THRESHOLD {
-                Some((id, name.clone()))
-            } else {
+    // Log members still waiting
+    for (&id, name) in &current_unhealthy {
+        if !zombies.iter().any(|(zid, _)| *zid == id) {
+            if let Some(first_seen) = tracker.get(&id) {
                 let remaining = ZOMBIE_THRESHOLD
                     .checked_sub(now.duration_since(*first_seen))
                     .unwrap_or_default();
@@ -110,10 +140,9 @@ pub fn cleanup_zombie_members(mesh_ipv6: &Ipv6Addr) -> usize {
                     remaining_secs = remaining.as_secs(),
                     "unhealthy PD member tracked, waiting for threshold"
                 );
-                None
             }
-        })
-        .collect();
+        }
+    }
 
     let mut removed = 0;
 
@@ -145,4 +174,99 @@ pub fn cleanup_zombie_members(mesh_ipv6: &Ipv6Addr) -> usize {
     }
 
     removed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn member_unhealthy_below_threshold_not_cleaned() {
+        let mut tracker = HashMap::new();
+        let now = Instant::now();
+        let threshold = Duration::from_secs(5 * 60);
+
+        let mut unhealthy = HashMap::new();
+        unhealthy.insert(1, "pd-node1".to_string());
+
+        // First call: member just appeared unhealthy
+        let zombies = update_tracker_and_find_zombies(&mut tracker, &unhealthy, now, threshold);
+        assert!(zombies.is_empty(), "member just seen should not be cleaned");
+
+        // Simulate 1 minute later — still below 5-min threshold
+        let later = now + Duration::from_secs(60);
+        let zombies = update_tracker_and_find_zombies(&mut tracker, &unhealthy, later, threshold);
+        assert!(zombies.is_empty(), "member unhealthy for 1 min should not be cleaned");
+    }
+
+    #[test]
+    fn member_unhealthy_above_threshold_cleaned() {
+        let mut tracker = HashMap::new();
+        let now = Instant::now();
+        let threshold = Duration::from_secs(5 * 60);
+
+        let mut unhealthy = HashMap::new();
+        unhealthy.insert(42, "pd-zombie".to_string());
+
+        // First seen
+        let _ = update_tracker_and_find_zombies(&mut tracker, &unhealthy, now, threshold);
+
+        // 6 minutes later — exceeds threshold
+        let later = now + Duration::from_secs(6 * 60);
+        let zombies = update_tracker_and_find_zombies(&mut tracker, &unhealthy, later, threshold);
+        assert_eq!(zombies.len(), 1);
+        assert_eq!(zombies[0].0, 42);
+        assert_eq!(zombies[0].1, "pd-zombie");
+    }
+
+    #[test]
+    fn member_recovers_resets_timer() {
+        let mut tracker = HashMap::new();
+        let now = Instant::now();
+        let threshold = Duration::from_secs(5 * 60);
+
+        let mut unhealthy = HashMap::new();
+        unhealthy.insert(7, "pd-flaky".to_string());
+
+        // First seen at t=0
+        let _ = update_tracker_and_find_zombies(&mut tracker, &unhealthy, now, threshold);
+
+        // 3 minutes later — still unhealthy
+        let t1 = now + Duration::from_secs(3 * 60);
+        let zombies = update_tracker_and_find_zombies(&mut tracker, &unhealthy, t1, threshold);
+        assert!(zombies.is_empty());
+
+        // Member recovers — remove from unhealthy set
+        let healthy: HashMap<u64, String> = HashMap::new();
+        let _ = update_tracker_and_find_zombies(&mut tracker, &healthy, t1, threshold);
+        assert!(!tracker.contains_key(&7), "recovered member should be removed from tracker");
+
+        // Member becomes unhealthy again at t=3min
+        let t2 = now + Duration::from_secs(3 * 60 + 1);
+        let _ = update_tracker_and_find_zombies(&mut tracker, &unhealthy, t2, threshold);
+
+        // 3 more minutes (total 6 min from start, but only 3 from re-appearance)
+        let t3 = now + Duration::from_secs(6 * 60 + 1);
+        let zombies = update_tracker_and_find_zombies(&mut tracker, &unhealthy, t3, threshold);
+        assert!(zombies.is_empty(), "timer should have reset; only 3 min since re-appearance");
+
+        // 5 more minutes from re-appearance — now exceeds threshold
+        let t4 = t2 + Duration::from_secs(5 * 60);
+        let zombies = update_tracker_and_find_zombies(&mut tracker, &unhealthy, t4, threshold);
+        assert_eq!(zombies.len(), 1);
+    }
+
+    #[test]
+    fn should_cleanup_member_boundary() {
+        let start = Instant::now();
+
+        // Exactly at threshold — should cleanup
+        assert!(should_cleanup_member(start, start + Duration::from_secs(300), Duration::from_secs(300)));
+
+        // 1 second before threshold — should not
+        assert!(!should_cleanup_member(start, start + Duration::from_secs(299), Duration::from_secs(300)));
+
+        // Well past threshold — should cleanup
+        assert!(should_cleanup_member(start, start + Duration::from_secs(600), Duration::from_secs(300)));
+    }
 }

--- a/layers/forge/src/reconciler/store.rs
+++ b/layers/forge/src/reconciler/store.rs
@@ -116,9 +116,7 @@ impl super::Reconciler for StoreReconciler {
         result.desired = stores
             .iter()
             .filter(|s| {
-                is_store_eligible_for_deregister(
-                    s["store"]["state_name"].as_str().unwrap_or(""),
-                )
+                is_store_eligible_for_deregister(s["store"]["state_name"].as_str().unwrap_or(""))
             })
             .count();
 
@@ -182,20 +180,30 @@ mod tests {
             "[fd12:3456:789a::2]:20160".to_string(),
         ];
 
-        assert!(match_store_to_peer("[fd12:3456:789a::1]:20160", &peer_addrs));
-        assert!(match_store_to_peer("[fd12:3456:789a::2]:20160", &peer_addrs));
+        assert!(match_store_to_peer(
+            "[fd12:3456:789a::1]:20160",
+            &peer_addrs
+        ));
+        assert!(match_store_to_peer(
+            "[fd12:3456:789a::2]:20160",
+            &peer_addrs
+        ));
     }
 
     #[test]
     fn store_address_no_match() {
-        let peer_addrs = vec![
-            "[fd12:3456:789a::1]:20160".to_string(),
-        ];
+        let peer_addrs = vec!["[fd12:3456:789a::1]:20160".to_string()];
 
         // Different address
-        assert!(!match_store_to_peer("[fd12:3456:789a::99]:20160", &peer_addrs));
+        assert!(!match_store_to_peer(
+            "[fd12:3456:789a::99]:20160",
+            &peer_addrs
+        ));
         // Different port
-        assert!(!match_store_to_peer("[fd12:3456:789a::1]:20161", &peer_addrs));
+        assert!(!match_store_to_peer(
+            "[fd12:3456:789a::1]:20161",
+            &peer_addrs
+        ));
         // Empty peer list
         assert!(!match_store_to_peer("[fd12:3456:789a::1]:20160", &[]));
     }

--- a/layers/forge/src/reconciler/store.rs
+++ b/layers/forge/src/reconciler/store.rs
@@ -16,6 +16,25 @@ use crate::types::{ReconcileContext, ReconcileResult};
 /// How long a peer must be unreachable before we offline its store (seconds).
 const UNREACHABLE_THRESHOLD_SECS: u64 = 60;
 
+/// Pure logic: returns true if the store address matches any of the expected
+/// peer addresses. Both sides use the `[ipv6]:port` format.
+fn match_store_to_peer(store_addr: &str, peer_addrs: &[String]) -> bool {
+    peer_addrs.iter().any(|a| a == store_addr)
+}
+
+/// Pure logic: returns true if a store with the given `state_name` is eligible
+/// for deregistration. Only "Up" stores should be offlined; Tombstone, Offline,
+/// and Disconnected stores are already handled by PD.
+fn is_store_eligible_for_deregister(state_name: &str) -> bool {
+    state_name == "Up"
+}
+
+/// Pure logic: returns true if a peer has been unreachable long enough based on
+/// its reference timestamp (`last_handshake` or `added_at`) and the current time.
+fn is_peer_unreachable_past_threshold(ref_time: u64, now: u64, threshold: u64) -> bool {
+    now.saturating_sub(ref_time) > threshold
+}
+
 pub struct StoreReconciler;
 
 #[async_trait::async_trait]
@@ -55,7 +74,7 @@ impl super::Reconciler for StoreReconciler {
                 } else {
                     p.added_at
                 };
-                now.saturating_sub(ref_time) > UNREACHABLE_THRESHOLD_SECS
+                is_peer_unreachable_past_threshold(ref_time, now, UNREACHABLE_THRESHOLD_SECS)
             })
             .collect();
 
@@ -96,7 +115,11 @@ impl super::Reconciler for StoreReconciler {
 
         result.desired = stores
             .iter()
-            .filter(|s| s["store"]["state_name"].as_str() == Some("Up"))
+            .filter(|s| {
+                is_store_eligible_for_deregister(
+                    s["store"]["state_name"].as_str().unwrap_or(""),
+                )
+            })
             .count();
 
         // For each "Up" store whose address matches an unreachable peer, offline it
@@ -105,11 +128,11 @@ impl super::Reconciler for StoreReconciler {
             let state_name = store["store"]["state_name"].as_str().unwrap_or("");
             let store_id = store["store"]["id"].as_u64().unwrap_or(0);
 
-            if state_name != "Up" || store_id == 0 {
+            if !is_store_eligible_for_deregister(state_name) || store_id == 0 {
                 continue;
             }
 
-            if !unreachable_addrs.iter().any(|a| a == addr) {
+            if !match_store_to_peer(addr, &unreachable_addrs) {
                 continue;
             }
 
@@ -145,5 +168,83 @@ impl super::Reconciler for StoreReconciler {
         }
 
         Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn store_address_matches_peer() {
+        let peer_addrs = vec![
+            "[fd12:3456:789a::1]:20160".to_string(),
+            "[fd12:3456:789a::2]:20160".to_string(),
+        ];
+
+        assert!(match_store_to_peer("[fd12:3456:789a::1]:20160", &peer_addrs));
+        assert!(match_store_to_peer("[fd12:3456:789a::2]:20160", &peer_addrs));
+    }
+
+    #[test]
+    fn store_address_no_match() {
+        let peer_addrs = vec![
+            "[fd12:3456:789a::1]:20160".to_string(),
+        ];
+
+        // Different address
+        assert!(!match_store_to_peer("[fd12:3456:789a::99]:20160", &peer_addrs));
+        // Different port
+        assert!(!match_store_to_peer("[fd12:3456:789a::1]:20161", &peer_addrs));
+        // Empty peer list
+        assert!(!match_store_to_peer("[fd12:3456:789a::1]:20160", &[]));
+    }
+
+    #[test]
+    fn store_up_is_eligible() {
+        assert!(is_store_eligible_for_deregister("Up"));
+    }
+
+    #[test]
+    fn store_tombstone_not_eligible() {
+        assert!(!is_store_eligible_for_deregister("Tombstone"));
+    }
+
+    #[test]
+    fn store_offline_not_eligible() {
+        assert!(!is_store_eligible_for_deregister("Offline"));
+        assert!(!is_store_eligible_for_deregister("Disconnected"));
+        assert!(!is_store_eligible_for_deregister(""));
+    }
+
+    #[test]
+    fn peer_unreachable_past_threshold() {
+        let now = 1000;
+        let threshold = 60;
+
+        // last_handshake was 120s ago — well past 60s threshold
+        assert!(is_peer_unreachable_past_threshold(880, now, threshold));
+
+        // last_handshake was 61s ago — just past threshold
+        assert!(is_peer_unreachable_past_threshold(939, now, threshold));
+    }
+
+    #[test]
+    fn peer_unreachable_within_threshold() {
+        let now = 1000;
+        let threshold = 60;
+
+        // last_handshake was 30s ago — within threshold
+        assert!(!is_peer_unreachable_past_threshold(970, now, threshold));
+
+        // last_handshake was exactly 60s ago — not past (> not >=)
+        assert!(!is_peer_unreachable_past_threshold(940, now, threshold));
+    }
+
+    #[test]
+    fn peer_unreachable_zero_ref_time() {
+        // ref_time = 0 (never handshaked), now = 100, threshold = 60
+        // saturating_sub(0) = 100 > 60 → unreachable
+        assert!(is_peer_unreachable_past_threshold(0, 100, 60));
     }
 }


### PR DESCRIPTION
## Summary
- Extract pure functions from `pd.rs` (`should_cleanup_member`, `update_tracker_and_find_zombies`) and `store.rs` (`match_store_to_peer`, `is_store_eligible_for_deregister`, `is_peer_unreachable_past_threshold`)
- Wire extracted helpers into the main reconcile code paths (no behavior change)
- Add 12 unit tests covering threshold tracking, health recovery/timer reset, address matching, store state filtering, and unreachable peer timing

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test -- --skip disk_free_check` passes (all 12 new tests green)
- [x] No mocking of curl/systemctl — tests only exercise pure logic

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)