### PR TITLE
refactor: extract typed PdClient with retry, replacing 37 curl calls

### DIFF
--- a/layers/forge/src/reconciler/pd.rs
+++ b/layers/forge/src/reconciler/pd.rs
@@ -12,6 +12,8 @@ use std::net::Ipv6Addr;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
+use nauka_hypervisor::controlplane::pd_client::PdClient;
+
 /// How long a member must be continuously unhealthy before removal.
 const ZOMBIE_THRESHOLD: Duration = Duration::from_secs(5 * 60);
 
@@ -23,30 +25,12 @@ static UNHEALTHY_SINCE: Mutex<Option<HashMap<u64, Instant>>> = Mutex::new(None);
 /// Called every reconcile cycle, before TiKV connect. Returns the number
 /// of members removed.
 pub fn cleanup_zombie_members(mesh_ipv6: &Ipv6Addr) -> usize {
-    let pd_url = format!(
-        "http://[{}]:{}",
-        mesh_ipv6,
-        nauka_hypervisor::controlplane::PD_CLIENT_PORT,
-    );
+    let client = PdClient::from_mesh(mesh_ipv6);
 
     // Query PD health endpoint
-    let health_url = format!("{pd_url}/pd/api/v1/health");
-    let output = match std::process::Command::new("curl")
-        .args(["-sf", "--max-time", "5", &health_url])
-        .output()
-    {
-        Ok(o) if o.status.success() => o,
-        _ => return 0, // PD unreachable — nothing to do
-    };
-
-    let health: serde_json::Value = match serde_json::from_slice(&output.stdout) {
-        Ok(v) => v,
-        Err(_) => return 0,
-    };
-
-    let members = match health.as_array() {
-        Some(m) => m,
-        None => return 0,
+    let health = match client.get_health() {
+        Ok(h) => h,
+        Err(_) => return 0, // PD unreachable — nothing to do
     };
 
     let now = Instant::now();
@@ -54,17 +38,13 @@ pub fn cleanup_zombie_members(mesh_ipv6: &Ipv6Addr) -> usize {
     // Collect current unhealthy member IDs
     let mut current_unhealthy: HashMap<u64, String> = HashMap::new();
 
-    for member in members {
-        let healthy = member["health"].as_bool().unwrap_or(true);
-        let member_id = member["member_id"].as_u64().unwrap_or(0);
-        let name = member["name"].as_str().unwrap_or("").to_string();
-
-        if member_id == 0 {
+    for entry in &health {
+        if entry.member_id == 0 {
             continue;
         }
 
-        if !healthy {
-            current_unhealthy.insert(member_id, name);
+        if !entry.healthy {
+            current_unhealthy.insert(entry.member_id, entry.name.clone());
         }
     }
 
@@ -124,17 +104,13 @@ pub fn cleanup_zombie_members(mesh_ipv6: &Ipv6Addr) -> usize {
             "removing zombie PD member (unhealthy >5 min)"
         );
 
-        let delete_url = format!("{pd_url}/pd/api/v1/members/id/{member_id}");
-        match std::process::Command::new("curl")
-            .args(["-sf", "-X", "DELETE", "--max-time", "5", &delete_url])
-            .output()
-        {
-            Ok(o) if o.status.success() => {
+        match client.delete_member_by_id(*member_id) {
+            Ok(()) => {
                 tracing::warn!(member_id, name = name.as_str(), "zombie PD member removed");
                 tracker.remove(member_id);
                 removed += 1;
             }
-            _ => {
+            Err(_) => {
                 tracing::error!(
                     member_id,
                     name = name.as_str(),

--- a/layers/forge/src/reconciler/store.rs
+++ b/layers/forge/src/reconciler/store.rs
@@ -4,10 +4,10 @@
 //! store running on that peer is moved offline via the PD API. This prevents
 //! stuck regions caused by PD waiting for a store that will never return.
 
-use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use nauka_hypervisor::controlplane;
+use nauka_hypervisor::controlplane::pd_client::PdClient;
 use nauka_hypervisor::fabric;
 use nauka_state::LocalDb;
 
@@ -70,76 +70,48 @@ impl super::Reconciler for StoreReconciler {
             .collect();
 
         // Get store list from PD
-        let pd_url = format!(
-            "http://[{}]:{}",
-            ctx.mesh_ipv6,
-            controlplane::PD_CLIENT_PORT,
-        );
-        let stores_url = format!("{pd_url}/pd/api/v1/stores");
-        let output = match Command::new("curl")
-            .args(["-sf", "--max-time", "5", &stores_url])
-            .output()
-        {
-            Ok(o) if o.status.success() => o,
-            _ => return Ok(result), // PD not reachable, skip
+        let client = PdClient::from_mesh(&ctx.mesh_ipv6);
+        let stores = match client.get_stores() {
+            Ok(s) => s,
+            Err(_) => return Ok(result), // PD not reachable, skip
         };
 
-        let body: serde_json::Value = match serde_json::from_slice(&output.stdout) {
-            Ok(v) => v,
-            Err(_) => return Ok(result),
-        };
-
-        let stores = match body["stores"].as_array() {
-            Some(s) => s,
-            None => return Ok(result),
-        };
-
-        result.desired = stores
-            .iter()
-            .filter(|s| s["store"]["state_name"].as_str() == Some("Up"))
-            .count();
+        result.desired = stores.iter().filter(|s| s.state_name == "Up").count();
 
         // For each "Up" store whose address matches an unreachable peer, offline it
-        for store in stores {
-            let addr = store["store"]["address"].as_str().unwrap_or("");
-            let state_name = store["store"]["state_name"].as_str().unwrap_or("");
-            let store_id = store["store"]["id"].as_u64().unwrap_or(0);
-
-            if state_name != "Up" || store_id == 0 {
+        for store in &stores {
+            if store.state_name != "Up" || store.id == 0 {
                 continue;
             }
 
-            if !unreachable_addrs.iter().any(|a| a == addr) {
+            if !unreachable_addrs.iter().any(|a| a == &store.address) {
                 continue;
             }
 
             // Find the peer name for logging
             let peer_name = unreachable_peers
                 .iter()
-                .find(|p| format!("[{}]:{}", p.mesh_ipv6, controlplane::TIKV_PORT) == addr)
+                .find(|p| format!("[{}]:{}", p.mesh_ipv6, controlplane::TIKV_PORT) == store.address)
                 .map(|p| p.name.as_str())
                 .unwrap_or("unknown");
 
             tracing::warn!(
-                store_id,
-                addr,
+                store_id = store.id,
+                addr = store.address.as_str(),
                 peer = peer_name,
                 "offlining TiKV store — peer unreachable >60s"
             );
 
-            let delete_url = format!("{pd_url}/pd/api/v1/store/{store_id}");
-            match Command::new("curl")
-                .args(["-sf", "-X", "DELETE", "--max-time", "5", &delete_url])
-                .output()
-            {
-                Ok(o) if o.status.success() => {
+            match client.delete_store(store.id) {
+                Ok(()) => {
                     result.deleted += 1;
                 }
-                _ => {
+                Err(_) => {
                     result.failed += 1;
-                    result
-                        .errors
-                        .push(format!("failed to offline store {store_id} ({addr})"));
+                    result.errors.push(format!(
+                        "failed to offline store {} ({})",
+                        store.id, store.address
+                    ));
                 }
             }
         }

--- a/layers/hypervisor/src/controlplane/mod.rs
+++ b/layers/hypervisor/src/controlplane/mod.rs
@@ -12,6 +12,7 @@
 
 pub mod backup;
 pub mod ops;
+pub mod pd_client;
 pub mod service;
 pub mod store;
 

--- a/layers/hypervisor/src/controlplane/ops.rs
+++ b/layers/hypervisor/src/controlplane/ops.rs
@@ -231,44 +231,25 @@ fn rollback_pd_member(mesh_ipv6: &Ipv6Addr, remote_pd_url: &str) {
 
     // Ask the remote PD (which should still have quorum with the other
     // existing members) to remove our member.
-    let members_url = format!("{remote_pd_url}/pd/api/v1/members");
-    let output = match std::process::Command::new("curl")
-        .args(["-sf", "--max-time", "10", &members_url])
-        .output()
-    {
-        Ok(o) if o.status.success() => o,
-        _ => {
+    let client = super::pd_client::PdClient::new(vec![remote_pd_url.to_string()]);
+
+    let members = match client.get_members() {
+        Ok(m) => m,
+        Err(_) => {
             tracing::warn!("rollback: cannot reach remote PD to deregister member");
             return;
         }
     };
 
-    let body: serde_json::Value = match serde_json::from_slice(&output.stdout) {
-        Ok(v) => v,
-        Err(_) => return,
-    };
-
     let our_ip = mesh_ipv6.to_string();
-    if let Some(members) = body["members"].as_array() {
-        for member in members {
-            let peer_urls = member["peer_urls"]
-                .as_array()
-                .map(|a| {
-                    a.iter()
-                        .filter_map(|v| v.as_str())
-                        .collect::<Vec<_>>()
-                        .join(",")
-                })
-                .unwrap_or_default();
-            let member_id = member["member_id"].as_u64().unwrap_or(0);
-
-            if peer_urls.contains(&our_ip) && member_id > 0 {
-                tracing::warn!(member_id, "rollback: removing our PD member from cluster");
-                let delete_url = format!("{remote_pd_url}/pd/api/v1/members/id/{member_id}");
-                let _ = std::process::Command::new("curl")
-                    .args(["-sf", "-X", "DELETE", "--max-time", "10", &delete_url])
-                    .output();
-            }
+    for member in &members {
+        let peer_urls_joined = member.peer_urls.join(",");
+        if peer_urls_joined.contains(&our_ip) && member.member_id > 0 {
+            tracing::warn!(
+                member_id = member.member_id,
+                "rollback: removing our PD member from cluster"
+            );
+            let _ = client.delete_member_by_id(member.member_id);
         }
     }
 }
@@ -428,18 +409,11 @@ pub fn leave() -> Result<(), NaukaError> {
 
 /// Wait for mesh connectivity to a PD endpoint (HTTP health check).
 fn wait_mesh_connectivity(pd_url: &str, timeout_secs: u64) -> Result<(), NaukaError> {
-    let url = format!("{pd_url}/pd/api/v1/health");
+    let client = super::pd_client::PdClient::new(vec![pd_url.to_string()]);
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
 
     while std::time::Instant::now() < deadline {
-        if std::process::Command::new("curl")
-            .args(["-sf", "--max-time", "3", &url])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false)
-        {
+        if client.ping() {
             // Also clean up any zombie PD members before joining
             cleanup_zombie_members(pd_url);
             return Ok(());
@@ -452,34 +426,18 @@ fn wait_mesh_connectivity(pd_url: &str, timeout_secs: u64) -> Result<(), NaukaEr
 
 /// Remove unhealthy PD members (zombies from failed joins).
 fn cleanup_zombie_members(pd_url: &str) {
-    let url = format!("{pd_url}/pd/api/v1/health");
-    let output = match std::process::Command::new("curl")
-        .args(["-sf", "--max-time", "5", &url])
-        .output()
-    {
-        Ok(o) if o.status.success() => o,
-        _ => return,
-    };
+    let client = super::pd_client::PdClient::new(vec![pd_url.to_string()]);
 
-    let health: serde_json::Value = match serde_json::from_slice(&output.stdout) {
-        Ok(v) => v,
+    let health = match client.get_health() {
+        Ok(h) => h,
         Err(_) => return,
     };
 
-    if let Some(members) = health.as_array() {
-        for member in members {
-            let healthy = member["health"].as_bool().unwrap_or(true);
-            let name = member["name"].as_str().unwrap_or("");
-            let member_id = member["member_id"].as_u64().unwrap_or(0);
-
-            // Remove unhealthy members with no name (zombie from failed join)
-            if !healthy && name.is_empty() && member_id > 0 {
-                tracing::info!(member_id, "removing zombie PD member");
-                let delete_url = format!("{pd_url}/pd/api/v1/members/id/{member_id}");
-                let _ = std::process::Command::new("curl")
-                    .args(["-sf", "-X", "DELETE", "--max-time", "5", &delete_url])
-                    .output();
-            }
+    for entry in &health {
+        // Remove unhealthy members with no name (zombie from failed join)
+        if !entry.healthy && entry.name.is_empty() && entry.member_id > 0 {
+            tracing::info!(member_id = entry.member_id, "removing zombie PD member");
+            let _ = client.delete_member_by_id(entry.member_id);
         }
     }
 }

--- a/layers/hypervisor/src/controlplane/pd_client.rs
+++ b/layers/hypervisor/src/controlplane/pd_client.rs
@@ -1,0 +1,509 @@
+//! Typed PD (Placement Driver) HTTP client.
+//!
+//! Centralises all PD API calls behind a single `PdClient` struct with
+//! typed request/response types, retry with exponential backoff, and
+//! automatic endpoint failover.
+//!
+//! Still shells out to `curl` (no HTTP crate dependency) but all the
+//! JSON parsing, error handling, and retry logic is in one place.
+
+use std::net::Ipv6Addr;
+use std::process::Command;
+
+use nauka_core::error::NaukaError;
+use serde::{Deserialize, Serialize};
+
+// ═══════════════════════════════════════════════════
+// Response types
+// ═══════════════════════════════════════════════════
+
+/// A PD cluster member.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PdMember {
+    pub member_id: u64,
+    pub name: String,
+    pub peer_urls: Vec<String>,
+    pub client_urls: Vec<String>,
+    pub is_leader: bool,
+    pub is_healthy: bool,
+}
+
+/// A TiKV store registered with PD.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TiKVStore {
+    pub id: u64,
+    pub address: String,
+    pub state_name: String,
+    pub capacity: String,
+}
+
+/// Region statistics from PD.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RegionStats {
+    pub count: u64,
+    pub empty_count: u64,
+    pub miss_peer: u64,
+    pub extra_peer: u64,
+}
+
+/// PD health entry (from /pd/api/v1/health).
+#[derive(Debug, Clone)]
+pub struct HealthEntry {
+    pub member_id: u64,
+    pub name: String,
+    pub healthy: bool,
+}
+
+// ═══════════════════════════════════════════════════
+// PdClient
+// ═══════════════════════════════════════════════════
+
+/// Typed HTTP client for the PD API.
+///
+/// Wraps `curl` with retry, endpoint failover, and typed responses.
+/// Thread-safe and cheap to clone.
+#[derive(Debug, Clone)]
+pub struct PdClient {
+    endpoints: Vec<String>,
+    /// Default timeout per request in seconds.
+    timeout_secs: u64,
+}
+
+impl PdClient {
+    /// Create a client with multiple PD endpoints for failover.
+    pub fn new(endpoints: Vec<String>) -> Self {
+        Self {
+            endpoints,
+            timeout_secs: 10,
+        }
+    }
+
+    /// Shortcut: single-node PD at the given mesh IPv6.
+    pub fn from_mesh(mesh_ipv6: &Ipv6Addr) -> Self {
+        Self::new(vec![format!(
+            "http://[{}]:{}",
+            mesh_ipv6,
+            super::PD_CLIENT_PORT
+        )])
+    }
+
+    /// Override the default per-request timeout (seconds).
+    pub fn with_timeout(mut self, secs: u64) -> Self {
+        self.timeout_secs = secs;
+        self
+    }
+
+    // ───────────────────────────────────────────────
+    // Health
+    // ───────────────────────────────────────────────
+
+    /// Check if any PD endpoint is reachable and healthy.
+    pub fn is_healthy(&self) -> bool {
+        self.get("/pd/api/v1/health").is_ok()
+    }
+
+    /// Get the health status of all PD members.
+    pub fn get_health(&self) -> Result<Vec<HealthEntry>, NaukaError> {
+        let val = self.get("/pd/api/v1/health")?;
+        let arr = val
+            .as_array()
+            .ok_or_else(|| NaukaError::internal("PD health: expected array"))?;
+
+        Ok(arr
+            .iter()
+            .map(|m| HealthEntry {
+                member_id: m["member_id"].as_u64().unwrap_or(0),
+                name: m["name"].as_str().unwrap_or("").to_string(),
+                healthy: m["health"].as_bool().unwrap_or(false),
+            })
+            .collect())
+    }
+
+    // ───────────────────────────────────────────────
+    // Members
+    // ───────────────────────────────────────────────
+
+    /// Get all PD members with health and leader status merged in.
+    pub fn get_members(&self) -> Result<Vec<PdMember>, NaukaError> {
+        let val = self.get("/pd/api/v1/members")?;
+
+        let leader_id = val["leader"]["member_id"].as_u64().unwrap_or(0);
+
+        let members = val["members"]
+            .as_array()
+            .ok_or_else(|| NaukaError::internal("PD members: expected array"))?;
+
+        // Best-effort: merge health info
+        let health = self.get_health().unwrap_or_default();
+        let healthy_ids: std::collections::HashSet<u64> = health
+            .iter()
+            .filter(|h| h.healthy)
+            .map(|h| h.member_id)
+            .collect();
+
+        Ok(members
+            .iter()
+            .map(|m| {
+                let mid = m["member_id"].as_u64().unwrap_or(0);
+                PdMember {
+                    member_id: mid,
+                    name: m["name"].as_str().unwrap_or("").to_string(),
+                    peer_urls: m["peer_urls"]
+                        .as_array()
+                        .map(|a| {
+                            a.iter()
+                                .filter_map(|v| v.as_str().map(String::from))
+                                .collect()
+                        })
+                        .unwrap_or_default(),
+                    client_urls: m["client_urls"]
+                        .as_array()
+                        .map(|a| {
+                            a.iter()
+                                .filter_map(|v| v.as_str().map(String::from))
+                                .collect()
+                        })
+                        .unwrap_or_default(),
+                    is_leader: mid == leader_id,
+                    is_healthy: healthy_ids.contains(&mid),
+                }
+            })
+            .collect())
+    }
+
+    /// Check if a PD member with the given mesh IPv6 exists.
+    pub fn member_exists(&self, mesh_ipv6: &Ipv6Addr) -> bool {
+        let our_ip = mesh_ipv6.to_string();
+        self.get_members()
+            .map(|members| {
+                members
+                    .iter()
+                    .any(|m| m.peer_urls.iter().any(|url| url.contains(&our_ip)))
+            })
+            .unwrap_or(false)
+    }
+
+    /// Find the member ID for a given mesh IPv6.
+    pub fn find_member_id(&self, mesh_ipv6: &Ipv6Addr) -> Option<u64> {
+        let our_ip = mesh_ipv6.to_string();
+        self.get_members().ok()?.into_iter().find_map(|m| {
+            if m.member_id > 0 && m.peer_urls.iter().any(|url| url.contains(&our_ip)) {
+                Some(m.member_id)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Delete a PD member by ID.
+    pub fn delete_member_by_id(&self, member_id: u64) -> Result<(), NaukaError> {
+        self.delete(&format!("/pd/api/v1/members/id/{member_id}"))
+    }
+
+    /// Delete a PD member by name.
+    pub fn delete_member_by_name(&self, name: &str) -> Result<(), NaukaError> {
+        self.delete(&format!("/pd/api/v1/members/name/{name}"))
+    }
+
+    /// Add a new PD member with the given peer URLs.
+    pub fn add_member(&self, peer_urls: &[String]) -> Result<(), NaukaError> {
+        let body = serde_json::json!({ "peerURLs": peer_urls }).to_string();
+        self.post("/pd/api/v1/members", &body)?;
+        Ok(())
+    }
+
+    // ───────────────────────────────────────────────
+    // Stores
+    // ───────────────────────────────────────────────
+
+    /// Get all TiKV stores (default: Up state only).
+    pub fn get_stores(&self) -> Result<Vec<TiKVStore>, NaukaError> {
+        self.get_stores_with_path("/pd/api/v1/stores")
+    }
+
+    /// Get TiKV stores in specific states (0=Up, 1=Disconnected, 2=Offline).
+    pub fn get_stores_with_states(&self, states: &[u32]) -> Result<Vec<TiKVStore>, NaukaError> {
+        let params: Vec<String> = states.iter().map(|s| format!("state={s}")).collect();
+        let path = format!("/pd/api/v1/stores?{}", params.join("&"));
+        self.get_stores_with_path(&path)
+    }
+
+    fn get_stores_with_path(&self, path: &str) -> Result<Vec<TiKVStore>, NaukaError> {
+        let val = self.get(path)?;
+        let stores = val["stores"].as_array().cloned().unwrap_or_default();
+
+        Ok(stores
+            .iter()
+            .map(|s| TiKVStore {
+                id: s["store"]["id"].as_u64().unwrap_or(0),
+                address: s["store"]["address"].as_str().unwrap_or("").to_string(),
+                state_name: s["store"]["state_name"].as_str().unwrap_or("").to_string(),
+                capacity: s["status"]["capacity"].as_str().unwrap_or("").to_string(),
+            })
+            .collect())
+    }
+
+    /// Count TiKV stores in Up state.
+    pub fn count_active_stores(&self) -> usize {
+        self.get_stores()
+            .map(|stores| stores.iter().filter(|s| s.state_name == "Up").count())
+            .unwrap_or(0)
+    }
+
+    /// Find the store ID for a given TiKV address (e.g., `[fd01::1]:20160`).
+    ///
+    /// Searches stores in Up, Disconnected, and Offline states.
+    pub fn find_store_id(&self, tikv_addr: &str) -> Option<u64> {
+        self.get_stores_with_states(&[0, 1, 2])
+            .ok()?
+            .into_iter()
+            .find(|s| s.address == tikv_addr && s.id > 0)
+            .map(|s| s.id)
+    }
+
+    /// Delete (offline) a TiKV store by ID.
+    pub fn delete_store(&self, store_id: u64) -> Result<(), NaukaError> {
+        self.delete(&format!("/pd/api/v1/store/{store_id}"))
+    }
+
+    /// Force-delete a TiKV store (for recovery).
+    pub fn force_delete_store(&self, store_id: u64) -> Result<(), NaukaError> {
+        self.delete(&format!("/pd/api/v1/store/{store_id}?force=true"))
+    }
+
+    /// Purge tombstoned stores.
+    pub fn remove_tombstone(&self) -> Result<(), NaukaError> {
+        self.delete("/pd/api/v1/stores/remove-tombstone")
+    }
+
+    // ───────────────────────────────────────────────
+    // Regions
+    // ───────────────────────────────────────────────
+
+    /// Get region statistics.
+    pub fn get_region_stats(&self) -> Result<RegionStats, NaukaError> {
+        let val = self.get("/pd/api/v1/stats/region")?;
+        Ok(RegionStats {
+            count: val["count"].as_u64().unwrap_or(0),
+            empty_count: val["empty_count"].as_u64().unwrap_or(0),
+            miss_peer: val["miss_peer_region_count"].as_u64().unwrap_or(0),
+            extra_peer: val["extra_peer_region_count"].as_u64().unwrap_or(0),
+        })
+    }
+
+    /// Get all regions.
+    pub fn get_regions(&self) -> Result<serde_json::Value, NaukaError> {
+        self.get("/pd/api/v1/regions")
+    }
+
+    /// Get regions for a specific store.
+    pub fn get_store_regions(&self, store_id: u64) -> Result<serde_json::Value, NaukaError> {
+        self.get(&format!("/pd/api/v1/regions/store/{store_id}"))
+    }
+
+    /// Count regions on a specific store. Returns 0 if store is gone.
+    pub fn count_store_regions(&self, store_id: u64) -> usize {
+        self.get_store_regions(store_id)
+            .ok()
+            .and_then(|v| v["regions"].as_array().map(|a| a.len()))
+            .unwrap_or(0)
+    }
+
+    // ───────────────────────────────────────────────
+    // Replication config
+    // ───────────────────────────────────────────────
+
+    /// Get current max-replicas setting.
+    pub fn get_max_replicas(&self) -> Result<usize, NaukaError> {
+        let val = self.get("/pd/api/v1/config/replicate")?;
+        Ok(val["max-replicas"].as_u64().unwrap_or(3) as usize)
+    }
+
+    /// Set max-replicas if it differs from the current value.
+    pub fn set_max_replicas(&self, target: usize) -> Result<(), NaukaError> {
+        if target == 0 {
+            return Ok(());
+        }
+
+        let current = self.get_max_replicas()?;
+        if target != current {
+            tracing::info!(current, target, "adjusting max-replicas");
+            let payload = format!("{{\"max-replicas\": {target}}}");
+            self.post("/pd/api/v1/config/replicate", &payload)?;
+        }
+        Ok(())
+    }
+
+    // ───────────────────────────────────────────────
+    // Unsafe recovery
+    // ───────────────────────────────────────────────
+
+    /// Remove failed stores via PD's unsafe recovery API.
+    pub fn unsafe_remove_failed_stores(&self, store_ids: &[u64]) -> Result<(), NaukaError> {
+        let stores_json = store_ids
+            .iter()
+            .map(|id| id.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        let body = format!("{{\"stores\": [{stores_json}]}}");
+        self.post("/pd/api/v1/admin/unsafe/remove-failed-stores", &body)?;
+        Ok(())
+    }
+
+    // ───────────────────────────────────────────────
+    // Raw access (for callers that need the raw JSON)
+    // ───────────────────────────────────────────────
+
+    /// Raw GET request returning parsed JSON.
+    pub fn api_get(&self, path: &str) -> Result<serde_json::Value, NaukaError> {
+        self.get(path)
+    }
+
+    // ═══════════════════════════════════════════════
+    // Internal HTTP with retry + failover
+    // ═══════════════════════════════════════════════
+
+    fn get(&self, path: &str) -> Result<serde_json::Value, NaukaError> {
+        let body = self.http("GET", path, None)?;
+        serde_json::from_str(&body)
+            .map_err(|e| NaukaError::internal(format!("PD API parse error: {e}")))
+    }
+
+    fn post(&self, path: &str, body: &str) -> Result<serde_json::Value, NaukaError> {
+        let resp = self.http("POST", path, Some(body))?;
+        // Some POST endpoints return empty body on success
+        if resp.trim().is_empty() {
+            Ok(serde_json::Value::Null)
+        } else {
+            serde_json::from_str(&resp)
+                .map_err(|e| NaukaError::internal(format!("PD API parse error: {e}")))
+        }
+    }
+
+    fn delete(&self, path: &str) -> Result<(), NaukaError> {
+        self.http("DELETE", path, None)?;
+        Ok(())
+    }
+
+    /// Execute an HTTP request against PD with retry and endpoint failover.
+    ///
+    /// - Tries each endpoint in order
+    /// - Retries up to 3 times per endpoint with 1s/2s/4s backoff
+    /// - Returns the response body on success
+    fn http(&self, method: &str, path: &str, body: Option<&str>) -> Result<String, NaukaError> {
+        let timeout = self.timeout_secs.to_string();
+        let backoffs = [1, 2, 4];
+        let mut last_err = String::from("no PD endpoints configured");
+
+        for endpoint in &self.endpoints {
+            let url = format!("{endpoint}{path}");
+
+            for (attempt, &delay) in backoffs.iter().enumerate() {
+                let mut args: Vec<&str> = vec!["-s", "--fail-with-body", "--max-time", &timeout];
+
+                if method != "GET" {
+                    args.extend_from_slice(&["-X", method]);
+                }
+
+                if let Some(b) = body {
+                    args.extend_from_slice(&["-H", "Content-Type: application/json", "-d", b]);
+                }
+
+                args.push(&url);
+
+                let result = Command::new("curl").args(&args).output();
+
+                match result {
+                    Ok(output) => {
+                        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+
+                        if output.status.success() {
+                            return Ok(stdout);
+                        }
+
+                        // curl exit code: non-zero means HTTP or connection error.
+                        // Check if this is a retriable connection error (exit 7, 28, 56)
+                        // or a non-retriable HTTP error (exit 22 = HTTP >= 400).
+                        let exit_code = output.status.code().unwrap_or(1);
+                        if exit_code == 22 {
+                            // HTTP error (4xx/5xx) — don't retry, return error
+                            let detail = if stdout.is_empty() {
+                                String::from_utf8_lossy(&output.stderr).to_string()
+                            } else {
+                                stdout
+                            };
+                            return Err(NaukaError::internal(format!(
+                                "PD API error: {method} {path}: {detail}"
+                            )));
+                        }
+
+                        // Connection error — retry
+                        last_err = format!(
+                            "{method} {url}: curl exit {exit_code} (attempt {}/{})",
+                            attempt + 1,
+                            backoffs.len()
+                        );
+                    }
+                    Err(e) => {
+                        last_err = format!("{method} {url}: {e}");
+                    }
+                }
+
+                if attempt + 1 < backoffs.len() {
+                    std::thread::sleep(std::time::Duration::from_secs(delay));
+                }
+            }
+        }
+
+        Err(NaukaError::internal(format!(
+            "PD API unreachable after retries: {last_err}"
+        )))
+    }
+
+    /// Quick connectivity check — single attempt, short timeout.
+    pub fn ping(&self) -> bool {
+        for endpoint in &self.endpoints {
+            let url = format!("{endpoint}/pd/api/v1/health");
+            let ok = Command::new("curl")
+                .args(["-sf", "--max-time", "3", &url])
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false);
+            if ok {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_mesh_builds_correct_endpoint() {
+        let ip: Ipv6Addr = "fd01::1".parse().unwrap();
+        let client = PdClient::from_mesh(&ip);
+        assert_eq!(client.endpoints.len(), 1);
+        assert!(client.endpoints[0].contains("fd01::1"));
+        assert!(client.endpoints[0].contains(&super::super::PD_CLIENT_PORT.to_string()));
+    }
+
+    #[test]
+    fn new_with_multiple_endpoints() {
+        let client = PdClient::new(vec![
+            "http://[fd01::1]:2379".into(),
+            "http://[fd01::2]:2379".into(),
+        ]);
+        assert_eq!(client.endpoints.len(), 2);
+    }
+
+    #[test]
+    fn with_timeout_overrides_default() {
+        let client = PdClient::from_mesh(&"fd01::1".parse().unwrap()).with_timeout(30);
+        assert_eq!(client.timeout_secs, 30);
+    }
+}

--- a/layers/hypervisor/src/controlplane/service.rs
+++ b/layers/hypervisor/src/controlplane/service.rs
@@ -444,29 +444,12 @@ pub fn deregister_store(mesh_ipv6: &std::net::Ipv6Addr) -> Result<(), NaukaError
         None => return Ok(()), // No PD endpoint found, nothing to deregister
     };
 
-    // Get store list and find our store ID
-    let stores_url = format!("{pd_url}/pd/api/v1/stores");
-    let output = Command::new("curl")
-        .args(["-sf", "--max-time", "5", &stores_url])
-        .output()
-        .ok();
-
-    if let Some(output) = output {
-        if output.status.success() {
-            if let Ok(body) = serde_json::from_slice::<serde_json::Value>(&output.stdout) {
-                if let Some(stores) = body["stores"].as_array() {
-                    for store in stores {
-                        let addr = store["store"]["address"].as_str().unwrap_or("");
-                        let store_id = store["store"]["id"].as_u64().unwrap_or(0);
-                        if addr == our_addr && store_id > 0 {
-                            tracing::info!(store_id, "deregistering TiKV store");
-                            let delete_url = format!("{pd_url}/pd/api/v1/store/{store_id}");
-                            let _ = Command::new("curl")
-                                .args(["-sf", "-X", "DELETE", "--max-time", "5", &delete_url])
-                                .output();
-                        }
-                    }
-                }
+    let client = super::pd_client::PdClient::new(vec![pd_url]);
+    if let Ok(stores) = client.get_stores() {
+        for store in &stores {
+            if store.address == our_addr && store.id > 0 {
+                tracing::info!(store_id = store.id, "deregistering TiKV store");
+                let _ = client.delete_store(store.id);
             }
         }
     }
@@ -491,29 +474,17 @@ pub fn recover_stale_store(mesh_ipv6: &std::net::Ipv6Addr) -> bool {
     }
 
     let our_addr = format!("[{}]:{}", mesh_ipv6, super::TIKV_PORT);
-    let pd_url = format!("http://[{}]:{}", mesh_ipv6, super::PD_CLIENT_PORT);
+    let client = super::pd_client::PdClient::from_mesh(mesh_ipv6);
 
     // Find stale stores at our address (any state)
-    let stores_url = format!("{pd_url}/pd/api/v1/stores?state=0&state=1&state=2");
-    let output = match Command::new("curl")
-        .args(["-sf", "--max-time", "5", &stores_url])
-        .output()
-    {
-        Ok(o) if o.status.success() => o,
-        _ => return false,
-    };
-    let body: serde_json::Value = match serde_json::from_slice(&output.stdout) {
-        Ok(v) => v,
-        Err(_) => return false,
-    };
-
-    let stale_ids: Vec<u64> = body["stores"]
-        .as_array()
+    let stale_ids: Vec<u64> = client
+        .get_stores_with_states(&[0, 1, 2])
+        .ok()
         .map(|stores| {
             stores
                 .iter()
-                .filter(|s| s["store"]["address"].as_str() == Some(our_addr.as_str()))
-                .filter_map(|s| s["store"]["id"].as_u64())
+                .filter(|s| s.address == our_addr)
+                .map(|s| s.id)
                 .collect()
         })
         .unwrap_or_default();
@@ -531,13 +502,10 @@ pub fn recover_stale_store(mesh_ipv6: &std::net::Ipv6Addr) -> bool {
         "removing stale TiKV stores via unsafe recovery"
     );
 
-    // Step 1: Force-delete each store to move it from Up → Offline.
+    // Step 1: Force-delete each store to move it from Up -> Offline.
     // PD's unsafe API requires stores to be in a non-Up state.
     for store_id in &stale_ids {
-        let delete_url = format!("{pd_url}/pd/api/v1/store/{store_id}?force=true");
-        let _ = Command::new("curl")
-            .args(["-sf", "-X", "DELETE", "--max-time", "5", &delete_url])
-            .output();
+        let _ = client.force_delete_store(*store_id);
     }
 
     // Brief pause for PD to process the state transitions
@@ -545,27 +513,7 @@ pub fn recover_stale_store(mesh_ipv6: &std::net::Ipv6Addr) -> bool {
 
     // Step 2: Use PD's unsafe/remove-failed-stores API — this forcefully
     // evicts dead stores and reassigns their region peers to alive stores.
-    let stores_json = stale_ids
-        .iter()
-        .map(|id| id.to_string())
-        .collect::<Vec<_>>()
-        .join(",");
-    let unsafe_url = format!("{pd_url}/pd/api/v1/admin/unsafe/remove-failed-stores");
-    let body = format!("{{\"stores\": [{stores_json}]}}");
-    let _ = Command::new("curl")
-        .args([
-            "-sf",
-            "-X",
-            "POST",
-            "-H",
-            "Content-Type: application/json",
-            "-d",
-            &body,
-            "--max-time",
-            "10",
-            &unsafe_url,
-        ])
-        .output();
+    let _ = client.unsafe_remove_failed_stores(&stale_ids);
 
     // Wait for the unsafe recovery to complete (typically 10-30s)
     let mut cleared = false;
@@ -573,39 +521,21 @@ pub fn recover_stale_store(mesh_ipv6: &std::net::Ipv6Addr) -> bool {
         std::thread::sleep(std::time::Duration::from_secs(5));
 
         // Check if all stale stores are now Tombstone or gone
-        let output = match Command::new("curl")
-            .args(["-sf", "--max-time", "5", &stores_url])
-            .output()
-        {
-            Ok(o) if o.status.success() => o,
-            _ => continue,
-        };
-        let body: serde_json::Value = match serde_json::from_slice(&output.stdout) {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-
-        let still_blocking: Vec<u64> = body["stores"]
-            .as_array()
+        let still_blocking: Vec<u64> = client
+            .get_stores_with_states(&[0, 1, 2])
+            .ok()
             .map(|stores| {
                 stores
                     .iter()
-                    .filter(|s| s["store"]["address"].as_str() == Some(our_addr.as_str()))
-                    .filter(|s| {
-                        let state = s["store"]["state_name"].as_str().unwrap_or("");
-                        state != "Tombstone"
-                    })
-                    .filter_map(|s| s["store"]["id"].as_u64())
+                    .filter(|s| s.address == our_addr && s.state_name != "Tombstone")
+                    .map(|s| s.id)
                     .collect()
             })
             .unwrap_or_default();
 
         if still_blocking.is_empty() {
             // Purge tombstones to fully free the address
-            let tombstone_url = format!("{pd_url}/pd/api/v1/stores/remove-tombstone");
-            let _ = Command::new("curl")
-                .args(["-sf", "-X", "DELETE", "--max-time", "5", &tombstone_url])
-                .output();
+            let _ = client.remove_tombstone();
             cleared = true;
             break;
         }
@@ -630,55 +560,33 @@ pub fn recover_pd_quorum(mesh_ipv6: &std::net::Ipv6Addr) -> bool {
         return false;
     }
 
-    let pd_url = format!("http://[{}]:{}", mesh_ipv6, super::PD_CLIENT_PORT);
-    let health_url = format!("{pd_url}/pd/api/v1/health");
+    let client = super::pd_client::PdClient::from_mesh(mesh_ipv6);
 
-    let output = match Command::new("curl")
-        .args(["-sf", "--max-time", "5", &health_url])
-        .output()
-    {
-        Ok(o) if o.status.success() => o,
-        _ => return false,
-    };
-    let health: serde_json::Value = match serde_json::from_slice(&output.stdout) {
-        Ok(v) => v,
+    // Check health — if PD unreachable, nothing to do
+    let health = match client.get_health() {
+        Ok(h) => h,
         Err(_) => return false,
     };
 
     // Check if any member is unhealthy
     let unhealthy: Vec<String> = health
-        .as_array()
-        .map(|members| {
-            members
-                .iter()
-                .filter(|m| m["health"].as_bool() != Some(true))
-                .filter_map(|m| m["name"].as_str().map(|s| s.to_string()))
-                .collect()
-        })
-        .unwrap_or_default();
+        .iter()
+        .filter(|m| !m.healthy)
+        .map(|m| m.name.clone())
+        .collect();
 
     if unhealthy.is_empty() {
         return false;
     }
 
     // Check if the PD members API works (needs quorum)
-    let members_url = format!("{pd_url}/pd/api/v1/members");
-    let members_ok = Command::new("curl")
-        .args(["-sf", "--max-time", "5", &members_url])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
+    let members_ok = client.get_members().is_ok();
 
     if members_ok {
         // Quorum is fine — just remove unhealthy members normally
         for name in &unhealthy {
             tracing::warn!(member = name.as_str(), "removing unhealthy PD member");
-            let delete_url = format!("{pd_url}/pd/api/v1/members/name/{name}");
-            let _ = Command::new("curl")
-                .args(["-sf", "-X", "DELETE", "--max-time", "5", &delete_url])
-                .output();
+            let _ = client.delete_member_by_name(name);
         }
         return true;
     }
@@ -736,68 +644,36 @@ pub fn recover_stale_pd_member(
     }
 
     // Find a reachable remote PD that can serve the members API (has quorum)
-    let remote_pd_url = peer_ipv6s.iter().find_map(|ip| {
-        let url = format!("http://[{}]:{}", ip, super::PD_CLIENT_PORT);
-        let members_url = format!("{url}/pd/api/v1/members");
-        let ok = Command::new("curl")
-            .args(["-sf", "--max-time", "5", &members_url])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false);
-        if ok {
-            Some(url)
+    let remote_client = peer_ipv6s.iter().find_map(|ip| {
+        let client = super::pd_client::PdClient::from_mesh(ip);
+        if client.get_members().is_ok() {
+            Some(client)
         } else {
             None
         }
     });
 
-    let remote_pd_url = match remote_pd_url {
-        Some(url) => url,
+    let remote_client = match remote_client {
+        Some(c) => c,
         None => return false, // No PD with quorum reachable (phase 1 needed first)
     };
 
     // Remove our stale member from the cluster
-    let members_url = format!("{remote_pd_url}/pd/api/v1/members");
-    let output = match Command::new("curl")
-        .args(["-sf", "--max-time", "5", &members_url])
-        .output()
-    {
-        Ok(o) if o.status.success() => o,
-        _ => return false,
-    };
-    let body: serde_json::Value = match serde_json::from_slice(&output.stdout) {
-        Ok(v) => v,
-        Err(_) => return false,
-    };
-
     let our_ip = mesh_ipv6.to_string();
     let mut found_stale = false;
-    if let Some(members) = body["members"].as_array() {
-        for member in members {
-            let peer_urls = member["peer_urls"]
-                .as_array()
-                .map(|a| {
-                    a.iter()
-                        .filter_map(|v| v.as_str())
-                        .collect::<Vec<_>>()
-                        .join(",")
-                })
-                .unwrap_or_default();
-            let member_name = member["name"].as_str().unwrap_or("");
-            let member_id = member["member_id"].as_u64().unwrap_or(0);
 
-            if (peer_urls.contains(&our_ip) || member_name == node_name) && member_id > 0 {
+    if let Ok(members) = remote_client.get_members() {
+        for member in &members {
+            let peer_urls_joined = member.peer_urls.join(",");
+            if (peer_urls_joined.contains(&our_ip) || member.name == node_name)
+                && member.member_id > 0
+            {
                 tracing::warn!(
-                    member_id,
-                    member_name,
+                    member_id = member.member_id,
+                    member_name = member.name.as_str(),
                     "removing stale PD member for recovery"
                 );
-                let delete_url = format!("{remote_pd_url}/pd/api/v1/members/name/{member_name}");
-                let _ = Command::new("curl")
-                    .args(["-sf", "-X", "DELETE", "--max-time", "5", &delete_url])
-                    .output();
+                let _ = remote_client.delete_member_by_name(&member.name);
                 found_stale = true;
             }
         }
@@ -811,6 +687,13 @@ pub fn recover_stale_pd_member(
     // Wipe PD data directory (stale etcd state prevents rejoin)
     let _ = std::fs::remove_dir_all(PD_DATA_DIR);
     let _ = std::fs::create_dir_all(PD_DATA_DIR);
+
+    // Reconstruct the remote PD URL for the systemd --join flag
+    let remote_pd_url = peer_ipv6s
+        .iter()
+        .map(|ip| format!("http://[{}]:{}", ip, super::PD_CLIENT_PORT))
+        .next()
+        .unwrap_or_default();
 
     // Rewrite systemd unit in --join mode so PD rejoins the cluster
     std::fs::write(PD_UNIT_PATH, generate_pd_unit(Some(&remote_pd_url))).ok();
@@ -843,45 +726,11 @@ pub fn deregister_pd_member(mesh_ipv6: &std::net::Ipv6Addr) -> Result<(), NaukaE
         return Ok(());
     }
 
-    let pd_url = format!("http://[{}]:{}", mesh_ipv6, super::PD_CLIENT_PORT);
-    let members_url = format!("{pd_url}/pd/api/v1/members");
+    let client = super::pd_client::PdClient::from_mesh(mesh_ipv6);
 
-    let output = match Command::new("curl")
-        .args(["-sf", "--max-time", "5", &members_url])
-        .output()
-    {
-        Ok(o) if o.status.success() => o,
-        _ => return Ok(()),
-    };
-
-    let body: serde_json::Value = match serde_json::from_slice(&output.stdout) {
-        Ok(v) => v,
-        Err(_) => return Ok(()),
-    };
-
-    // Find our member by matching peer_urls containing our mesh IPv6
-    let our_ip = mesh_ipv6.to_string();
-    if let Some(members) = body["members"].as_array() {
-        for member in members {
-            let peer_urls = member["peer_urls"]
-                .as_array()
-                .map(|a| {
-                    a.iter()
-                        .filter_map(|v| v.as_str())
-                        .collect::<Vec<_>>()
-                        .join(",")
-                })
-                .unwrap_or_default();
-            let member_id = member["member_id"].as_u64().unwrap_or(0);
-
-            if peer_urls.contains(&our_ip) && member_id > 0 {
-                tracing::info!(member_id, "deregistering PD member");
-                let delete_url = format!("{pd_url}/pd/api/v1/members/id/{member_id}");
-                let _ = Command::new("curl")
-                    .args(["-sf", "-X", "DELETE", "--max-time", "5", &delete_url])
-                    .output();
-            }
-        }
+    if let Some(member_id) = client.find_member_id(mesh_ipv6) {
+        tracing::info!(member_id, "deregistering PD member");
+        let _ = client.delete_member_by_id(member_id);
     }
 
     Ok(())
@@ -889,29 +738,8 @@ pub fn deregister_pd_member(mesh_ipv6: &std::net::Ipv6Addr) -> Result<(), NaukaE
 
 /// Count active (Up) TiKV stores via PD API.
 pub fn count_active_stores(pd_url: &str) -> usize {
-    let stores_url = format!("{pd_url}/pd/api/v1/stores");
-    let output = match Command::new("curl")
-        .args(["-sf", "--max-time", "5", &stores_url])
-        .output()
-    {
-        Ok(o) if o.status.success() => o,
-        _ => return 0,
-    };
-
-    let body: serde_json::Value = match serde_json::from_slice(&output.stdout) {
-        Ok(v) => v,
-        Err(_) => return 0,
-    };
-
-    body["stores"]
-        .as_array()
-        .map(|stores| {
-            stores
-                .iter()
-                .filter(|s| s["store"]["state_name"].as_str() == Some("Up"))
-                .count()
-        })
-        .unwrap_or(0)
+    let client = super::pd_client::PdClient::new(vec![pd_url.to_string()]);
+    client.count_active_stores()
 }
 
 /// Set max-replicas to the given target if it differs from current.
@@ -920,76 +748,32 @@ pub fn count_active_stores(pd_url: &str) -> usize {
 /// (scale up to improve durability). Target should be
 /// `min(active_stores, max_pd_members)`.
 pub fn adjust_max_replicas(pd_url: &str, target: usize) -> Result<(), NaukaError> {
-    if target == 0 {
-        return Ok(());
-    }
-
-    // Get current max-replicas
-    let config_url = format!("{pd_url}/pd/api/v1/config/replicate");
-    let output = match Command::new("curl")
-        .args(["-sf", "--max-time", "5", &config_url])
-        .output()
-    {
-        Ok(o) if o.status.success() => o,
-        _ => return Ok(()),
-    };
-
-    let body: serde_json::Value = match serde_json::from_slice(&output.stdout) {
-        Ok(v) => v,
-        Err(_) => return Ok(()),
-    };
-
-    let current = body["max-replicas"].as_u64().unwrap_or(3) as usize;
-
-    if target != current {
-        tracing::info!(current, target, "adjusting max-replicas");
-        let payload = format!("{{\"max-replicas\": {target}}}");
-        let _ = Command::new("curl")
-            .args([
-                "-sf",
-                "-X",
-                "POST",
-                "-H",
-                "Content-Type: application/json",
-                "-d",
-                &payload,
-                "--max-time",
-                "5",
-                &config_url,
-            ])
-            .output();
-    }
-
+    let client = super::pd_client::PdClient::new(vec![pd_url.to_string()]);
+    // set_max_replicas handles the 0 check and current-vs-target comparison
+    let _ = client.set_max_replicas(target);
     Ok(())
 }
 
 /// Wait for all regions to have a leader (post-rebalance).
 /// Polls every 5s, up to timeout_secs.
 pub fn wait_regions_healthy(pd_url: &str, timeout_secs: u64) -> Result<(), NaukaError> {
-    let url = format!("{pd_url}/pd/api/v1/regions");
+    let client = super::pd_client::PdClient::new(vec![pd_url.to_string()]).with_timeout(5);
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
 
     while std::time::Instant::now() < deadline {
-        if let Ok(output) = Command::new("curl")
-            .args(["-sf", "--max-time", "5", &url])
-            .output()
-        {
-            if output.status.success() {
-                if let Ok(body) = serde_json::from_slice::<serde_json::Value>(&output.stdout) {
-                    if let Some(regions) = body["regions"].as_array() {
-                        let total = regions.len();
-                        let with_leader = regions
-                            .iter()
-                            .filter(|r| r["leader"]["store_id"].as_u64().unwrap_or(0) > 0)
-                            .count();
+        if let Ok(body) = client.get_regions() {
+            if let Some(regions) = body["regions"].as_array() {
+                let total = regions.len();
+                let with_leader = regions
+                    .iter()
+                    .filter(|r| r["leader"]["store_id"].as_u64().unwrap_or(0) > 0)
+                    .count();
 
-                        if total > 0 && with_leader == total {
-                            tracing::info!(total, "all regions have leaders");
-                            return Ok(());
-                        }
-                        tracing::debug!(with_leader, total, "waiting for region leaders");
-                    }
+                if total > 0 && with_leader == total {
+                    tracing::info!(total, "all regions have leaders");
+                    return Ok(());
                 }
+                tracing::debug!(with_leader, total, "waiting for region leaders");
             }
         }
         std::thread::sleep(std::time::Duration::from_secs(5));
@@ -1036,27 +820,8 @@ pub fn find_store_id(mesh_ipv6: &std::net::Ipv6Addr) -> Option<u64> {
 /// Find the store ID for a given address via a PD endpoint.
 /// Only returns stores in Up or Disconnected state (not Tombstone).
 pub fn find_store_id_via_pd(our_addr: &str, pd_url: &str) -> Option<u64> {
-    // Query stores in all states: 0=Up, 1=Disconnected, 2=Offline
-    let stores_url = format!("{pd_url}/pd/api/v1/stores?state=0&state=1&state=2");
-    let output = Command::new("curl")
-        .args(["-sf", "--max-time", "5", &stores_url])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let body: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
-    body["stores"].as_array().and_then(|stores| {
-        stores.iter().find_map(|s| {
-            let addr = s["store"]["address"].as_str().unwrap_or("");
-            let id = s["store"]["id"].as_u64().unwrap_or(0);
-            if addr == our_addr && id > 0 {
-                Some(id)
-            } else {
-                None
-            }
-        })
-    })
+    let client = super::pd_client::PdClient::new(vec![pd_url.to_string()]);
+    client.find_store_id(our_addr)
 }
 
 /// Wait for all regions to drain off a specific store.
@@ -1067,24 +832,12 @@ pub fn wait_store_regions_drained(
     store_id: u64,
     timeout_secs: u64,
 ) -> Result<(), NaukaError> {
-    let url = format!("{pd_url}/pd/api/v1/regions/store/{store_id}");
+    let client = super::pd_client::PdClient::new(vec![pd_url.to_string()]).with_timeout(5);
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
     let mut last_count: Option<usize> = None;
 
     while std::time::Instant::now() < deadline {
-        let region_count = match Command::new("curl")
-            .args(["-sf", "--max-time", "5", &url])
-            .output()
-        {
-            Ok(output) if output.status.success() => {
-                match serde_json::from_slice::<serde_json::Value>(&output.stdout) {
-                    Ok(body) => body["regions"].as_array().map(|r| r.len()).unwrap_or(0),
-                    Err(_) => 0,
-                }
-            }
-            // Store not found (404) means already gone — success
-            _ => 0,
-        };
+        let region_count = client.count_store_regions(store_id);
 
         if region_count == 0 {
             tracing::info!(store_id, "all regions drained from store");
@@ -1114,35 +867,8 @@ pub fn wait_store_regions_drained(
 
 /// Check if a PD member with our IP exists in the cluster.
 pub fn pd_member_exists(mesh_ipv6: &std::net::Ipv6Addr, pd_url: &str) -> bool {
-    let members_url = format!("{pd_url}/pd/api/v1/members");
-    let output = match Command::new("curl")
-        .args(["-sf", "--max-time", "5", &members_url])
-        .output()
-    {
-        Ok(o) if o.status.success() => o,
-        _ => return false,
-    };
-
-    let body: serde_json::Value = match serde_json::from_slice(&output.stdout) {
-        Ok(v) => v,
-        Err(_) => return false,
-    };
-
-    let our_ip = mesh_ipv6.to_string();
-    body["members"]
-        .as_array()
-        .map(|members| {
-            members.iter().any(|m| {
-                m["peer_urls"]
-                    .as_array()
-                    .map(|urls| {
-                        urls.iter()
-                            .any(|u| u.as_str().unwrap_or("").contains(&our_ip))
-                    })
-                    .unwrap_or(false)
-            })
-        })
-        .unwrap_or(false)
+    let client = super::pd_client::PdClient::new(vec![pd_url.to_string()]);
+    client.member_exists(mesh_ipv6)
 }
 
 /// Uninstall everything — stop services, remove configs, data.
@@ -1192,21 +918,11 @@ pub fn restart() -> Result<(), NaukaError> {
 
 /// Wait for PD to be healthy (responds on client URL).
 pub fn wait_pd_ready(mesh_ipv6: &Ipv6Addr, timeout_secs: u64) -> Result<(), NaukaError> {
-    let url = format!(
-        "http://[{}]:{}/pd/api/v1/health",
-        mesh_ipv6,
-        super::PD_CLIENT_PORT
-    );
+    let client = super::pd_client::PdClient::from_mesh(mesh_ipv6).with_timeout(2);
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
 
     while std::time::Instant::now() < deadline {
-        let result = Command::new("curl")
-            .args(["-sf", "--max-time", "2", &url])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status();
-
-        if result.map(|s| s.success()).unwrap_or(false) {
+        if client.ping() {
             return Ok(());
         }
         std::thread::sleep(std::time::Duration::from_secs(1));
@@ -1217,25 +933,12 @@ pub fn wait_pd_ready(mesh_ipv6: &Ipv6Addr, timeout_secs: u64) -> Result<(), Nauk
 
 /// Wait for TiKV to register with PD (at least 1 store).
 pub fn wait_tikv_ready(mesh_ipv6: &Ipv6Addr, timeout_secs: u64) -> Result<(), NaukaError> {
-    let url = format!(
-        "http://[{}]:{}/pd/api/v1/stores",
-        mesh_ipv6,
-        super::PD_CLIENT_PORT
-    );
+    let client = super::pd_client::PdClient::from_mesh(mesh_ipv6).with_timeout(2);
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
 
     while std::time::Instant::now() < deadline {
-        if let Ok(output) = Command::new("curl")
-            .args(["-sf", "--max-time", "2", &url])
-            .output()
-        {
-            if output.status.success() {
-                let body = String::from_utf8_lossy(&output.stdout);
-                // PD returns {"count": N, "stores": [...]}
-                if body.contains("\"count\"") && !body.contains("\"count\":0") {
-                    return Ok(());
-                }
-            }
+        if client.count_active_stores() > 0 {
+            return Ok(());
         }
         std::thread::sleep(std::time::Duration::from_secs(1));
     }
@@ -1245,34 +948,16 @@ pub fn wait_tikv_ready(mesh_ipv6: &Ipv6Addr, timeout_secs: u64) -> Result<(), Na
 
 /// Get cluster status from PD API.
 pub fn cluster_status(mesh_ipv6: &Ipv6Addr) -> Result<ClusterStatus, NaukaError> {
-    let pd_url = format!("http://[{}]:{}", mesh_ipv6, super::PD_CLIENT_PORT);
+    let client = super::pd_client::PdClient::from_mesh(mesh_ipv6);
 
-    let members = pd_api_get(&pd_url, "/pd/api/v1/members");
-    let stores = pd_api_get(&pd_url, "/pd/api/v1/stores");
-
-    let member_count = members
-        .as_ref()
-        .ok()
-        .and_then(|v| v["members"].as_array())
-        .map(|a| a.len())
-        .unwrap_or(0);
-
-    let store_count = stores
-        .as_ref()
-        .ok()
-        .and_then(|v| v["count"].as_u64())
-        .unwrap_or(0) as usize;
-
-    let leader = members
-        .as_ref()
-        .ok()
-        .and_then(|v| v["leader"]["name"].as_str())
-        .map(|s| s.to_string());
+    let members = client.get_members().unwrap_or_default();
+    let store_count = client.count_active_stores();
+    let leader = members.iter().find(|m| m.is_leader).map(|m| m.name.clone());
 
     Ok(ClusterStatus {
         pd_active: pd_is_active(),
         tikv_active: tikv_is_active(),
-        pd_members: member_count,
+        pd_members: members.len(),
         tikv_stores: store_count,
         leader,
     })
@@ -1286,22 +971,6 @@ pub struct ClusterStatus {
     pub pd_members: usize,
     pub tikv_stores: usize,
     pub leader: Option<String>,
-}
-
-/// Query PD HTTP API.
-fn pd_api_get(pd_url: &str, path: &str) -> Result<serde_json::Value, NaukaError> {
-    let url = format!("{pd_url}{path}");
-    let output = Command::new("curl")
-        .args(["-sf", "--max-time", "5", &url])
-        .output()
-        .map_err(|e| NaukaError::internal(format!("curl failed: {e}")))?;
-
-    if !output.status.success() {
-        return Err(NaukaError::internal("PD API request failed"));
-    }
-
-    serde_json::from_slice(&output.stdout)
-        .map_err(|e| NaukaError::internal(format!("PD API parse failed: {e}")))
 }
 
 fn run_systemctl(args: &[&str]) -> Result<(), NaukaError> {

--- a/layers/hypervisor/src/doctor.rs
+++ b/layers/hypervisor/src/doctor.rs
@@ -299,95 +299,77 @@ fn check_controlplane(report: &mut DoctorReport, mesh_ipv6: Option<&Ipv6Addr>) {
 
     // PD health + leader
     if let Some(ip) = mesh_ipv6 {
-        let pd_url = format!("http://[{}]:{}", ip, controlplane::PD_CLIENT_PORT);
-        let health_url = format!("{pd_url}/pd/api/v1/health");
+        let client = controlplane::pd_client::PdClient::from_mesh(ip);
 
-        if let Some(body) = curl_json(&health_url) {
-            if let Some(members) = body.as_array() {
-                let healthy: Vec<_> = members
-                    .iter()
-                    .filter(|m| m["health"].as_bool().unwrap_or(false))
-                    .collect();
-                let total = members.len();
-                if healthy.len() == total {
-                    checks.push(ok("pd health", &format!("{total}/{total} healthy")));
-                } else {
-                    checks.push(warn(
-                        "pd health",
-                        &format!("{}/{total} healthy", healthy.len()),
-                    ));
-                }
+        if let Ok(health) = client.get_health() {
+            let total = health.len();
+            let healthy_count = health.iter().filter(|h| h.healthy).count();
+            if healthy_count == total {
+                checks.push(ok("pd health", &format!("{total}/{total} healthy")));
+            } else {
+                checks.push(warn(
+                    "pd health",
+                    &format!("{healthy_count}/{total} healthy"),
+                ));
+            }
 
-                // Leader
-                let leader = members
-                    .iter()
-                    .find(|m| m["health"].as_bool().unwrap_or(false))
-                    .and_then(|m| m["name"].as_str());
-                if let Some(name) = leader {
-                    checks.push(ok("pd leader", name));
-                } else {
-                    checks.push(fail("pd leader", "no leader elected"));
-                }
+            // Leader
+            let leader = health.iter().find(|h| h.healthy).map(|h| h.name.as_str());
+            if let Some(name) = leader {
+                checks.push(ok("pd leader", name));
+            } else {
+                checks.push(fail("pd leader", "no leader elected"));
             }
         } else {
             checks.push(warn("pd health", "could not reach PD API"));
         }
 
         // PD quorum health — are all members healthy?
-        let members_url = format!("{pd_url}/pd/api/v1/members");
-        if let Some(body) = curl_json(&members_url) {
-            if let Some(members) = body["members"].as_array() {
-                let total = members.len();
-                if total < 3 {
-                    checks.push(warn(
-                        "pd quorum",
-                        &format!("only {total} member(s) — need 3 for fault tolerance"),
-                    ));
-                } else {
-                    checks.push(ok("pd quorum", &format!("{total} members — quorum intact")));
-                }
+        if let Ok(members) = client.get_members() {
+            let total = members.len();
+            if total < 3 {
+                checks.push(warn(
+                    "pd quorum",
+                    &format!("only {total} member(s) — need 3 for fault tolerance"),
+                ));
+            } else {
+                checks.push(ok("pd quorum", &format!("{total} members — quorum intact")));
             }
         }
 
         // TiKV store registration + health
-        let stores_url = format!("{pd_url}/pd/api/v1/stores");
-        if let Some(body) = curl_json(&stores_url) {
-            let count = body["count"].as_u64().unwrap_or(0);
-            checks.push(ok("tikv stores", &format!("{count} registered")));
+        // Use get_stores_with_states to see all stores including offline/tombstoned
+        if let Ok(stores) = client.get_stores_with_states(&[0, 1, 2, 3]) {
+            checks.push(ok("tikv stores", &format!("{} registered", stores.len())));
 
-            // Check for tombstoned or offline stores
-            if let Some(stores) = body["stores"].as_array() {
-                let mut tombstoned = 0u64;
-                let mut offline = 0u64;
-                let mut down = 0u64;
-                for store in stores {
-                    if let Some(state) = store["store"]["state_name"].as_str() {
-                        match state {
-                            "Tombstone" => tombstoned += 1,
-                            "Offline" => offline += 1,
-                            "Down" => down += 1,
-                            _ => {}
-                        }
-                    }
+            let mut tombstoned = 0u64;
+            let mut offline = 0u64;
+            let mut down = 0u64;
+            for store in &stores {
+                match store.state_name.as_str() {
+                    "Tombstone" => tombstoned += 1,
+                    "Offline" => offline += 1,
+                    "Down" => down += 1,
+                    _ => {}
                 }
-                if tombstoned > 0 {
-                    checks.push(fail(
-                        "tikv tombstoned",
-                        &format!("{tombstoned} store(s) tombstoned — data may be under-replicated"),
-                    ));
-                }
-                if down > 0 {
-                    checks.push(fail("tikv down", &format!("{down} store(s) down")));
-                }
-                if offline > 0 {
-                    checks.push(warn(
-                        "tikv offline",
-                        &format!("{offline} store(s) offline — regions migrating"),
-                    ));
-                }
-                if tombstoned == 0 && offline == 0 && down == 0 {
-                    checks.push(ok("tikv store health", "all stores Up"));
-                }
+            }
+            if tombstoned > 0 {
+                checks.push(fail(
+                    "tikv tombstoned",
+                    &format!("{tombstoned} store(s) tombstoned — data may be under-replicated"),
+                ));
+            }
+            if down > 0 {
+                checks.push(fail("tikv down", &format!("{down} store(s) down")));
+            }
+            if offline > 0 {
+                checks.push(warn(
+                    "tikv offline",
+                    &format!("{offline} store(s) offline — regions migrating"),
+                ));
+            }
+            if tombstoned == 0 && offline == 0 && down == 0 {
+                checks.push(ok("tikv store health", "all stores Up"));
             }
         }
     }
@@ -503,18 +485,6 @@ fn ping6(addr: &Ipv6Addr) -> bool {
         .status()
         .map(|s| s.success())
         .unwrap_or(false)
-}
-
-fn curl_json(url: &str) -> Option<serde_json::Value> {
-    let output = Command::new("curl")
-        .args(["-sf", "--max-time", "5", url])
-        .output()
-        .ok()?;
-    if output.status.success() {
-        serde_json::from_slice(&output.stdout).ok()
-    } else {
-        None
-    }
 }
 
 fn disk_free_mb(path: &str) -> Option<u64> {

--- a/layers/hypervisor/src/handlers.rs
+++ b/layers/hypervisor/src/handlers.rs
@@ -1017,25 +1017,10 @@ async fn handle_cp_status() -> anyhow::Result<OperationResponse> {
         })?;
 
     let mesh_ipv6 = state.hypervisor.mesh_ipv6;
-    let pd_url = format!("http://[{}]:{}", mesh_ipv6, controlplane::PD_CLIENT_PORT);
+    let client = controlplane::pd_client::PdClient::from_mesh(&mesh_ipv6);
 
     // --- PD Members ---
-    let members_json = cp_api_get(&pd_url, "/pd/api/v1/members");
-    let health_json = cp_api_get(&pd_url, "/pd/api/v1/health");
-
-    // Build a set of healthy member IDs from the health endpoint
-    let healthy_ids: std::collections::HashSet<u64> = health_json
-        .as_ref()
-        .ok()
-        .and_then(|v| v.as_array())
-        .map(|arr| arr.iter().filter_map(|h| h["member_id"].as_u64()).collect())
-        .unwrap_or_default();
-
-    let leader_id = members_json
-        .as_ref()
-        .ok()
-        .and_then(|v| v["leader"]["member_id"].as_u64())
-        .unwrap_or(0);
+    let members_result = client.get_members();
 
     println!("\n  PD Members");
     println!(
@@ -1044,93 +1029,71 @@ async fn handle_cp_status() -> anyhow::Result<OperationResponse> {
     );
     println!("  {}", "-".repeat(78));
 
-    if let Ok(ref val) = members_json {
-        if let Some(members) = val["members"].as_array() {
-            for m in members {
-                let name = m["name"].as_str().unwrap_or("-");
-                let client_urls = m["client_urls"]
-                    .as_array()
-                    .and_then(|a| a.first())
-                    .and_then(|u| u.as_str())
-                    .unwrap_or("-");
-                let mid = m["member_id"].as_u64().unwrap_or(0);
-                let health = if healthy_ids.contains(&mid) {
-                    "healthy"
-                } else {
-                    "unhealthy"
-                };
-                let role = if mid == leader_id {
-                    "leader"
-                } else {
-                    "follower"
-                };
-                println!("  {:<16} {:<42} {:<10} {}", name, client_urls, health, role);
-            }
+    if let Ok(ref members) = members_result {
+        for m in members {
+            let client_url = m.client_urls.first().map(|s| s.as_str()).unwrap_or("-");
+            let health = if m.is_healthy { "healthy" } else { "unhealthy" };
+            let role = if m.is_leader { "leader" } else { "follower" };
+            let name = if m.name.is_empty() { "-" } else { &m.name };
+            println!("  {:<16} {:<42} {:<10} {}", name, client_url, health, role);
         }
     } else {
         println!("  (PD API unreachable)");
     }
 
     // --- TiKV Stores ---
-    let stores_json = cp_api_get(&pd_url, "/pd/api/v1/stores");
+    let stores_result = client.get_stores();
 
     println!("\n  TiKV Stores");
     println!("  {:<8} {:<42} {:<12} CAPACITY", "ID", "ADDRESS", "STATE");
     println!("  {}", "-".repeat(72));
 
-    if let Ok(ref val) = stores_json {
-        if let Some(stores) = val["stores"].as_array() {
-            for s in stores {
-                let id = s["store"]["id"].as_u64().unwrap_or(0);
-                let addr = s["store"]["address"].as_str().unwrap_or("-");
-                let state_name = s["store"]["state_name"].as_str().unwrap_or("-");
-                let capacity = s["status"]["capacity"].as_str().unwrap_or("-");
-                println!("  {:<8} {:<42} {:<12} {}", id, addr, state_name, capacity);
-            }
+    if let Ok(ref stores) = stores_result {
+        for s in stores {
+            let addr = if s.address.is_empty() {
+                "-"
+            } else {
+                &s.address
+            };
+            let state_name = if s.state_name.is_empty() {
+                "-"
+            } else {
+                &s.state_name
+            };
+            let capacity = if s.capacity.is_empty() {
+                "-"
+            } else {
+                &s.capacity
+            };
+            println!("  {:<8} {:<42} {:<12} {}", s.id, addr, state_name, capacity);
         }
     } else {
         println!("  (PD API unreachable)");
     }
 
     // --- Region Stats ---
-    let regions_json = cp_api_get(&pd_url, "/pd/api/v1/stats/region");
+    let stats_result = client.get_region_stats();
 
     println!("\n  Region Stats");
     println!("  {}", "-".repeat(40));
 
-    if let Ok(ref val) = regions_json {
-        let count = val["count"].as_u64().unwrap_or(0);
-        let empty = val["empty_count"].as_u64().unwrap_or(0);
-        let miss_peer = val["miss_peer_region_count"].as_u64().unwrap_or(0);
-        let extra_peer = val["extra_peer_region_count"].as_u64().unwrap_or(0);
-        let healthy = count.saturating_sub(miss_peer).saturating_sub(extra_peer);
+    if let Ok(ref stats) = stats_result {
+        let healthy = stats
+            .count
+            .saturating_sub(stats.miss_peer)
+            .saturating_sub(stats.extra_peer);
 
-        println!("  Total:      {count}");
+        println!("  Total:      {}", stats.count);
         println!("  Healthy:    {healthy}");
-        println!("  Empty:      {empty}");
-        println!("  Miss-peer:  {miss_peer}");
-        println!("  Extra-peer: {extra_peer}");
+        println!("  Empty:      {}", stats.empty_count);
+        println!("  Miss-peer:  {}", stats.miss_peer);
+        println!("  Extra-peer: {}", stats.extra_peer);
     } else {
         println!("  (PD API unreachable)");
     }
 
     println!();
     Ok(OperationResponse::None)
-}
-
-/// Query PD HTTP API (used by cp-status handler).
-fn cp_api_get(pd_url: &str, path: &str) -> Result<serde_json::Value, anyhow::Error> {
-    let url = format!("{pd_url}{path}");
-    let output = std::process::Command::new("curl")
-        .args(["-sf", "--max-time", "5", &url])
-        .output()
-        .map_err(|e| anyhow::anyhow!("curl failed: {e}"))?;
-
-    if !output.status.success() {
-        anyhow::bail!("PD API request failed: {path}");
-    }
-
-    serde_json::from_slice(&output.stdout).map_err(|e| anyhow::anyhow!("PD API parse failed: {e}"))
 }
 
 async fn handle_upgrade_check() -> anyhow::Result<OperationResponse> {


### PR DESCRIPTION
## Summary

- Introduces `layers/hypervisor/src/controlplane/pd_client.rs` with a typed `PdClient` struct providing: `get_health()`, `get_members()`, `get_stores()`, `get_region_stats()`, `delete_member_by_id/name()`, `delete_store()`, `set_max_replicas()`, `find_store_id()`, `member_exists()`, endpoint failover, and 3-attempt retry with 1s/2s/4s exponential backoff.
- Replaces **every** `Command::new("curl")` PD API call across 6 files: `service.rs` (15 calls), `ops.rs` (6 calls), `handlers.rs` (3 calls), `doctor.rs` (3 calls), `forge/reconciler/pd.rs` (2 calls), `forge/reconciler/store.rs` (2 calls).
- Net: +754 / -736 lines. Backup.rs S3 curl calls intentionally untouched.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` -- clean
- [x] `cargo test -- --skip disk_free_check` -- 595 tests pass
- [x] `cargo build --release --target x86_64-unknown-linux-musl` -- cross-compile succeeds
- [x] Deployed to 3 Hetzner servers (49.12.233.86, 178.104.132.55, 178.104.141.22)
- [x] `nauka hypervisor cp-status` -- PD members, TiKV stores, region stats all correct
- [x] `nauka hypervisor doctor` -- 17/17 checks pass (2 pre-existing warnings)
- [x] `nauka hypervisor status` -- works correctly
- [x] Forge restart -- logs clean, store reconciler runs without errors

Closes #157