### PR TITLE
test: add unit tests for VPC reconciler

### DIFF
--- a/layers/forge/src/reconciler/vpc.rs
+++ b/layers/forge/src/reconciler/vpc.rs
@@ -4,6 +4,73 @@ use nauka_network::vpc::provision;
 
 use crate::types::{ReconcileContext, ReconcileResult};
 
+// ═══════════════════════════════════════════════════
+// Pure helper functions (no I/O, fully testable)
+// ═══════════════════════════════════════════════════
+
+/// Derive the VXLAN interface name from a bridge name by swapping the prefix.
+///
+/// Bridge names use `nkb-{hash}`, VXLAN names use `nkx-{hash}`.
+fn vxlan_name_from_bridge(bridge: &str) -> String {
+    bridge.replace("nkb-", "nkx-")
+}
+
+/// Identify orphaned bridges — bridges that exist on the system but are not
+/// needed by any VM currently assigned to this node.
+///
+/// Returns the list of bridge names that should be removed.
+fn find_orphaned_bridges<'a>(
+    actual_bridges: &'a [String],
+    needed_bridge_names: &[String],
+) -> Vec<&'a String> {
+    actual_bridges
+        .iter()
+        .filter(|b| !needed_bridge_names.contains(b))
+        .collect()
+}
+
+/// Build nftables FORWARD rules for a list of peered bridge pairs.
+///
+/// Returns a Vec of rule strings in nft format (e.g. "iifname nkb-x oifname nkb-y accept").
+/// Each pair generates two rules (bidirectional).
+fn build_forward_rules(peered_pairs: &[(String, String)]) -> Vec<String> {
+    let mut rules = Vec::new();
+    for (br_a, br_b) in peered_pairs {
+        rules.push(format!("iifname {br_a} oifname {br_b} accept"));
+        rules.push(format!("iifname {br_b} oifname {br_a} accept"));
+    }
+    rules
+}
+
+/// Check whether an ip-rule entry already exists in `ip rule show` output.
+///
+/// Returns true if a rule matching both `direction bridge` and `lookup table`
+/// is found in the output.
+fn ip_rule_exists(rule_output: &str, direction: &str, bridge: &str, table: &str) -> bool {
+    rule_output.contains(&format!("{direction} {bridge}"))
+        && rule_output.contains(&format!("lookup {table}"))
+}
+
+/// Parse a PID from file contents (trimmed string to u32).
+///
+/// Returns `None` if the string is empty or not a valid u32.
+fn parse_container_pid(contents: &str) -> Option<u32> {
+    contents.trim().parse::<u32>().ok()
+}
+
+/// Format a gateway IP as a CIDR address with /24 prefix length.
+fn gateway_cidr(gateway_ip: &str) -> String {
+    format!("{gateway_ip}/24")
+}
+
+/// Deduplicate a peered bridge pair — returns true if the pair (in either
+/// direction) already exists in the list.
+fn peering_pair_exists(pairs: &[(String, String)], br_a: &str, br_b: &str) -> bool {
+    pairs
+        .iter()
+        .any(|(a, b)| (a == br_a && b == br_b) || (a == br_b && b == br_a))
+}
+
 pub struct VpcReconciler;
 
 #[async_trait::async_trait]
@@ -77,18 +144,16 @@ impl super::Reconciler for VpcReconciler {
             .iter()
             .map(|(id, _)| provision::bridge_name(id))
             .collect();
-        for bridge in &actual_bridges {
-            if !needed_bridge_names.contains(bridge) {
-                tracing::info!(bridge, "removing orphaned bridge");
-                let vxlan = bridge.replace("nkb-", "nkx-");
-                let _ = std::process::Command::new("ip")
-                    .args(["link", "del", &vxlan])
-                    .status();
-                let _ = std::process::Command::new("ip")
-                    .args(["link", "del", bridge])
-                    .status();
-                result.deleted += 1;
-            }
+        for bridge in find_orphaned_bridges(&actual_bridges, &needed_bridge_names) {
+            tracing::info!(bridge, "removing orphaned bridge");
+            let vxlan = vxlan_name_from_bridge(bridge);
+            let _ = std::process::Command::new("ip")
+                .args(["link", "del", &vxlan])
+                .status();
+            let _ = std::process::Command::new("ip")
+                .args(["link", "del", bridge])
+                .status();
+            result.deleted += 1;
         }
 
         // 5b. Ensure nftables host isolation rules for all active bridges
@@ -171,7 +236,7 @@ impl super::Reconciler for VpcReconciler {
                     .get(local_vm.subnet_id.as_str(), None, None)
                     .await
                 {
-                    let gw_cidr = format!("{}/24", subnet.gateway);
+                    let gw_cidr = gateway_cidr(&subnet.gateway);
                     let table = vni.to_string();
 
                     // Set gateway IP on the bridge
@@ -233,10 +298,7 @@ impl super::Reconciler for VpcReconciler {
                         && crate::observer::network::bridge_exists(&br_b)
                     {
                         // Deduplicate — peering is seen from both VPCs
-                        if !peered_bridge_pairs
-                            .iter()
-                            .any(|(a, b)| (a == &br_a && b == &br_b) || (a == &br_b && b == &br_a))
-                        {
+                        if !peering_pair_exists(&peered_bridge_pairs, &br_a, &br_b) {
                             peered_bridge_pairs.push((br_a.clone(), br_b.clone()));
                         }
                         let _ = provision::ensure_peering_routes(
@@ -330,16 +392,9 @@ fn ensure_forward_rules(peered_pairs: &[(String, String)]) {
         .status();
 
     // Whitelist each peered bridge pair (bidirectional)
-    for (br_a, br_b) in peered_pairs {
-        let rule_ab = format!("iifname {br_a} oifname {br_b} accept");
-        let rule_ba = format!("iifname {br_b} oifname {br_a} accept");
+    for rule in build_forward_rules(peered_pairs) {
         let _ = Command::new("nft")
-            .args(["add", "rule", "inet", "nauka", "forward", &rule_ab])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status();
-        let _ = Command::new("nft")
-            .args(["add", "rule", "inet", "nauka", "forward", &rule_ba])
+            .args(["add", "rule", "inet", "nauka", "forward", &rule])
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status();
@@ -358,8 +413,7 @@ fn ensure_ip_rule(direction: &str, bridge: &str, table: &str) {
         .as_ref()
         .map(|o| {
             let stdout = String::from_utf8_lossy(&o.stdout);
-            stdout.contains(&format!("{direction} {bridge}"))
-                && stdout.contains(&format!("lookup {table}"))
+            ip_rule_exists(&stdout, direction, bridge, table)
         })
         .unwrap_or(false);
 
@@ -380,8 +434,15 @@ fn get_container_pid(vm_id: &str) -> Option<u32> {
         .join("pid");
     std::fs::read_to_string(pid_path)
         .ok()
-        .and_then(|s| s.trim().parse::<u32>().ok())
-        .filter(|&pid| unsafe { libc::kill(pid as i32, 0) == 0 })
+        .and_then(|s| parse_container_pid(&s))
+        .filter(|&pid| {
+            // SAFETY: `kill(pid, 0)` sends no signal — it only checks whether the
+            // process exists and is reachable. The pid comes from a file we wrote
+            // during VM creation, so it is always a valid positive integer. The
+            // worst case (stale PID file pointing at a recycled PID) simply returns
+            // 0 (process exists) or -1 (no such process), both harmless.
+            unsafe { libc::kill(pid as i32, 0) == 0 }
+        })
 }
 
 /// Add a static ARP entry inside a container's network namespace.
@@ -432,4 +493,174 @@ fn resolve_hypervisor_ipv6(
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── vxlan_name_from_bridge ──────────────────────────────────────
+
+    #[test]
+    fn vxlan_name_from_bridge_swaps_prefix() {
+        assert_eq!(vxlan_name_from_bridge("nkb-a1b2c3"), "nkx-a1b2c3");
+    }
+
+    #[test]
+    fn vxlan_name_from_bridge_no_match_unchanged() {
+        // If the bridge name doesn't contain "nkb-", it's returned as-is
+        assert_eq!(vxlan_name_from_bridge("br0"), "br0");
+    }
+
+    // ── find_orphaned_bridges ───────────────────────────────────────
+
+    #[test]
+    fn orphaned_bridges_detected() {
+        let actual = vec![
+            "nkb-aaa111".to_string(),
+            "nkb-bbb222".to_string(),
+            "nkb-ccc333".to_string(),
+        ];
+        let needed = vec!["nkb-aaa111".to_string(), "nkb-ccc333".to_string()];
+
+        let orphaned = find_orphaned_bridges(&actual, &needed);
+        assert_eq!(orphaned.len(), 1);
+        assert_eq!(orphaned[0], "nkb-bbb222");
+    }
+
+    #[test]
+    fn no_orphaned_bridges_when_all_needed() {
+        let actual = vec!["nkb-aaa111".to_string(), "nkb-bbb222".to_string()];
+        let needed = vec!["nkb-aaa111".to_string(), "nkb-bbb222".to_string()];
+
+        let orphaned = find_orphaned_bridges(&actual, &needed);
+        assert!(orphaned.is_empty());
+    }
+
+    #[test]
+    fn all_bridges_orphaned_when_no_vpcs_needed() {
+        let actual = vec!["nkb-aaa111".to_string(), "nkb-bbb222".to_string()];
+        let needed: Vec<String> = vec![];
+
+        let orphaned = find_orphaned_bridges(&actual, &needed);
+        assert_eq!(orphaned.len(), 2);
+    }
+
+    #[test]
+    fn no_orphaned_bridges_when_none_exist() {
+        let actual: Vec<String> = vec![];
+        let needed = vec!["nkb-aaa111".to_string()];
+
+        let orphaned = find_orphaned_bridges(&actual, &needed);
+        assert!(orphaned.is_empty());
+    }
+
+    // ── build_forward_rules ─────────────────────────────────────────
+
+    #[test]
+    fn forward_rules_bidirectional() {
+        let pairs = vec![("nkb-aaa".to_string(), "nkb-bbb".to_string())];
+        let rules = build_forward_rules(&pairs);
+
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0], "iifname nkb-aaa oifname nkb-bbb accept");
+        assert_eq!(rules[1], "iifname nkb-bbb oifname nkb-aaa accept");
+    }
+
+    #[test]
+    fn forward_rules_multiple_pairs() {
+        let pairs = vec![
+            ("nkb-aaa".to_string(), "nkb-bbb".to_string()),
+            ("nkb-ccc".to_string(), "nkb-ddd".to_string()),
+        ];
+        let rules = build_forward_rules(&pairs);
+        assert_eq!(rules.len(), 4);
+    }
+
+    #[test]
+    fn forward_rules_empty_pairs() {
+        let rules = build_forward_rules(&[]);
+        assert!(rules.is_empty());
+    }
+
+    // ── ip_rule_exists ──────────────────────────────────────────────
+
+    #[test]
+    fn ip_rule_found_in_output() {
+        let output = "32765:\tfrom all iif nkb-a1b2c3 lookup 100\n\
+                       32766:\tfrom all lookup main\n";
+        assert!(ip_rule_exists(output, "iif", "nkb-a1b2c3", "100"));
+    }
+
+    #[test]
+    fn ip_rule_not_found_wrong_table() {
+        let output = "32765:\tfrom all iif nkb-a1b2c3 lookup 200\n";
+        assert!(!ip_rule_exists(output, "iif", "nkb-a1b2c3", "100"));
+    }
+
+    #[test]
+    fn ip_rule_not_found_wrong_bridge() {
+        let output = "32765:\tfrom all iif nkb-ffffff lookup 100\n";
+        assert!(!ip_rule_exists(output, "iif", "nkb-a1b2c3", "100"));
+    }
+
+    #[test]
+    fn ip_rule_not_found_empty_output() {
+        assert!(!ip_rule_exists("", "iif", "nkb-a1b2c3", "100"));
+    }
+
+    // ── parse_container_pid ─────────────────────────────────────────
+
+    #[test]
+    fn parse_pid_valid() {
+        assert_eq!(parse_container_pid("12345\n"), Some(12345));
+    }
+
+    #[test]
+    fn parse_pid_with_whitespace() {
+        assert_eq!(parse_container_pid("  42  \n"), Some(42));
+    }
+
+    #[test]
+    fn parse_pid_invalid_string() {
+        assert_eq!(parse_container_pid("not-a-pid"), None);
+    }
+
+    #[test]
+    fn parse_pid_empty() {
+        assert_eq!(parse_container_pid(""), None);
+    }
+
+    // ── gateway_cidr ────────────────────────────────────────────────
+
+    #[test]
+    fn gateway_cidr_format() {
+        assert_eq!(gateway_cidr("10.0.1.1"), "10.0.1.1/24");
+    }
+
+    // ── peering_pair_exists ─────────────────────────────────────────
+
+    #[test]
+    fn peering_pair_found_same_order() {
+        let pairs = vec![("nkb-aaa".to_string(), "nkb-bbb".to_string())];
+        assert!(peering_pair_exists(&pairs, "nkb-aaa", "nkb-bbb"));
+    }
+
+    #[test]
+    fn peering_pair_found_reverse_order() {
+        let pairs = vec![("nkb-aaa".to_string(), "nkb-bbb".to_string())];
+        assert!(peering_pair_exists(&pairs, "nkb-bbb", "nkb-aaa"));
+    }
+
+    #[test]
+    fn peering_pair_not_found() {
+        let pairs = vec![("nkb-aaa".to_string(), "nkb-bbb".to_string())];
+        assert!(!peering_pair_exists(&pairs, "nkb-aaa", "nkb-ccc"));
+    }
+
+    #[test]
+    fn peering_pair_empty_list() {
+        let pairs: Vec<(String, String)> = vec![];
+        assert!(!peering_pair_exists(&pairs, "nkb-aaa", "nkb-bbb"));
+    }
 }


### PR DESCRIPTION
## Summary
- Extract 7 pure functions from the VPC reconciler (`vxlan_name_from_bridge`, `find_orphaned_bridges`, `build_forward_rules`, `ip_rule_exists`, `parse_container_pid`, `gateway_cidr`, `peering_pair_exists`) and rewire the reconciler to call them
- Add 22 unit tests covering bridge naming, orphan detection, nft forward rule generation, ip-rule output parsing, container PID parsing, gateway CIDR formatting, and peering pair deduplication
- Add `// SAFETY:` comment on the `libc::kill` call explaining why it is safe

Partial #163

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test -- --skip disk_free_check` passes (22 new tests in `reconciler::vpc::tests`)
- [x] `cargo build --release --target x86_64-unknown-linux-musl` cross-compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)