### PR TITLE
test: add unit tests for VM reconciler

### DIFF
--- a/layers/forge/src/reconciler/vm.rs
+++ b/layers/forge/src/reconciler/vm.rs
@@ -9,6 +9,61 @@ use nauka_network::vpc::provision as vpc_provision;
 
 use crate::types::{ReconcileContext, ReconcileResult};
 
+/// Pure logic: returns true if this VM is assigned to one of the local node IDs.
+fn is_local_vm(hypervisor_id: Option<&str>, node_ids: &[String]) -> bool {
+    hypervisor_id
+        .map(|hid| node_ids.iter().any(|nid| nid == hid))
+        .unwrap_or(false)
+}
+
+/// Pure logic: returns true if this VM's state means it should have a running
+/// process on the node (i.e., it is either `Pending` or `Running`).
+fn should_vm_exist(state: &VmState) -> bool {
+    matches!(state, VmState::Pending | VmState::Running)
+}
+
+/// Pure logic: given the current VM state and whether the process is actually
+/// running, returns the action the reconciler should take.
+#[derive(Debug, PartialEq)]
+pub(crate) enum VmAction {
+    /// Process is running but state is `Pending` — correct to `Running`,
+    /// then run health checks.
+    CorrectStateAndHealthCheck,
+    /// Process is running and state is already `Running` — just health check.
+    HealthCheck,
+    /// Process is not running — start it.
+    Start,
+}
+
+/// Pure logic: decide what action to take for a VM that should exist.
+pub(crate) fn decide_vm_action(state: &VmState, process_running: bool) -> VmAction {
+    if process_running {
+        if *state == VmState::Pending {
+            VmAction::CorrectStateAndHealthCheck
+        } else {
+            VmAction::HealthCheck
+        }
+    } else {
+        VmAction::Start
+    }
+}
+
+/// Pure logic: returns the IDs of processes that are orphaned — they are running
+/// but no longer have a corresponding VM that should exist on this node.
+fn find_orphaned_processes(actual_processes: &[String], needed_ids: &[&str]) -> Vec<String> {
+    actual_processes
+        .iter()
+        .filter(|vm_id| !needed_ids.contains(&vm_id.as_str()))
+        .cloned()
+        .collect()
+}
+
+/// Pure logic: returns true if the expected network interface name is present
+/// in the list of actual interfaces.
+fn is_interface_present(expected: &str, actual: &[String]) -> bool {
+    actual.iter().any(|v| v == expected)
+}
+
 pub struct VmReconciler;
 
 impl VmReconciler {
@@ -37,12 +92,7 @@ impl super::Reconciler for VmReconciler {
         let all_vms = vm_store.list(None, None, None).await?;
         let local_vms: Vec<_> = all_vms
             .iter()
-            .filter(|vm| {
-                vm.hypervisor_id
-                    .as_ref()
-                    .map(|hid| ctx.node_ids.iter().any(|nid| nid == hid))
-                    .unwrap_or(false)
-            })
+            .filter(|vm| is_local_vm(vm.hypervisor_id.as_deref(), &ctx.node_ids))
             .collect();
 
         // VMs that should be running (pending = needs starting, running = should be alive).
@@ -50,7 +100,7 @@ impl super::Reconciler for VmReconciler {
         let org_store = nauka_org::store::OrgStore::new(ctx.db.clone());
         let mut should_exist: Vec<_> = Vec::new();
         for vm in &local_vms {
-            if vm.state != VmState::Pending && vm.state != VmState::Running {
+            if !should_vm_exist(&vm.state) {
                 continue;
             }
             if org_store.get(vm.org_id.as_str()).await?.is_none() {
@@ -79,7 +129,7 @@ impl super::Reconciler for VmReconciler {
             if use_veth {
                 let expected = provision::veth_host_name(&vm.meta.id);
                 let actual = provision::list_veths();
-                let veth_was_missing = !actual.iter().any(|v| v == &expected);
+                let veth_was_missing = !is_interface_present(&expected, &actual);
                 if veth_was_missing {
                     if let Err(e) = provision::ensure_veth(&vm.meta.id, &bridge) {
                         tracing::error!(vm_id = vm.meta.id.as_str(), error = %e, "failed to create veth");
@@ -136,7 +186,7 @@ impl super::Reconciler for VmReconciler {
             } else {
                 let expected = provision::tap_name(&vm.meta.id);
                 let actual = provision::list_taps();
-                if !actual.iter().any(|t| t == &expected) {
+                if !is_interface_present(&expected, &actual) {
                     if let Err(e) = provision::ensure_tap(&vm.meta.id, &bridge) {
                         tracing::error!(vm_id = vm.meta.id.as_str(), error = %e, "failed to create TAP");
                         result.failed += 1;
@@ -146,9 +196,14 @@ impl super::Reconciler for VmReconciler {
                 }
             }
 
+            let action = decide_vm_action(&vm.state, actual_processes.contains(&vm.meta.id));
+
             // If process is already running, check health and correct state
-            if actual_processes.contains(&vm.meta.id) {
-                if vm.state == VmState::Pending {
+            if matches!(
+                action,
+                VmAction::CorrectStateAndHealthCheck | VmAction::HealthCheck
+            ) {
+                if action == VmAction::CorrectStateAndHealthCheck {
                     if let Err(e) = vm_store
                         .update_state(&vm.meta.id, VmState::Running, None, None, None)
                         .await
@@ -261,7 +316,7 @@ impl super::Reconciler for VmReconciler {
             }
 
             // Ensure process is running — clean up stale state first
-            if !actual_processes.contains(&vm.meta.id) {
+            if action == VmAction::Start {
                 // Kill orphaned processes and clean stale container state
                 // before recreating. This handles the case where the container
                 // died but `sleep infinity` or tini survived as an orphan.
@@ -342,19 +397,147 @@ impl super::Reconciler for VmReconciler {
 
         // 4. Remove orphaned processes + network interfaces
         let needed_ids: Vec<&str> = should_exist.iter().map(|vm| vm.meta.id.as_str()).collect();
-        for vm_id in &actual_processes {
-            if !needed_ids.contains(&vm_id.as_str()) {
-                tracing::info!(vm_id, "stopping orphaned VM");
-                let _ = rt.stop(vm_id);
-                if use_veth {
-                    let _ = provision::remove_veth(vm_id);
-                } else {
-                    let _ = provision::remove_tap(vm_id);
-                }
-                result.deleted += 1;
+        let orphaned = find_orphaned_processes(&actual_processes, &needed_ids);
+        for vm_id in &orphaned {
+            tracing::info!(vm_id = vm_id.as_str(), "stopping orphaned VM");
+            let _ = rt.stop(vm_id);
+            if use_veth {
+                let _ = provision::remove_veth(vm_id);
+            } else {
+                let _ = provision::remove_tap(vm_id);
             }
+            result.deleted += 1;
         }
 
         Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── is_local_vm ──────────────────────────────────────────────
+
+    #[test]
+    fn local_vm_matches_node_id() {
+        let node_ids = vec!["hv-aaa".to_string(), "hv-bbb".to_string()];
+        assert!(is_local_vm(Some("hv-aaa"), &node_ids));
+        assert!(is_local_vm(Some("hv-bbb"), &node_ids));
+    }
+
+    #[test]
+    fn local_vm_no_match() {
+        let node_ids = vec!["hv-aaa".to_string()];
+        assert!(!is_local_vm(Some("hv-zzz"), &node_ids));
+    }
+
+    #[test]
+    fn local_vm_none_hypervisor_id() {
+        let node_ids = vec!["hv-aaa".to_string()];
+        assert!(!is_local_vm(None, &node_ids));
+    }
+
+    #[test]
+    fn local_vm_empty_node_ids() {
+        assert!(!is_local_vm(Some("hv-aaa"), &[]));
+    }
+
+    // ── should_vm_exist ──────────────────────────────────────────
+
+    #[test]
+    fn pending_and_running_should_exist() {
+        assert!(should_vm_exist(&VmState::Pending));
+        assert!(should_vm_exist(&VmState::Running));
+    }
+
+    #[test]
+    fn other_states_should_not_exist() {
+        assert!(!should_vm_exist(&VmState::Stopped));
+        assert!(!should_vm_exist(&VmState::Deleting));
+        assert!(!should_vm_exist(&VmState::Deleted));
+        assert!(!should_vm_exist(&VmState::Creating));
+    }
+
+    // ── decide_vm_action ─────────────────────────────────────────
+
+    #[test]
+    fn running_process_with_pending_state_corrects() {
+        assert_eq!(
+            decide_vm_action(&VmState::Pending, true),
+            VmAction::CorrectStateAndHealthCheck
+        );
+    }
+
+    #[test]
+    fn running_process_with_running_state_health_checks() {
+        assert_eq!(
+            decide_vm_action(&VmState::Running, true),
+            VmAction::HealthCheck
+        );
+    }
+
+    #[test]
+    fn no_process_starts_vm() {
+        assert_eq!(decide_vm_action(&VmState::Pending, false), VmAction::Start);
+        assert_eq!(decide_vm_action(&VmState::Running, false), VmAction::Start);
+    }
+
+    // ── find_orphaned_processes ──────────────────────────────────
+
+    #[test]
+    fn orphans_detected() {
+        let actual = vec![
+            "vm-aaa".to_string(),
+            "vm-bbb".to_string(),
+            "vm-ccc".to_string(),
+        ];
+        let needed = vec!["vm-aaa", "vm-ccc"];
+        let orphaned = find_orphaned_processes(&actual, &needed);
+        assert_eq!(orphaned, vec!["vm-bbb"]);
+    }
+
+    #[test]
+    fn no_orphans_when_all_needed() {
+        let actual = vec!["vm-aaa".to_string(), "vm-bbb".to_string()];
+        let needed = vec!["vm-aaa", "vm-bbb"];
+        let orphaned = find_orphaned_processes(&actual, &needed);
+        assert!(orphaned.is_empty());
+    }
+
+    #[test]
+    fn all_orphans_when_nothing_needed() {
+        let actual = vec!["vm-aaa".to_string(), "vm-bbb".to_string()];
+        let needed: Vec<&str> = vec![];
+        let orphaned = find_orphaned_processes(&actual, &needed);
+        assert_eq!(orphaned.len(), 2);
+    }
+
+    #[test]
+    fn empty_actual_no_orphans() {
+        let actual: Vec<String> = vec![];
+        let needed = vec!["vm-aaa"];
+        let orphaned = find_orphaned_processes(&actual, &needed);
+        assert!(orphaned.is_empty());
+    }
+
+    // ── is_interface_present ─────────────────────────────────────
+
+    #[test]
+    fn interface_found() {
+        let actual = vec!["nkh-abc123".to_string(), "nkh-def456".to_string()];
+        assert!(is_interface_present("nkh-abc123", &actual));
+    }
+
+    #[test]
+    fn interface_not_found() {
+        let actual = vec!["nkh-abc123".to_string()];
+        assert!(!is_interface_present("nkh-zzz999", &actual));
+    }
+
+    #[test]
+    fn interface_empty_list() {
+        let actual: Vec<String> = vec![];
+        assert!(!is_interface_present("nkh-abc123", &actual));
     }
 }


### PR DESCRIPTION
## Summary
- Extracted 5 pure decision functions from the VM reconciler (`is_local_vm`, `should_vm_exist`, `decide_vm_action`, `find_orphaned_processes`, `is_interface_present`) and wired them into the existing `reconcile()` method
- Added 16 unit tests covering VM locality matching, state filtering, action decisions, orphan detection, and network interface presence checks
- Addresses the highest-risk untested module flagged by production readiness audit

Partial #163

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test -- --skip disk_free_check` passes (all 16 new tests + full suite)
- [x] `cargo build --release --target x86_64-unknown-linux-musl` cross-compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)