### PR TITLE
feat: centralize resource framework validation and API standards

### DIFF
--- a/layers/core/src/api/error_response.rs
+++ b/layers/core/src/api/error_response.rs
@@ -12,6 +12,24 @@ impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
         let status =
             StatusCode::from_u16(self.0.http_status()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+
+        // Structured error logging
+        if status.is_server_error() {
+            tracing::error!(
+                error_code = self.0.code.as_str(),
+                http_status = status.as_u16(),
+                message = %self.0.message,
+                "API server error"
+            );
+        } else if status.is_client_error() {
+            tracing::warn!(
+                error_code = self.0.code.as_str(),
+                http_status = status.as_u16(),
+                message = %self.0.message,
+                "API client error"
+            );
+        }
+
         let body = axum::Json(serde_json::json!({
             "error": {
                 "code": self.0.code.as_str(),

--- a/layers/core/src/api/middleware.rs
+++ b/layers/core/src/api/middleware.rs
@@ -107,8 +107,12 @@ impl RateLimiter {
 /// Middleware that validates Content-Type on POST/PATCH/PUT requests.
 /// Returns 415 Unsupported Media Type if Content-Type is not application/json.
 pub async fn require_json_content_type(req: Request, next: Next) -> Response {
-    if matches!(*req.method(), axum::http::Method::POST | axum::http::Method::PATCH | axum::http::Method::PUT) {
-        let content_type = req.headers()
+    if matches!(
+        *req.method(),
+        axum::http::Method::POST | axum::http::Method::PATCH | axum::http::Method::PUT
+    ) {
+        let content_type = req
+            .headers()
             .get(axum::http::header::CONTENT_TYPE)
             .and_then(|v| v.to_str().ok())
             .unwrap_or("");
@@ -228,10 +232,7 @@ mod tests {
             .route("/test", get(|| async { "ok" }))
             .layer(axum::middleware::from_fn(require_json_content_type));
 
-        let req = Request::builder()
-            .uri("/test")
-            .body(Body::empty())
-            .unwrap();
+        let req = Request::builder().uri("/test").body(Body::empty()).unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), 200);
     }

--- a/layers/core/src/api/middleware.rs
+++ b/layers/core/src/api/middleware.rs
@@ -3,7 +3,7 @@
 use axum::extract::Request;
 use axum::http::HeaderValue;
 use axum::middleware::Next;
-use axum::response::Response;
+use axum::response::{IntoResponse, Response};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
@@ -101,64 +101,29 @@ impl RateLimiter {
 }
 
 // ═══════════════════════════════════════════════════
-// 3. Pagination query params
+// 7. Content-Type validation
 // ═══════════════════════════════════════════════════
 
-/// Standard pagination parameters extracted from query string.
-#[derive(Debug, Clone, serde::Deserialize)]
-pub struct Pagination {
-    /// Number of items to return (default 50, max 200).
-    #[serde(default = "default_limit")]
-    pub limit: u64,
-    /// Offset for pagination (default 0).
-    #[serde(default)]
-    pub offset: u64,
-    /// Sort field.
-    #[serde(default)]
-    pub sort: Option<String>,
-    /// Sort order: "asc" or "desc".
-    #[serde(default = "default_order")]
-    pub order: String,
-}
+/// Middleware that validates Content-Type on POST/PATCH/PUT requests.
+/// Returns 415 Unsupported Media Type if Content-Type is not application/json.
+pub async fn require_json_content_type(req: Request, next: Next) -> Response {
+    if matches!(*req.method(), axum::http::Method::POST | axum::http::Method::PATCH | axum::http::Method::PUT) {
+        let content_type = req.headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
 
-fn default_limit() -> u64 {
-    50
-}
-fn default_order() -> String {
-    "asc".into()
-}
-
-impl Pagination {
-    /// Clamp limit to max 200.
-    pub fn clamped_limit(&self) -> u64 {
-        self.limit.min(200)
-    }
-}
-
-/// Paginated list response.
-#[derive(Debug, serde::Serialize)]
-pub struct PaginatedResponse<T: serde::Serialize> {
-    pub items: Vec<T>,
-    pub count: usize,
-    pub total: u64,
-    pub offset: u64,
-    pub limit: u64,
-    pub has_more: bool,
-}
-
-impl<T: serde::Serialize> PaginatedResponse<T> {
-    pub fn new(items: Vec<T>, total: u64, pagination: &Pagination) -> Self {
-        let count = items.len();
-        let has_more = pagination.offset + (count as u64) < total;
-        Self {
-            items,
-            count,
-            total,
-            offset: pagination.offset,
-            limit: pagination.clamped_limit(),
-            has_more,
+        if !content_type.starts_with("application/json") {
+            let body = axum::Json(serde_json::json!({
+                "error": {
+                    "code": "UnsupportedMediaType",
+                    "message": "Content-Type must be application/json",
+                }
+            }));
+            return (axum::http::StatusCode::UNSUPPORTED_MEDIA_TYPE, body).into_response();
         }
     }
+    next.run(req).await
 }
 
 #[cfg(test)]
@@ -201,67 +166,6 @@ mod tests {
         assert_eq!(rl.check().unwrap(), 3);
     }
 
-    // ── Pagination ──
-
-    #[test]
-    fn pagination_defaults() {
-        let p: Pagination = serde_json::from_str("{}").unwrap();
-        assert_eq!(p.limit, 50);
-        assert_eq!(p.offset, 0);
-        assert_eq!(p.order, "asc");
-    }
-
-    #[test]
-    fn pagination_clamped() {
-        let p = Pagination {
-            limit: 999,
-            offset: 0,
-            sort: None,
-            order: "asc".into(),
-        };
-        assert_eq!(p.clamped_limit(), 200);
-    }
-
-    #[test]
-    fn paginated_response_has_more() {
-        let p = Pagination {
-            limit: 2,
-            offset: 0,
-            sort: None,
-            order: "asc".into(),
-        };
-        let resp = PaginatedResponse::new(vec!["a", "b"], 5, &p);
-        assert!(resp.has_more);
-        assert_eq!(resp.total, 5);
-        assert_eq!(resp.count, 2);
-    }
-
-    #[test]
-    fn paginated_response_no_more() {
-        let p = Pagination {
-            limit: 10,
-            offset: 0,
-            sort: None,
-            order: "asc".into(),
-        };
-        let resp = PaginatedResponse::new(vec!["a", "b"], 2, &p);
-        assert!(!resp.has_more);
-    }
-
-    #[test]
-    fn paginated_response_serializes() {
-        let p = Pagination {
-            limit: 50,
-            offset: 0,
-            sort: None,
-            order: "asc".into(),
-        };
-        let resp = PaginatedResponse::new(vec!["x"], 100, &p);
-        let json = serde_json::to_string(&resp).unwrap();
-        assert!(json.contains("\"has_more\":true"));
-        assert!(json.contains("\"total\":100"));
-    }
-
     // ── Request counter ──
 
     #[test]
@@ -270,5 +174,65 @@ mod tests {
         REQUEST_COUNTER.fetch_add(1, Ordering::Relaxed);
         let b = REQUEST_COUNTER.load(Ordering::Relaxed);
         assert_eq!(b, a + 1);
+    }
+
+    // ── Content-Type validation ──
+
+    #[tokio::test]
+    async fn content_type_rejects_non_json() {
+        use axum::{body::Body, routing::post, Router};
+        use http::Request;
+        use tower::ServiceExt;
+
+        let app = Router::new()
+            .route("/test", post(|| async { "ok" }))
+            .layer(axum::middleware::from_fn(require_json_content_type));
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/test")
+            .header("content-type", "text/plain")
+            .body(Body::from("hello"))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), 415);
+    }
+
+    #[tokio::test]
+    async fn content_type_allows_json() {
+        use axum::{body::Body, routing::post, Router};
+        use http::Request;
+        use tower::ServiceExt;
+
+        let app = Router::new()
+            .route("/test", post(|| async { "ok" }))
+            .layer(axum::middleware::from_fn(require_json_content_type));
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/test")
+            .header("content-type", "application/json")
+            .body(Body::from("{}"))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+
+    #[tokio::test]
+    async fn content_type_skips_get() {
+        use axum::{body::Body, routing::get, Router};
+        use http::Request;
+        use tower::ServiceExt;
+
+        let app = Router::new()
+            .route("/test", get(|| async { "ok" }))
+            .layer(axum::middleware::from_fn(require_json_content_type));
+
+        let req = Request::builder()
+            .uri("/test")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), 200);
     }
 }

--- a/layers/core/src/api/route_gen.rs
+++ b/layers/core/src/api/route_gen.rs
@@ -212,13 +212,11 @@ fn add_resource_routes(
                     router = router.route(&instance_path, handler);
                 } else {
                     let handler = axum::routing::patch(
-                        move |Path(id): Path<String>,
-                              Json(body): Json<HashMap<String, String>>| {
+                        move |Path(id): Path<String>, Json(body): Json<HashMap<String, String>>| {
                             let r = Arc::clone(&r);
                             let op = op_name.clone();
                             async move {
-                                handle_scoped(&r, &op, Some(id), body, ScopeValues::default())
-                                    .await
+                                handle_scoped(&r, &op, Some(id), body, ScopeValues::default()).await
                             }
                         },
                     );
@@ -326,7 +324,10 @@ fn classify_anyhow(err: anyhow::Error) -> NaukaError {
     }
 
     // Missing / required field → 400
-    if msg.contains("missing required field") || msg.contains("is required") || msg.contains("missing name") {
+    if msg.contains("missing required field")
+        || msg.contains("is required")
+        || msg.contains("missing name")
+    {
         return NaukaError::validation(msg);
     }
 
@@ -380,20 +381,16 @@ async fn handle_scoped(
         validation::apply_defaults(&reg.def, op_def, &mut fields);
 
         // Validate name
-        validation::validate_name(&name, &op_def.semantics)
-            .map_err(ApiError)?;
+        validation::validate_name(&name, &op_def.semantics).map_err(ApiError)?;
 
         // Validate scope parents
-        validation::validate_scope(&reg.def, op_def, &scope)
-            .map_err(ApiError)?;
+        validation::validate_scope(&reg.def, op_def, &scope).map_err(ApiError)?;
 
         // Validate required fields
-        validation::validate_required_fields(&reg.def, op_def, &fields)
-            .map_err(ApiError)?;
+        validation::validate_required_fields(&reg.def, op_def, &fields).map_err(ApiError)?;
 
         // Validate field types
-        validation::validate_field_types(&reg.def, op_def, &fields)
-            .map_err(ApiError)?;
+        validation::validate_field_types(&reg.def, op_def, &fields).map_err(ApiError)?;
 
         // Validate constraints
         for constraint in &op_def.constraints {
@@ -431,7 +428,9 @@ async fn handle_scoped(
                 if let Some(id) = v.get("id").and_then(|v| v.as_str()) {
                     let location = format!("/{}/{}", reg.def.identity.plural, id);
                     if let Ok(loc) = axum::http::HeaderValue::from_str(&location) {
-                        response.headers_mut().insert(axum::http::header::LOCATION, loc);
+                        response
+                            .headers_mut()
+                            .insert(axum::http::header::LOCATION, loc);
                     }
                 }
             }
@@ -548,10 +547,7 @@ pub fn openapi_spec(registrations: &[ResourceRegistration], prefix: &str) -> ser
 
     let mut schemas = serde_json::Map::new();
     for reg in registrations {
-        schemas.insert(
-            reg.def.identity.kind.to_string(),
-            resource_schema(&reg.def),
-        );
+        schemas.insert(reg.def.identity.kind.to_string(), resource_schema(&reg.def));
         fn add_child_schemas(
             children: &[ResourceRegistration],
             schemas: &mut serde_json::Map<String, serde_json::Value>,

--- a/layers/core/src/api/route_gen.rs
+++ b/layers/core/src/api/route_gen.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 
 use super::error_response::ApiError;
 use crate::error::NaukaError;
+use crate::resource::validation;
 use crate::resource::{
     OperationRequest, OperationResponse, OperationSemantics, ResourceRegistration, ScopeValues,
 };
@@ -193,6 +194,37 @@ fn add_resource_routes(
                     router = router.route(&instance_path, handler);
                 }
             }
+            OperationSemantics::Update { .. } => {
+                if has_parents {
+                    let handler = axum::routing::patch(
+                        move |Path(path_params): Path<HashMap<String, String>>,
+                              Json(body): Json<HashMap<String, String>>| {
+                            let r = Arc::clone(&r);
+                            let op = op_name.clone();
+                            let pk = pkinds.clone();
+                            async move {
+                                let scope = extract_scope(&path_params, &pk);
+                                let id = path_params.get("id").cloned();
+                                handle_scoped(&r, &op, id, body, scope).await
+                            }
+                        },
+                    );
+                    router = router.route(&instance_path, handler);
+                } else {
+                    let handler = axum::routing::patch(
+                        move |Path(id): Path<String>,
+                              Json(body): Json<HashMap<String, String>>| {
+                            let r = Arc::clone(&r);
+                            let op = op_name.clone();
+                            async move {
+                                handle_scoped(&r, &op, Some(id), body, ScopeValues::default())
+                                    .await
+                            }
+                        },
+                    );
+                    router = router.route(&instance_path, handler);
+                }
+            }
             OperationSemantics::Action => {
                 let route = format!("{base}/{}", op.name);
                 if has_parents {
@@ -293,6 +325,21 @@ fn classify_anyhow(err: anyhow::Error) -> NaukaError {
         return NaukaError::validation(msg);
     }
 
+    // Missing / required field → 400
+    if msg.contains("missing required field") || msg.contains("is required") || msg.contains("missing name") {
+        return NaukaError::validation(msg);
+    }
+
+    // Invalid name → 400
+    if msg.contains("invalid name") || msg.contains("InvalidName") {
+        return NaukaError::validation(msg);
+    }
+
+    // General validation errors → 400
+    if msg.contains("invalid") || msg.contains("cannot be empty") {
+        return NaukaError::validation(msg);
+    }
+
     // Default: 500
     NaukaError::internal(msg)
 }
@@ -305,8 +352,50 @@ async fn handle_scoped(
     fields: HashMap<String, String>,
     scope: ScopeValues,
 ) -> impl IntoResponse {
+    let span = tracing::info_span!(
+        "api_operation",
+        resource = reg.def.identity.kind,
+        operation = operation,
+    );
+    let _guard = span.enter();
+
+    tracing::debug!(
+        resource = reg.def.identity.kind,
+        operation = operation,
+        name = ?name,
+        "handling API request"
+    );
+
+    drop(_guard);
+
     let op_def = reg.def.operations.iter().find(|o| o.name == operation);
+
+    // ── Pre-handler validation pipeline ──
+    let mut fields = fields; // make mutable
     if let Some(op_def) = op_def {
+        // Filter ReadOnly/Internal fields from API input
+        validation::filter_readonly_fields(&reg.def, &mut fields);
+
+        // Apply defaults for missing optional fields
+        validation::apply_defaults(&reg.def, op_def, &mut fields);
+
+        // Validate name
+        validation::validate_name(&name, &op_def.semantics)
+            .map_err(ApiError)?;
+
+        // Validate scope parents
+        validation::validate_scope(&reg.def, op_def, &scope)
+            .map_err(ApiError)?;
+
+        // Validate required fields
+        validation::validate_required_fields(&reg.def, op_def, &fields)
+            .map_err(ApiError)?;
+
+        // Validate field types
+        validation::validate_field_types(&reg.def, op_def, &fields)
+            .map_err(ApiError)?;
+
+        // Validate constraints
         for constraint in &op_def.constraints {
             if let Err(msg) = constraint.validate(&fields) {
                 return Err(ApiError(NaukaError::validation(msg)));
@@ -336,7 +425,17 @@ async fn handle_scoped(
             } else {
                 axum::http::StatusCode::OK
             };
-            Ok((status, axum::Json(v)).into_response())
+            let mut response = (status, axum::Json(v.clone())).into_response();
+            // Add Location header for created resources
+            if operation == "create" {
+                if let Some(id) = v.get("id").and_then(|v| v.as_str()) {
+                    let location = format!("/{}/{}", reg.def.identity.plural, id);
+                    if let Ok(loc) = axum::http::HeaderValue::from_str(&location) {
+                        response.headers_mut().insert(axum::http::header::LOCATION, loc);
+                    }
+                }
+            }
+            Ok(response)
         }
         OperationResponse::ResourceList(items) => {
             let total = items.len();
@@ -447,6 +546,27 @@ pub fn openapi_spec(registrations: &[ResourceRegistration], prefix: &str) -> ser
         });
     }
 
+    let mut schemas = serde_json::Map::new();
+    for reg in registrations {
+        schemas.insert(
+            reg.def.identity.kind.to_string(),
+            resource_schema(&reg.def),
+        );
+        fn add_child_schemas(
+            children: &[ResourceRegistration],
+            schemas: &mut serde_json::Map<String, serde_json::Value>,
+        ) {
+            for child in children {
+                schemas.insert(
+                    child.def.identity.kind.to_string(),
+                    resource_schema(&child.def),
+                );
+                add_child_schemas(&child.children, schemas);
+            }
+        }
+        add_child_schemas(&reg.children, &mut schemas);
+    }
+
     serde_json::json!({
         "openapi": "3.0.0",
         "info": {
@@ -454,6 +574,59 @@ pub fn openapi_spec(registrations: &[ResourceRegistration], prefix: &str) -> ser
             "version": env!("CARGO_PKG_VERSION"),
         },
         "paths": paths,
+        "components": {
+            "schemas": schemas,
+        },
+    })
+}
+
+/// Generate a JSON Schema-like object from a ResourceDef's schema fields.
+fn resource_schema(def: &crate::resource::ResourceDef) -> serde_json::Value {
+    let mut properties = serde_json::Map::new();
+    let mut required = Vec::new();
+
+    // Name is always present
+    properties.insert("name".to_string(), serde_json::json!({"type": "string"}));
+    required.push(serde_json::json!("name"));
+
+    for field in &def.schema.fields {
+        let field_schema = match &field.field_type {
+            crate::resource::FieldType::String
+            | crate::resource::FieldType::Secret
+            | crate::resource::FieldType::Path
+            | crate::resource::FieldType::Duration
+            | crate::resource::FieldType::Cidr
+            | crate::resource::FieldType::IpAddr
+            | crate::resource::FieldType::ResourceRef(_)
+            | crate::resource::FieldType::KeyValue => {
+                serde_json::json!({"type": "string", "description": field.description})
+            }
+            crate::resource::FieldType::Integer
+            | crate::resource::FieldType::Port
+            | crate::resource::FieldType::SizeGb
+            | crate::resource::FieldType::SizeMb => {
+                serde_json::json!({"type": "integer", "description": field.description})
+            }
+            crate::resource::FieldType::Flag => {
+                serde_json::json!({"type": "boolean", "description": field.description})
+            }
+            crate::resource::FieldType::Enum(e) => {
+                serde_json::json!({"type": "string", "enum": e.values, "description": field.description})
+            }
+        };
+        properties.insert(field.name.to_string(), field_schema);
+
+        if matches!(field.mutability, crate::resource::Mutability::CreateOnly)
+            && field.default.is_none()
+        {
+            required.push(serde_json::json!(field.name));
+        }
+    }
+
+    serde_json::json!({
+        "type": "object",
+        "properties": properties,
+        "required": required,
     })
 }
 
@@ -639,7 +812,7 @@ mod tests {
         let resp = handle_scoped(
             &reg,
             "create",
-            Some("w1".into()),
+            Some("widget-one".into()),
             HashMap::new(),
             ScopeValues::default(),
         )
@@ -653,7 +826,7 @@ mod tests {
         let resp = handle_scoped(
             &reg,
             "delete",
-            Some("w1".into()),
+            Some("widget-one".into()),
             HashMap::new(),
             ScopeValues::default(),
         )
@@ -673,6 +846,7 @@ mod tests {
         assert!(spec["paths"]["/admin/v1/widgets"]["post"].is_object());
         assert!(spec["paths"]["/admin/v1/widgets/{id}"]["get"].is_object());
         assert!(spec["paths"]["/admin/v1/widgets/{id}"]["delete"].is_object());
+        assert!(spec["components"]["schemas"].is_object());
     }
 
     #[test]
@@ -680,6 +854,7 @@ mod tests {
         let spec = openapi_spec(&[], "/v1");
         assert_eq!(spec["openapi"], "3.0.0");
         assert!(spec["paths"].as_object().unwrap().is_empty());
+        assert!(spec["components"]["schemas"].is_object());
     }
 
     // ── Pagination (#116) ──
@@ -875,5 +1050,37 @@ mod tests {
         let classified = classify_anyhow(err);
         assert_eq!(classified.code, crate::error::ErrorCode::InternalError);
         assert_eq!(classified.http_status(), 500);
+    }
+
+    #[test]
+    fn classify_missing_required_field() {
+        let err = anyhow::anyhow!("missing required field: s3-endpoint");
+        let classified = classify_anyhow(err);
+        assert_eq!(classified.code, crate::error::ErrorCode::ValidationError);
+        assert_eq!(classified.http_status(), 400);
+    }
+
+    #[test]
+    fn classify_is_required() {
+        let err = anyhow::anyhow!("--org is required");
+        let classified = classify_anyhow(err);
+        assert_eq!(classified.code, crate::error::ErrorCode::ValidationError);
+        assert_eq!(classified.http_status(), 400);
+    }
+
+    #[test]
+    fn classify_missing_name() {
+        let err = anyhow::anyhow!("missing name");
+        let classified = classify_anyhow(err);
+        assert_eq!(classified.code, crate::error::ErrorCode::ValidationError);
+        assert_eq!(classified.http_status(), 400);
+    }
+
+    #[test]
+    fn classify_invalid_name() {
+        let err = anyhow::anyhow!("invalid name 'AB': must start with a lowercase letter");
+        let classified = classify_anyhow(err);
+        assert_eq!(classified.code, crate::error::ErrorCode::ValidationError);
+        assert_eq!(classified.http_status(), 400);
     }
 }

--- a/layers/core/src/api/server.rs
+++ b/layers/core/src/api/server.rs
@@ -137,7 +137,9 @@ fn build_api_router(
         .merge(health)
         .merge(openapi)
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer(axum::middleware::from_fn(middleware::require_json_content_type))
+        .layer(axum::middleware::from_fn(
+            middleware::require_json_content_type,
+        ))
         .layer(axum::middleware::from_fn(middleware::request_id))
         .layer(axum::middleware::from_fn(middleware::version_header))
 }

--- a/layers/core/src/api/server.rs
+++ b/layers/core/src/api/server.rs
@@ -108,6 +108,9 @@ fn build_api_router(
     registrations: Vec<ResourceRegistration>,
     prefix: &str,
 ) -> Router {
+    use super::route_gen::openapi_spec;
+    let spec = openapi_spec(&registrations, prefix);
+
     let api_routes = build_router(registrations, prefix);
 
     let health = Router::new().route(
@@ -124,17 +127,8 @@ fn build_api_router(
     let openapi = Router::new().route(
         "/openapi.json",
         axum::routing::get(move || {
-            async move {
-                // Can't access registrations here easily — return minimal spec
-                axum::Json(serde_json::json!({
-                    "openapi": "3.0.0",
-                    "info": {
-                        "title": "Nauka API",
-                        "version": env!("CARGO_PKG_VERSION"),
-                    },
-                    "paths": {},
-                }))
-            }
+            let spec = spec.clone();
+            async move { axum::Json(spec) }
         }),
     );
 
@@ -143,6 +137,7 @@ fn build_api_router(
         .merge(health)
         .merge(openapi)
         .layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(axum::middleware::from_fn(middleware::require_json_content_type))
         .layer(axum::middleware::from_fn(middleware::request_id))
         .layer(axum::middleware::from_fn(middleware::version_header))
 }
@@ -264,7 +259,7 @@ mod tests {
 
         // GET
         let req = Request::builder()
-            .uri("/admin/v1/things/t1")
+            .uri("/admin/v1/things/thing-one")
             .body(Body::empty())
             .unwrap();
         let resp = server.admin_router.clone().oneshot(req).await.unwrap();
@@ -273,7 +268,7 @@ mod tests {
         // DELETE
         let req = Request::builder()
             .method("DELETE")
-            .uri("/admin/v1/things/t1")
+            .uri("/admin/v1/things/thing-one")
             .body(Body::empty())
             .unwrap();
         let resp = server.admin_router.clone().oneshot(req).await.unwrap();
@@ -327,6 +322,13 @@ mod tests {
             .unwrap();
         let resp = server.admin_router.clone().oneshot(req).await.unwrap();
         assert_eq!(resp.status(), 200);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let spec: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(spec["openapi"], "3.0.0");
+        assert!(spec["paths"]["/admin/v1/things"]["get"].is_object());
+        assert!(spec["components"]["schemas"].is_object());
     }
 
     #[tokio::test]

--- a/layers/core/src/resource/dispatch.rs
+++ b/layers/core/src/resource/dispatch.rs
@@ -8,8 +8,8 @@ use super::operation::OutputKind;
 use super::registry::{
     OperationRequest, OperationResponse, ResourceRegistration, ScopeValues, ValidatedRequest,
 };
-use super::ResourceDef;
 use super::validation;
+use super::ResourceDef;
 
 /// Dispatch a parsed CLI invocation to the appropriate resource handler.
 ///

--- a/layers/core/src/resource/dispatch.rs
+++ b/layers/core/src/resource/dispatch.rs
@@ -9,6 +9,7 @@ use super::registry::{
     OperationRequest, OperationResponse, ResourceRegistration, ScopeValues, ValidatedRequest,
 };
 use super::ResourceDef;
+use super::validation;
 
 /// Dispatch a parsed CLI invocation to the appropriate resource handler.
 ///
@@ -117,6 +118,15 @@ pub async fn dispatch(
             }
         }
     }
+
+    // ── 1c. Apply defaults for missing optional fields ──
+    validation::apply_defaults(def, op, &mut fields);
+
+    // ── 1d. Pre-handler validation pipeline ──
+    validation::validate_name(&name, &op.semantics)?;
+    validation::validate_scope(def, op, &scope)?;
+    validation::validate_required_fields(def, op, &fields)?;
+    validation::validate_field_types(def, op, &fields)?;
 
     // ── 2. Validate constraints → ValidatedRequest ──
 
@@ -307,6 +317,11 @@ fn extract_fields(
                     .unwrap_or(false)
             {
                 fields.insert(arg.name.to_string(), "true".to_string());
+            }
+        }
+        if let super::operation::ArgSource::FromSchema(_schema_field_name) = &arg.source {
+            if let Some(val) = matches.try_get_one::<String>(arg.name).ok().flatten() {
+                fields.insert(arg.name.to_string(), val.clone());
             }
         }
     }

--- a/layers/core/src/resource/lint.rs
+++ b/layers/core/src/resource/lint.rs
@@ -915,7 +915,7 @@ mod tests {
 
     #[test]
     fn e040_from_schema_references_nonexistent_field() {
-        use crate::resource::operation::{OperationArg, ArgSource};
+        use crate::resource::operation::{ArgSource, OperationArg};
 
         let def = ResourceDef {
             identity: ResourceIdentity {
@@ -927,15 +927,14 @@ mod tests {
             },
             scope: ScopeDef::global(),
             schema: ResourceSchema::new(),
-            operations: vec![
-                OperationDef::action("filter", "Filter things")
-                    .with_arg(OperationArg {
-                        name: "missing-field",
-                        description: "A field that doesn't exist",
-                        required: false,
-                        source: ArgSource::FromSchema("nonexistent"),
-                    }),
-            ],
+            operations: vec![OperationDef::action("filter", "Filter things").with_arg(
+                OperationArg {
+                    name: "missing-field",
+                    description: "A field that doesn't exist",
+                    required: false,
+                    source: ArgSource::FromSchema("nonexistent"),
+                },
+            )],
             presentation: PresentationDef::none(),
         };
         let violations = lint_def(&def);

--- a/layers/core/src/resource/lint.rs
+++ b/layers/core/src/resource/lint.rs
@@ -279,6 +279,26 @@ fn structural_rules(def: &ResourceDef, kind: &'static str, v: &mut Vec<Violation
             }
         }
     }
+
+    // E040: FromSchema references must resolve to existing schema fields
+    for op in &def.operations {
+        for arg in &op.args {
+            if let super::operation::ArgSource::FromSchema(field_name) = &arg.source {
+                let exists = def.schema.fields.iter().any(|f| f.name == *field_name);
+                if !exists {
+                    v.push(Violation {
+                        rule: "E040",
+                        resource: kind,
+                        message: format!(
+                            "operation '{}' arg '{}' references schema field '{}' which does not exist",
+                            op.name, arg.name, field_name
+                        ),
+                        severity: Severity::Error,
+                    });
+                }
+            }
+        }
+    }
 }
 
 // ── UX (W001–W007) ───────────────────────────────────────────
@@ -530,6 +550,19 @@ fn scope_rules(def: &ResourceDef, kind: &'static str, v: &mut Vec<Violation>) {
     // get/delete don't have. Hard to check generically without knowing which
     // args are parent filters vs data filters. Skip for now — covered by
     // handler review.
+
+    // W080: delete with multiple parents should clarify scope
+    if has_op(def, "delete") && def.scope.parents.len() > 1 {
+        let all_resolve = def.scope.parents.iter().all(|p| p.required_on_resolve);
+        if !all_resolve {
+            v.push(Violation {
+                rule: "W080",
+                resource: kind,
+                message: "delete operation with multiple parents: consider setting required_on_resolve=true for unambiguous deletion".into(),
+                severity: Severity::Warning,
+            });
+        }
+    }
 }
 
 // ── Description (W040, W041) ─────────────────────────────────
@@ -878,5 +911,38 @@ mod tests {
             .done();
         let violations = lint_registry(&[&def]);
         assert!(violations.iter().any(|v| v.rule == "E011"), "expected E011");
+    }
+
+    #[test]
+    fn e040_from_schema_references_nonexistent_field() {
+        use crate::resource::operation::{OperationArg, ArgSource};
+
+        let def = ResourceDef {
+            identity: ResourceIdentity {
+                kind: "thing",
+                cli_name: "thing",
+                plural: "things",
+                description: "Test thing",
+                aliases: &[],
+            },
+            scope: ScopeDef::global(),
+            schema: ResourceSchema::new(),
+            operations: vec![
+                OperationDef::action("filter", "Filter things")
+                    .with_arg(OperationArg {
+                        name: "missing-field",
+                        description: "A field that doesn't exist",
+                        required: false,
+                        source: ArgSource::FromSchema("nonexistent"),
+                    }),
+            ],
+            presentation: PresentationDef::none(),
+        };
+        let violations = lint_def(&def);
+        assert!(
+            violations.iter().any(|v| v.rule == "E040"),
+            "expected E040, got: {}",
+            format_violations(&violations)
+        );
     }
 }

--- a/layers/core/src/resource/mod.rs
+++ b/layers/core/src/resource/mod.rs
@@ -17,6 +17,7 @@ mod presentation;
 mod registry;
 mod schema;
 mod scope;
+pub(crate) mod validation;
 
 pub use api_response::*;
 pub use builder::*;
@@ -29,6 +30,7 @@ pub use presentation::*;
 pub use registry::*;
 pub use schema::*;
 pub use scope::*;
+pub use validation::*;
 
 /// The complete definition of a cloud resource.
 /// This is the single source of truth from which CLI, API, validation,

--- a/layers/core/src/resource/validation.rs
+++ b/layers/core/src/resource/validation.rs
@@ -1,0 +1,554 @@
+//! Centralized pre-handler validation pipeline.
+//!
+//! Called from both CLI dispatch and API route_gen BEFORE the handler.
+//! Handlers can assume all inputs are validated.
+
+use crate::error::NaukaError;
+use super::constraint::FieldMap;
+use super::operation::{OperationDef, OperationSemantics, ArgSource};
+use super::schema::{FieldDef, FieldType, Mutability};
+use super::ResourceDef;
+use super::registry::ScopeValues;
+
+/// Validate the resource name based on operation semantics.
+///
+/// Create, Get, Delete, and Update operations require a name that passes
+/// `crate::validate::name()`. List and Action operations skip name validation
+/// (List never has a name; Action may or may not).
+pub fn validate_name(
+    name: &Option<String>,
+    semantics: &OperationSemantics,
+) -> Result<(), NaukaError> {
+    match semantics {
+        OperationSemantics::Create
+        | OperationSemantics::Get
+        | OperationSemantics::Delete
+        | OperationSemantics::Update { .. } => {
+            let n = name.as_deref().ok_or_else(|| {
+                NaukaError::validation("name is required for this operation")
+            })?;
+            crate::validate::name(n)
+        }
+        OperationSemantics::List | OperationSemantics::Action => Ok(()),
+    }
+}
+
+/// Validate that required scope parents are present.
+///
+/// For Create and Delete operations, every parent with `required_on_create == true`
+/// must be present in the scope values. Delete requires the same scope as Create
+/// to prevent accidental deletion of the wrong resource.
+pub fn validate_scope(
+    def: &ResourceDef,
+    op: &OperationDef,
+    scope: &ScopeValues,
+) -> Result<(), NaukaError> {
+    for parent in &def.scope.parents {
+        let required = match &op.semantics {
+            OperationSemantics::Create | OperationSemantics::Delete => {
+                parent.required_on_create
+            }
+            _ => false,
+        };
+
+        if required && scope.get(parent.kind).is_none() {
+            let flag_name = parent.flag.trim_start_matches('-');
+            return Err(NaukaError::validation(format!(
+                "--{} is required",
+                flag_name,
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Validate that all required fields are present.
+///
+/// Checks two categories:
+/// 1. Operation args marked as `required: true` must be in the field map.
+/// 2. For Create operations, schema fields with `CreateOnly` or `Mutable` mutability
+///    and no default value must also be present.
+pub fn validate_required_fields(
+    def: &ResourceDef,
+    op: &OperationDef,
+    fields: &FieldMap,
+) -> Result<(), NaukaError> {
+    // Check required operation args.
+    for arg in &op.args {
+        if arg.required && !fields.contains_key(arg.name) {
+            return Err(NaukaError::validation(format!(
+                "missing required field: {}",
+                arg.name,
+            )));
+        }
+    }
+
+    // For Create, schema fields that are settable and have no default must be present.
+    if op.semantics == OperationSemantics::Create {
+        for field in &def.schema.fields {
+            let settable = matches!(
+                field.mutability,
+                Mutability::CreateOnly | Mutability::Mutable
+            );
+            if settable && field.default.is_none() && !fields.contains_key(field.name) {
+                return Err(NaukaError::validation(format!(
+                    "missing required field: {}",
+                    field.name,
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate field values match their declared types.
+///
+/// Looks up the `FieldDef` for each field (from schema or operation args) and
+/// validates the value against its `FieldType`. Fields without a known definition
+/// are silently skipped (they may be internal or framework-managed).
+pub fn validate_field_types(
+    def: &ResourceDef,
+    op: &OperationDef,
+    fields: &FieldMap,
+) -> Result<(), NaukaError> {
+    for (name, value) in fields {
+        let field_def = match find_field_def(def, op, name) {
+            Some(fd) => fd,
+            None => continue,
+        };
+        validate_single_field(name, value, &field_def.field_type)?;
+    }
+    Ok(())
+}
+
+/// Apply default values for fields not already present.
+///
+/// Fills in defaults from two sources:
+/// 1. Schema fields with `default: Some(val)`.
+/// 2. Operation args with `ArgSource::Custom(field_def)` where the field def
+///    has a default.
+pub fn apply_defaults(def: &ResourceDef, op: &OperationDef, fields: &mut FieldMap) {
+    // Schema-level defaults.
+    for field in &def.schema.fields {
+        if let Some(default) = field.default {
+            fields.entry(field.name.to_string()).or_insert_with(|| default.to_string());
+        }
+    }
+
+    // Operation arg defaults.
+    for arg in &op.args {
+        if let ArgSource::Custom(ref field_def) = arg.source {
+            if let Some(default) = field_def.default {
+                fields.entry(arg.name.to_string()).or_insert_with(|| default.to_string());
+            }
+        }
+    }
+}
+
+/// Remove fields that clients should never set.
+///
+/// Strips any field whose `FieldDef` has `Mutability::ReadOnly` or
+/// `Mutability::Internal`. This prevents API clients from injecting system
+/// fields like `id` or `created_at`.
+pub fn filter_readonly_fields(def: &ResourceDef, fields: &mut FieldMap) {
+    fields.retain(|name, _| {
+        let Some(field) = def.schema.fields.iter().find(|f| f.name == name) else {
+            // Not a schema field — keep it (might be an operation-specific arg).
+            return true;
+        };
+        !matches!(field.mutability, Mutability::ReadOnly | Mutability::Internal)
+    });
+}
+
+// ── Helpers ──────────────────────────────────────────────
+
+/// Find the `FieldDef` for a field by name, searching both the resource schema
+/// and the operation's args.
+fn find_field_def<'a>(
+    def: &'a ResourceDef,
+    op: &'a OperationDef,
+    name: &str,
+) -> Option<&'a FieldDef> {
+    // Check schema fields first.
+    if let Some(field) = def.schema.fields.iter().find(|f| f.name == name) {
+        return Some(field);
+    }
+    // Then check operation args with custom field defs.
+    for arg in &op.args {
+        if arg.name == name {
+            if let ArgSource::Custom(ref field_def) = arg.source {
+                return Some(field_def);
+            }
+            // ArgSource::FromSchema — already checked in schema above.
+        }
+    }
+    None
+}
+
+/// Validate a single field value against its declared type.
+fn validate_single_field(
+    name: &str,
+    value: &str,
+    field_type: &FieldType,
+) -> Result<(), NaukaError> {
+    match field_type {
+        FieldType::Enum(enum_def) => {
+            if !enum_def.values.contains(&value) {
+                return Err(NaukaError::validation(format!(
+                    "--{}: must be one of [{}], got '{}'",
+                    name,
+                    enum_def.values.join(", "),
+                    value,
+                )));
+            }
+        }
+        FieldType::Integer => {
+            value.parse::<i64>().map_err(|_| {
+                NaukaError::validation(format!(
+                    "--{}: expected an integer, got '{}'",
+                    name, value,
+                ))
+            })?;
+        }
+        FieldType::Port => {
+            value.parse::<u16>().map_err(|_| {
+                NaukaError::validation(format!(
+                    "--{}: expected a port number (0-65535), got '{}'",
+                    name, value,
+                ))
+            })?;
+        }
+        FieldType::SizeGb | FieldType::SizeMb => {
+            value.parse::<u64>().map_err(|_| {
+                NaukaError::validation(format!(
+                    "--{}: expected a positive number, got '{}'",
+                    name, value,
+                ))
+            })?;
+        }
+        FieldType::Cidr => {
+            crate::validate::cidr(value).map_err(|_| {
+                NaukaError::validation(format!(
+                    "--{}: invalid CIDR notation '{}'",
+                    name, value,
+                ))
+            })?;
+        }
+        FieldType::IpAddr => {
+            value.parse::<std::net::IpAddr>().map_err(|_| {
+                NaukaError::validation(format!(
+                    "--{}: invalid IP address '{}'",
+                    name, value,
+                ))
+            })?;
+        }
+        FieldType::Flag => {
+            if value != "true" && value != "false" {
+                return Err(NaukaError::validation(format!(
+                    "--{}: expected 'true' or 'false', got '{}'",
+                    name, value,
+                )));
+            }
+        }
+        // String, Path, Secret, Duration, KeyValue, ResourceRef: accept any string.
+        FieldType::String
+        | FieldType::Path
+        | FieldType::Secret
+        | FieldType::Duration
+        | FieldType::KeyValue
+        | FieldType::ResourceRef(_) => {}
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resource::operation::{OperationArg, OutputDef, OutputKind, ProgressHint};
+    use crate::resource::schema::{FieldDef, ResourceSchema};
+    use crate::resource::scope::ScopeDef;
+    use crate::resource::identity::ResourceIdentity;
+    use crate::resource::presentation::PresentationDef;
+
+    fn test_resource_def() -> ResourceDef {
+        ResourceDef {
+            identity: ResourceIdentity {
+                kind: "vm",
+                cli_name: "vm",
+                description: "Virtual machine",
+                plural: "VMs",
+                aliases: &[],
+            },
+            scope: ScopeDef::within("vpc", "--vpc", "Parent VPC"),
+            schema: ResourceSchema {
+                fields: vec![
+                    FieldDef::string("region", "Region")
+                        .with_default("fsn1"),
+                    FieldDef::string("type", "Server type"),
+                    FieldDef {
+                        name: "id",
+                        description: "Resource ID",
+                        field_type: FieldType::String,
+                        mutability: Mutability::ReadOnly,
+                        short: None,
+                        default: None,
+                        env_var: None,
+                        visibility: crate::resource::schema::CliVisibility::Hidden,
+                    },
+                    FieldDef::integer("vcpus", "Number of vCPUs")
+                        .with_default("2"),
+                    FieldDef::enum_field("size", "Disk size", &["small", "medium", "large"]),
+                ],
+            },
+            operations: Vec::new(),
+            presentation: PresentationDef::none(),
+        }
+    }
+
+    fn create_op() -> OperationDef {
+        OperationDef {
+            name: "create",
+            description: "Create a VM",
+            semantics: OperationSemantics::Create,
+            args: vec![
+                OperationArg {
+                    name: "image",
+                    description: "OS image",
+                    required: true,
+                    source: ArgSource::Custom(FieldDef::string("image", "OS image")),
+                },
+            ],
+            constraints: Vec::new(),
+            confirmable: false,
+            output: OutputDef {
+                kind: OutputKind::Resource,
+                success_message: None,
+            },
+            examples: Vec::new(),
+            progress: ProgressHint::None,
+        }
+    }
+
+    fn list_op() -> OperationDef {
+        OperationDef {
+            name: "list",
+            description: "List VMs",
+            semantics: OperationSemantics::List,
+            args: Vec::new(),
+            constraints: Vec::new(),
+            confirmable: false,
+            output: OutputDef {
+                kind: OutputKind::ResourceList,
+                success_message: None,
+            },
+            examples: Vec::new(),
+            progress: ProgressHint::None,
+        }
+    }
+
+    // ── validate_name ──
+
+    #[test]
+    fn name_required_for_create() {
+        let result = validate_name(&None, &OperationSemantics::Create);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn name_valid_for_create() {
+        let result = validate_name(
+            &Some("my-vm".to_string()),
+            &OperationSemantics::Create,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn name_skipped_for_list() {
+        let result = validate_name(&None, &OperationSemantics::List);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn name_skipped_for_action() {
+        let result = validate_name(&None, &OperationSemantics::Action);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn name_invalid_characters() {
+        let result = validate_name(
+            &Some("MY_VM".to_string()),
+            &OperationSemantics::Get,
+        );
+        assert!(result.is_err());
+    }
+
+    // ── validate_scope ──
+
+    #[test]
+    fn scope_required_on_create() {
+        let def = test_resource_def();
+        let op = create_op();
+        let scope = ScopeValues::default();
+        let result = validate_scope(&def, &op, &scope);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("--vpc"));
+    }
+
+    #[test]
+    fn scope_present_on_create() {
+        let def = test_resource_def();
+        let op = create_op();
+        let mut scope = ScopeValues::default();
+        scope.set("vpc", "my-vpc");
+        let result = validate_scope(&def, &op, &scope);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn scope_optional_on_list() {
+        let def = test_resource_def();
+        let op = list_op();
+        let scope = ScopeValues::default();
+        let result = validate_scope(&def, &op, &scope);
+        assert!(result.is_ok());
+    }
+
+    // ── validate_required_fields ──
+
+    #[test]
+    fn required_op_arg_missing() {
+        let def = test_resource_def();
+        let op = create_op();
+        let fields = FieldMap::new();
+        let result = validate_required_fields(&def, &op, &fields);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("image"));
+    }
+
+    #[test]
+    fn required_schema_field_missing_on_create() {
+        let def = test_resource_def();
+        let op = create_op();
+        // Provide the required op arg but not the schema field "type" (no default).
+        let mut fields = FieldMap::new();
+        fields.insert("image".to_string(), "ubuntu-22.04".to_string());
+        let result = validate_required_fields(&def, &op, &fields);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("type"));
+    }
+
+    #[test]
+    fn all_required_fields_present() {
+        let def = test_resource_def();
+        let op = create_op();
+        let mut fields = FieldMap::new();
+        fields.insert("image".to_string(), "ubuntu-22.04".to_string());
+        fields.insert("type".to_string(), "cx21".to_string());
+        fields.insert("size".to_string(), "small".to_string());
+        let result = validate_required_fields(&def, &op, &fields);
+        assert!(result.is_ok());
+    }
+
+    // ── validate_field_types ──
+
+    #[test]
+    fn valid_enum_field() {
+        let def = test_resource_def();
+        let op = create_op();
+        let mut fields = FieldMap::new();
+        fields.insert("size".to_string(), "medium".to_string());
+        let result = validate_field_types(&def, &op, &fields);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn invalid_enum_field() {
+        let def = test_resource_def();
+        let op = create_op();
+        let mut fields = FieldMap::new();
+        fields.insert("size".to_string(), "xxl".to_string());
+        let result = validate_field_types(&def, &op, &fields);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().message;
+        assert!(msg.contains("--size"));
+        assert!(msg.contains("xxl"));
+    }
+
+    #[test]
+    fn valid_integer_field() {
+        let def = test_resource_def();
+        let op = create_op();
+        let mut fields = FieldMap::new();
+        fields.insert("vcpus".to_string(), "4".to_string());
+        let result = validate_field_types(&def, &op, &fields);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn invalid_integer_field() {
+        let def = test_resource_def();
+        let op = create_op();
+        let mut fields = FieldMap::new();
+        fields.insert("vcpus".to_string(), "abc".to_string());
+        let result = validate_field_types(&def, &op, &fields);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("--vcpus"));
+    }
+
+    #[test]
+    fn unknown_field_skipped() {
+        let def = test_resource_def();
+        let op = create_op();
+        let mut fields = FieldMap::new();
+        fields.insert("unknown-field".to_string(), "whatever".to_string());
+        let result = validate_field_types(&def, &op, &fields);
+        assert!(result.is_ok());
+    }
+
+    // ── apply_defaults ──
+
+    #[test]
+    fn defaults_applied() {
+        let def = test_resource_def();
+        let op = create_op();
+        let mut fields = FieldMap::new();
+        apply_defaults(&def, &op, &mut fields);
+        assert_eq!(fields.get("region").map(|s| s.as_str()), Some("fsn1"));
+        assert_eq!(fields.get("vcpus").map(|s| s.as_str()), Some("2"));
+    }
+
+    #[test]
+    fn defaults_do_not_overwrite() {
+        let def = test_resource_def();
+        let op = create_op();
+        let mut fields = FieldMap::new();
+        fields.insert("region".to_string(), "nbg1".to_string());
+        apply_defaults(&def, &op, &mut fields);
+        assert_eq!(fields.get("region").map(|s| s.as_str()), Some("nbg1"));
+    }
+
+    // ── filter_readonly_fields ──
+
+    #[test]
+    fn readonly_fields_removed() {
+        let def = test_resource_def();
+        let mut fields = FieldMap::new();
+        fields.insert("id".to_string(), "injected-id".to_string());
+        fields.insert("region".to_string(), "fsn1".to_string());
+        filter_readonly_fields(&def, &mut fields);
+        assert!(!fields.contains_key("id"));
+        assert!(fields.contains_key("region"));
+    }
+
+    #[test]
+    fn non_schema_fields_kept() {
+        let def = test_resource_def();
+        let mut fields = FieldMap::new();
+        fields.insert("custom-op-arg".to_string(), "value".to_string());
+        filter_readonly_fields(&def, &mut fields);
+        assert!(fields.contains_key("custom-op-arg"));
+    }
+}

--- a/layers/core/src/resource/validation.rs
+++ b/layers/core/src/resource/validation.rs
@@ -3,12 +3,12 @@
 //! Called from both CLI dispatch and API route_gen BEFORE the handler.
 //! Handlers can assume all inputs are validated.
 
-use crate::error::NaukaError;
 use super::constraint::FieldMap;
-use super::operation::{OperationDef, OperationSemantics, ArgSource};
+use super::operation::{ArgSource, OperationDef, OperationSemantics};
+use super::registry::ScopeValues;
 use super::schema::{FieldDef, FieldType, Mutability};
 use super::ResourceDef;
-use super::registry::ScopeValues;
+use crate::error::NaukaError;
 
 /// Validate the resource name based on operation semantics.
 ///
@@ -24,9 +24,9 @@ pub fn validate_name(
         | OperationSemantics::Get
         | OperationSemantics::Delete
         | OperationSemantics::Update { .. } => {
-            let n = name.as_deref().ok_or_else(|| {
-                NaukaError::validation("name is required for this operation")
-            })?;
+            let n = name
+                .as_deref()
+                .ok_or_else(|| NaukaError::validation("name is required for this operation"))?;
             crate::validate::name(n)
         }
         OperationSemantics::List | OperationSemantics::Action => Ok(()),
@@ -45,9 +45,7 @@ pub fn validate_scope(
 ) -> Result<(), NaukaError> {
     for parent in &def.scope.parents {
         let required = match &op.semantics {
-            OperationSemantics::Create | OperationSemantics::Delete => {
-                parent.required_on_create
-            }
+            OperationSemantics::Create | OperationSemantics::Delete => parent.required_on_create,
             _ => false,
         };
 
@@ -132,7 +130,9 @@ pub fn apply_defaults(def: &ResourceDef, op: &OperationDef, fields: &mut FieldMa
     // Schema-level defaults.
     for field in &def.schema.fields {
         if let Some(default) = field.default {
-            fields.entry(field.name.to_string()).or_insert_with(|| default.to_string());
+            fields
+                .entry(field.name.to_string())
+                .or_insert_with(|| default.to_string());
         }
     }
 
@@ -140,7 +140,9 @@ pub fn apply_defaults(def: &ResourceDef, op: &OperationDef, fields: &mut FieldMa
     for arg in &op.args {
         if let ArgSource::Custom(ref field_def) = arg.source {
             if let Some(default) = field_def.default {
-                fields.entry(arg.name.to_string()).or_insert_with(|| default.to_string());
+                fields
+                    .entry(arg.name.to_string())
+                    .or_insert_with(|| default.to_string());
             }
         }
     }
@@ -157,7 +159,10 @@ pub fn filter_readonly_fields(def: &ResourceDef, fields: &mut FieldMap) {
             // Not a schema field — keep it (might be an operation-specific arg).
             return true;
         };
-        !matches!(field.mutability, Mutability::ReadOnly | Mutability::Internal)
+        !matches!(
+            field.mutability,
+            Mutability::ReadOnly | Mutability::Internal
+        )
     });
 }
 
@@ -205,10 +210,7 @@ fn validate_single_field(
         }
         FieldType::Integer => {
             value.parse::<i64>().map_err(|_| {
-                NaukaError::validation(format!(
-                    "--{}: expected an integer, got '{}'",
-                    name, value,
-                ))
+                NaukaError::validation(format!("--{}: expected an integer, got '{}'", name, value,))
             })?;
         }
         FieldType::Port => {
@@ -229,18 +231,12 @@ fn validate_single_field(
         }
         FieldType::Cidr => {
             crate::validate::cidr(value).map_err(|_| {
-                NaukaError::validation(format!(
-                    "--{}: invalid CIDR notation '{}'",
-                    name, value,
-                ))
+                NaukaError::validation(format!("--{}: invalid CIDR notation '{}'", name, value,))
             })?;
         }
         FieldType::IpAddr => {
             value.parse::<std::net::IpAddr>().map_err(|_| {
-                NaukaError::validation(format!(
-                    "--{}: invalid IP address '{}'",
-                    name, value,
-                ))
+                NaukaError::validation(format!("--{}: invalid IP address '{}'", name, value,))
             })?;
         }
         FieldType::Flag => {
@@ -265,11 +261,11 @@ fn validate_single_field(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::resource::identity::ResourceIdentity;
     use crate::resource::operation::{OperationArg, OutputDef, OutputKind, ProgressHint};
+    use crate::resource::presentation::PresentationDef;
     use crate::resource::schema::{FieldDef, ResourceSchema};
     use crate::resource::scope::ScopeDef;
-    use crate::resource::identity::ResourceIdentity;
-    use crate::resource::presentation::PresentationDef;
 
     fn test_resource_def() -> ResourceDef {
         ResourceDef {
@@ -283,8 +279,7 @@ mod tests {
             scope: ScopeDef::within("vpc", "--vpc", "Parent VPC"),
             schema: ResourceSchema {
                 fields: vec![
-                    FieldDef::string("region", "Region")
-                        .with_default("fsn1"),
+                    FieldDef::string("region", "Region").with_default("fsn1"),
                     FieldDef::string("type", "Server type"),
                     FieldDef {
                         name: "id",
@@ -296,8 +291,7 @@ mod tests {
                         env_var: None,
                         visibility: crate::resource::schema::CliVisibility::Hidden,
                     },
-                    FieldDef::integer("vcpus", "Number of vCPUs")
-                        .with_default("2"),
+                    FieldDef::integer("vcpus", "Number of vCPUs").with_default("2"),
                     FieldDef::enum_field("size", "Disk size", &["small", "medium", "large"]),
                 ],
             },
@@ -311,14 +305,12 @@ mod tests {
             name: "create",
             description: "Create a VM",
             semantics: OperationSemantics::Create,
-            args: vec![
-                OperationArg {
-                    name: "image",
-                    description: "OS image",
-                    required: true,
-                    source: ArgSource::Custom(FieldDef::string("image", "OS image")),
-                },
-            ],
+            args: vec![OperationArg {
+                name: "image",
+                description: "OS image",
+                required: true,
+                source: ArgSource::Custom(FieldDef::string("image", "OS image")),
+            }],
             constraints: Vec::new(),
             confirmable: false,
             output: OutputDef {
@@ -357,10 +349,7 @@ mod tests {
 
     #[test]
     fn name_valid_for_create() {
-        let result = validate_name(
-            &Some("my-vm".to_string()),
-            &OperationSemantics::Create,
-        );
+        let result = validate_name(&Some("my-vm".to_string()), &OperationSemantics::Create);
         assert!(result.is_ok());
     }
 
@@ -378,10 +367,7 @@ mod tests {
 
     #[test]
     fn name_invalid_characters() {
-        let result = validate_name(
-            &Some("MY_VM".to_string()),
-            &OperationSemantics::Get,
-        );
+        let result = validate_name(&Some("MY_VM".to_string()), &OperationSemantics::Get);
         assert!(result.is_err());
     }
 

--- a/layers/core/tests/validation_pipeline.rs
+++ b/layers/core/tests/validation_pipeline.rs
@@ -82,10 +82,7 @@ fn rejects_missing_name_on_create() {
 
 #[test]
 fn rejects_invalid_name_uppercase() {
-    let result = validate_name(
-        &Some("MY_WIDGET".to_string()),
-        &OperationSemantics::Create,
-    );
+    let result = validate_name(&Some("MY_WIDGET".to_string()), &OperationSemantics::Create);
     assert!(result.is_err());
     let msg = result.unwrap_err().message;
     assert!(
@@ -96,10 +93,7 @@ fn rejects_invalid_name_uppercase() {
 
 #[test]
 fn rejects_name_too_short() {
-    let result = validate_name(
-        &Some("ab".to_string()),
-        &OperationSemantics::Create,
-    );
+    let result = validate_name(&Some("ab".to_string()), &OperationSemantics::Create);
     assert!(result.is_err());
     let msg = result.unwrap_err().message;
     assert!(
@@ -110,10 +104,7 @@ fn rejects_name_too_short() {
 
 #[test]
 fn rejects_name_consecutive_hyphens() {
-    let result = validate_name(
-        &Some("my--widget".to_string()),
-        &OperationSemantics::Create,
-    );
+    let result = validate_name(&Some("my--widget".to_string()), &OperationSemantics::Create);
     assert!(result.is_err());
     let msg = result.unwrap_err().message;
     assert!(
@@ -124,10 +115,7 @@ fn rejects_name_consecutive_hyphens() {
 
 #[test]
 fn rejects_name_starting_with_digit() {
-    let result = validate_name(
-        &Some("1widget".to_string()),
-        &OperationSemantics::Create,
-    );
+    let result = validate_name(&Some("1widget".to_string()), &OperationSemantics::Create);
     assert!(result.is_err());
     let msg = result.unwrap_err().message;
     assert!(
@@ -138,10 +126,7 @@ fn rejects_name_starting_with_digit() {
 
 #[test]
 fn rejects_name_ending_with_hyphen() {
-    let result = validate_name(
-        &Some("widget-".to_string()),
-        &OperationSemantics::Create,
-    );
+    let result = validate_name(&Some("widget-".to_string()), &OperationSemantics::Create);
     assert!(result.is_err());
     let msg = result.unwrap_err().message;
     assert!(
@@ -359,7 +344,10 @@ fn rejects_invalid_enum_value() {
     let result = validate_field_types(&def, op, &fields);
     assert!(result.is_err());
     let msg = result.unwrap_err().message;
-    assert!(msg.contains("--size"), "expected --size in error, got: {msg}");
+    assert!(
+        msg.contains("--size"),
+        "expected --size in error, got: {msg}"
+    );
     assert!(msg.contains("xxl"), "expected 'xxl' in error, got: {msg}");
     assert!(
         msg.contains("small") && msg.contains("medium") && msg.contains("large"),
@@ -437,7 +425,10 @@ fn validates_each_enum_variant() {
         let mut fields = HashMap::new();
         fields.insert("size".to_string(), variant.to_string());
         let result = validate_field_types(&def, op, &fields);
-        assert!(result.is_ok(), "enum variant '{variant}' should be accepted");
+        assert!(
+            result.is_ok(),
+            "enum variant '{variant}' should be accepted"
+        );
     }
 }
 
@@ -479,12 +470,10 @@ fn applies_op_arg_defaults() {
         },
         scope: ScopeDef::global(),
         schema: ResourceSchema { fields: vec![] },
-        operations: vec![
-            OperationDef::create().with_arg(OperationArg::optional(
-                "mode",
-                FieldDef::string("mode", "Operating mode").with_default("auto"),
-            )),
-        ],
+        operations: vec![OperationDef::create().with_arg(OperationArg::optional(
+            "mode",
+            FieldDef::string("mode", "Operating mode").with_default("auto"),
+        ))],
         presentation: PresentationDef::none(),
     };
     let op = &def.operations[0];
@@ -509,12 +498,10 @@ fn op_arg_default_does_not_overwrite() {
         },
         scope: ScopeDef::global(),
         schema: ResourceSchema { fields: vec![] },
-        operations: vec![
-            OperationDef::create().with_arg(OperationArg::optional(
-                "mode",
-                FieldDef::string("mode", "Operating mode").with_default("auto"),
-            )),
-        ],
+        operations: vec![OperationDef::create().with_arg(OperationArg::optional(
+            "mode",
+            FieldDef::string("mode", "Operating mode").with_default("auto"),
+        ))],
         presentation: PresentationDef::none(),
     };
     let op = &def.operations[0];

--- a/layers/core/tests/validation_pipeline.rs
+++ b/layers/core/tests/validation_pipeline.rs
@@ -1,0 +1,732 @@
+//! Integration tests for the centralized validation pipeline.
+//!
+//! These tests verify that the framework rejects bad input BEFORE calling handlers.
+//! Each validation function is tested through the public re-exports in
+//! `nauka_core::resource::*` (the module itself is `pub(crate)` but all items
+//! are re-exported via `pub use validation::*`).
+
+use nauka_core::resource::*;
+use std::collections::HashMap;
+
+// ── Test fixtures ────────────────────────────────────────
+
+/// A "widget" resource scoped to an org, with a mix of field types:
+/// - `color`: required string (CreateOnly, no default)
+/// - `count`: integer with default "1"
+/// - `size`: enum {small, medium, large}
+/// - `id`: ReadOnly / Hidden (should be stripped)
+fn widget_def() -> ResourceDef {
+    ResourceDef {
+        identity: ResourceIdentity {
+            kind: "widget",
+            cli_name: "widget",
+            plural: "widgets",
+            description: "Test widget",
+            aliases: &[],
+        },
+        scope: ScopeDef::within("org", "--org", "Organization"),
+        schema: ResourceSchema {
+            fields: vec![
+                FieldDef::string("color", "Widget color"),
+                FieldDef::integer("count", "Number of items").with_default("1"),
+                FieldDef::enum_field("size", "Widget size", &["small", "medium", "large"]),
+                FieldDef {
+                    name: "id",
+                    description: "Resource ID",
+                    field_type: FieldType::String,
+                    mutability: Mutability::ReadOnly,
+                    short: None,
+                    default: None,
+                    env_var: None,
+                    visibility: CliVisibility::Hidden,
+                },
+            ],
+        },
+        operations: vec![
+            OperationDef::create().with_arg(OperationArg::required(
+                "material",
+                FieldDef::string("material", "Material type"),
+            )),
+            OperationDef::list(),
+            OperationDef::get(),
+            OperationDef::delete(),
+        ],
+        presentation: PresentationDef::none(),
+    }
+}
+
+fn create_op(def: &ResourceDef) -> &OperationDef {
+    def.operations.iter().find(|o| o.name == "create").unwrap()
+}
+
+fn list_op(def: &ResourceDef) -> &OperationDef {
+    def.operations.iter().find(|o| o.name == "list").unwrap()
+}
+
+fn get_op(def: &ResourceDef) -> &OperationDef {
+    def.operations.iter().find(|o| o.name == "get").unwrap()
+}
+
+fn delete_op(def: &ResourceDef) -> &OperationDef {
+    def.operations.iter().find(|o| o.name == "delete").unwrap()
+}
+
+// ── validate_name ────────────────────────────────────────
+
+#[test]
+fn rejects_missing_name_on_create() {
+    let result = validate_name(&None, &OperationSemantics::Create);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().message.contains("name is required"));
+}
+
+#[test]
+fn rejects_invalid_name_uppercase() {
+    let result = validate_name(
+        &Some("MY_WIDGET".to_string()),
+        &OperationSemantics::Create,
+    );
+    assert!(result.is_err());
+    let msg = result.unwrap_err().message;
+    assert!(
+        msg.contains("invalid") || msg.contains("lowercase"),
+        "expected name-validation error, got: {msg}"
+    );
+}
+
+#[test]
+fn rejects_name_too_short() {
+    let result = validate_name(
+        &Some("ab".to_string()),
+        &OperationSemantics::Create,
+    );
+    assert!(result.is_err());
+    let msg = result.unwrap_err().message;
+    assert!(
+        msg.contains("at least 3"),
+        "expected too-short error, got: {msg}"
+    );
+}
+
+#[test]
+fn rejects_name_consecutive_hyphens() {
+    let result = validate_name(
+        &Some("my--widget".to_string()),
+        &OperationSemantics::Create,
+    );
+    assert!(result.is_err());
+    let msg = result.unwrap_err().message;
+    assert!(
+        msg.contains("consecutive hyphens"),
+        "expected consecutive-hyphens error, got: {msg}"
+    );
+}
+
+#[test]
+fn rejects_name_starting_with_digit() {
+    let result = validate_name(
+        &Some("1widget".to_string()),
+        &OperationSemantics::Create,
+    );
+    assert!(result.is_err());
+    let msg = result.unwrap_err().message;
+    assert!(
+        msg.contains("start with a lowercase letter"),
+        "expected start-with-letter error, got: {msg}"
+    );
+}
+
+#[test]
+fn rejects_name_ending_with_hyphen() {
+    let result = validate_name(
+        &Some("widget-".to_string()),
+        &OperationSemantics::Create,
+    );
+    assert!(result.is_err());
+    let msg = result.unwrap_err().message;
+    assert!(
+        msg.contains("end with"),
+        "expected end-with error, got: {msg}"
+    );
+}
+
+#[test]
+fn accepts_valid_name_on_create() {
+    let result = validate_name(
+        &Some("my-widget-1".to_string()),
+        &OperationSemantics::Create,
+    );
+    assert!(result.is_ok());
+}
+
+#[test]
+fn skips_name_on_list() {
+    // List operations never have a name — should pass even with None.
+    let result = validate_name(&None, &OperationSemantics::List);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn skips_name_on_action() {
+    let result = validate_name(&None, &OperationSemantics::Action);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn requires_name_on_get() {
+    let result = validate_name(&None, &OperationSemantics::Get);
+    assert!(result.is_err());
+}
+
+#[test]
+fn requires_name_on_delete() {
+    let result = validate_name(&None, &OperationSemantics::Delete);
+    assert!(result.is_err());
+}
+
+#[test]
+fn requires_name_on_update() {
+    let result = validate_name(&None, &OperationSemantics::Update { patch: false });
+    assert!(result.is_err());
+}
+
+// ── validate_scope ───────────────────────────────────────
+
+#[test]
+fn rejects_missing_scope_on_create() {
+    let def = widget_def();
+    let op = create_op(&def);
+    let scope = ScopeValues::default();
+    let result = validate_scope(&def, op, &scope);
+    assert!(result.is_err());
+    let msg = result.unwrap_err().message;
+    assert!(msg.contains("--org"), "expected --org error, got: {msg}");
+}
+
+#[test]
+fn accepts_scope_on_create() {
+    let def = widget_def();
+    let op = create_op(&def);
+    let mut scope = ScopeValues::default();
+    scope.set("org", "acme");
+    let result = validate_scope(&def, op, &scope);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn scope_optional_on_list() {
+    let def = widget_def();
+    let op = list_op(&def);
+    let scope = ScopeValues::default();
+    let result = validate_scope(&def, op, &scope);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn scope_optional_on_get() {
+    let def = widget_def();
+    let op = get_op(&def);
+    let scope = ScopeValues::default();
+    let result = validate_scope(&def, op, &scope);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn rejects_missing_scope_on_delete() {
+    let def = widget_def();
+    let op = delete_op(&def);
+    let scope = ScopeValues::default();
+    let result = validate_scope(&def, op, &scope);
+    assert!(result.is_err());
+    let msg = result.unwrap_err().message;
+    assert!(msg.contains("--org"), "expected --org error, got: {msg}");
+}
+
+#[test]
+fn global_scope_never_requires_parent() {
+    let def = ResourceDef {
+        identity: ResourceIdentity {
+            kind: "org",
+            cli_name: "org",
+            plural: "orgs",
+            description: "Organization",
+            aliases: &[],
+        },
+        scope: ScopeDef::global(),
+        schema: ResourceSchema { fields: vec![] },
+        operations: vec![OperationDef::create()],
+        presentation: PresentationDef::none(),
+    };
+    let op = &def.operations[0];
+    let scope = ScopeValues::default();
+    let result = validate_scope(&def, op, &scope);
+    assert!(result.is_ok());
+}
+
+// ── validate_required_fields ─────────────────────────────
+
+#[test]
+fn rejects_missing_required_op_arg() {
+    let def = widget_def();
+    let op = create_op(&def);
+    // Provide schema fields but NOT the required op arg "material".
+    let mut fields = HashMap::new();
+    fields.insert("color".to_string(), "red".to_string());
+    fields.insert("size".to_string(), "small".to_string());
+    let result = validate_required_fields(&def, op, &fields);
+    assert!(result.is_err());
+    let msg = result.unwrap_err().message;
+    assert!(
+        msg.contains("material"),
+        "expected 'material' in error, got: {msg}"
+    );
+}
+
+#[test]
+fn rejects_missing_schema_field_on_create() {
+    let def = widget_def();
+    let op = create_op(&def);
+    // Provide the required op arg "material" but miss required schema field "color".
+    let mut fields = HashMap::new();
+    fields.insert("material".to_string(), "steel".to_string());
+    fields.insert("size".to_string(), "small".to_string());
+    let result = validate_required_fields(&def, op, &fields);
+    assert!(result.is_err());
+    let msg = result.unwrap_err().message;
+    assert!(
+        msg.contains("color"),
+        "expected 'color' in error, got: {msg}"
+    );
+}
+
+#[test]
+fn accepts_all_required_fields() {
+    let def = widget_def();
+    let op = create_op(&def);
+    let mut fields = HashMap::new();
+    fields.insert("material".to_string(), "steel".to_string());
+    fields.insert("color".to_string(), "red".to_string());
+    fields.insert("size".to_string(), "small".to_string());
+    let result = validate_required_fields(&def, op, &fields);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn required_fields_not_checked_on_list() {
+    let def = widget_def();
+    let op = list_op(&def);
+    let fields = HashMap::new(); // empty — should be fine for list
+    let result = validate_required_fields(&def, op, &fields);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn readonly_field_not_required_on_create() {
+    // The "id" field is ReadOnly — it should NOT be required on create.
+    let def = widget_def();
+    let op = create_op(&def);
+    let mut fields = HashMap::new();
+    fields.insert("material".to_string(), "steel".to_string());
+    fields.insert("color".to_string(), "red".to_string());
+    fields.insert("size".to_string(), "small".to_string());
+    // "id" is NOT provided — should still pass.
+    let result = validate_required_fields(&def, op, &fields);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn field_with_default_not_required_on_create() {
+    // "count" has default "1" — should NOT be required on create.
+    let def = widget_def();
+    let op = create_op(&def);
+    let mut fields = HashMap::new();
+    fields.insert("material".to_string(), "steel".to_string());
+    fields.insert("color".to_string(), "red".to_string());
+    fields.insert("size".to_string(), "small".to_string());
+    // "count" is NOT provided — should still pass because it has a default.
+    let result = validate_required_fields(&def, op, &fields);
+    assert!(result.is_ok());
+}
+
+// ── validate_field_types ─────────────────────────────────
+
+#[test]
+fn rejects_invalid_enum_value() {
+    let def = widget_def();
+    let op = create_op(&def);
+    let mut fields = HashMap::new();
+    fields.insert("size".to_string(), "xxl".to_string());
+    let result = validate_field_types(&def, op, &fields);
+    assert!(result.is_err());
+    let msg = result.unwrap_err().message;
+    assert!(msg.contains("--size"), "expected --size in error, got: {msg}");
+    assert!(msg.contains("xxl"), "expected 'xxl' in error, got: {msg}");
+    assert!(
+        msg.contains("small") && msg.contains("medium") && msg.contains("large"),
+        "expected allowed values in error, got: {msg}"
+    );
+}
+
+#[test]
+fn rejects_non_integer() {
+    let def = widget_def();
+    let op = create_op(&def);
+    let mut fields = HashMap::new();
+    fields.insert("count".to_string(), "abc".to_string());
+    let result = validate_field_types(&def, op, &fields);
+    assert!(result.is_err());
+    let msg = result.unwrap_err().message;
+    assert!(
+        msg.contains("--count"),
+        "expected --count in error, got: {msg}"
+    );
+    assert!(
+        msg.contains("integer"),
+        "expected 'integer' in error, got: {msg}"
+    );
+}
+
+#[test]
+fn accepts_valid_types() {
+    let def = widget_def();
+    let op = create_op(&def);
+    let mut fields = HashMap::new();
+    fields.insert("color".to_string(), "red".to_string());
+    fields.insert("count".to_string(), "42".to_string());
+    fields.insert("size".to_string(), "medium".to_string());
+    let result = validate_field_types(&def, op, &fields);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn accepts_negative_integer() {
+    let def = widget_def();
+    let op = create_op(&def);
+    let mut fields = HashMap::new();
+    fields.insert("count".to_string(), "-5".to_string());
+    let result = validate_field_types(&def, op, &fields);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn unknown_field_silently_skipped() {
+    let def = widget_def();
+    let op = create_op(&def);
+    let mut fields = HashMap::new();
+    fields.insert("not-in-schema".to_string(), "whatever".to_string());
+    let result = validate_field_types(&def, op, &fields);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn validates_op_arg_custom_field_type() {
+    // "material" is a Custom ArgSource with String type — any value should pass.
+    let def = widget_def();
+    let op = create_op(&def);
+    let mut fields = HashMap::new();
+    fields.insert("material".to_string(), "anything-goes".to_string());
+    let result = validate_field_types(&def, op, &fields);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn validates_each_enum_variant() {
+    let def = widget_def();
+    let op = create_op(&def);
+    for variant in &["small", "medium", "large"] {
+        let mut fields = HashMap::new();
+        fields.insert("size".to_string(), variant.to_string());
+        let result = validate_field_types(&def, op, &fields);
+        assert!(result.is_ok(), "enum variant '{variant}' should be accepted");
+    }
+}
+
+// ── apply_defaults ───────────────────────────────────────
+
+#[test]
+fn applies_schema_defaults() {
+    let def = widget_def();
+    let op = create_op(&def);
+    let mut fields = HashMap::new();
+    apply_defaults(&def, op, &mut fields);
+    assert_eq!(fields.get("count").map(|s| s.as_str()), Some("1"));
+}
+
+#[test]
+fn does_not_overwrite_provided_values() {
+    let def = widget_def();
+    let op = create_op(&def);
+    let mut fields = HashMap::new();
+    fields.insert("count".to_string(), "99".to_string());
+    apply_defaults(&def, op, &mut fields);
+    assert_eq!(
+        fields.get("count").map(|s| s.as_str()),
+        Some("99"),
+        "apply_defaults should not overwrite user-provided value"
+    );
+}
+
+#[test]
+fn applies_op_arg_defaults() {
+    // Build a resource with an operation arg that has a default.
+    let def = ResourceDef {
+        identity: ResourceIdentity {
+            kind: "gizmo",
+            cli_name: "gizmo",
+            plural: "gizmos",
+            description: "Test gizmo",
+            aliases: &[],
+        },
+        scope: ScopeDef::global(),
+        schema: ResourceSchema { fields: vec![] },
+        operations: vec![
+            OperationDef::create().with_arg(OperationArg::optional(
+                "mode",
+                FieldDef::string("mode", "Operating mode").with_default("auto"),
+            )),
+        ],
+        presentation: PresentationDef::none(),
+    };
+    let op = &def.operations[0];
+    let mut fields = HashMap::new();
+    apply_defaults(&def, op, &mut fields);
+    assert_eq!(
+        fields.get("mode").map(|s| s.as_str()),
+        Some("auto"),
+        "operation arg default should be applied"
+    );
+}
+
+#[test]
+fn op_arg_default_does_not_overwrite() {
+    let def = ResourceDef {
+        identity: ResourceIdentity {
+            kind: "gizmo",
+            cli_name: "gizmo",
+            plural: "gizmos",
+            description: "Test gizmo",
+            aliases: &[],
+        },
+        scope: ScopeDef::global(),
+        schema: ResourceSchema { fields: vec![] },
+        operations: vec![
+            OperationDef::create().with_arg(OperationArg::optional(
+                "mode",
+                FieldDef::string("mode", "Operating mode").with_default("auto"),
+            )),
+        ],
+        presentation: PresentationDef::none(),
+    };
+    let op = &def.operations[0];
+    let mut fields = HashMap::new();
+    fields.insert("mode".to_string(), "manual".to_string());
+    apply_defaults(&def, op, &mut fields);
+    assert_eq!(fields.get("mode").map(|s| s.as_str()), Some("manual"));
+}
+
+// ── filter_readonly_fields ───────────────────────────────
+
+#[test]
+fn strips_readonly_from_input() {
+    let def = widget_def();
+    let mut fields = HashMap::new();
+    fields.insert("id".to_string(), "injected-id".to_string());
+    fields.insert("color".to_string(), "red".to_string());
+    filter_readonly_fields(&def, &mut fields);
+    assert!(
+        !fields.contains_key("id"),
+        "ReadOnly field 'id' should be stripped"
+    );
+}
+
+#[test]
+fn keeps_normal_fields() {
+    let def = widget_def();
+    let mut fields = HashMap::new();
+    fields.insert("color".to_string(), "red".to_string());
+    fields.insert("count".to_string(), "5".to_string());
+    fields.insert("size".to_string(), "large".to_string());
+    filter_readonly_fields(&def, &mut fields);
+    assert!(fields.contains_key("color"));
+    assert!(fields.contains_key("count"));
+    assert!(fields.contains_key("size"));
+}
+
+#[test]
+fn keeps_non_schema_fields() {
+    // Fields not in the schema (e.g. operation-specific args) should be kept.
+    let def = widget_def();
+    let mut fields = HashMap::new();
+    fields.insert("material".to_string(), "steel".to_string());
+    filter_readonly_fields(&def, &mut fields);
+    assert!(
+        fields.contains_key("material"),
+        "non-schema field should survive filter_readonly_fields"
+    );
+}
+
+#[test]
+fn strips_internal_fields() {
+    // Build a def with an Internal field.
+    let def = ResourceDef {
+        identity: ResourceIdentity {
+            kind: "secret",
+            cli_name: "secret",
+            plural: "secrets",
+            description: "Test secret",
+            aliases: &[],
+        },
+        scope: ScopeDef::global(),
+        schema: ResourceSchema {
+            fields: vec![
+                FieldDef::string("name", "Secret name"),
+                FieldDef {
+                    name: "internal-token",
+                    description: "Internal use only",
+                    field_type: FieldType::String,
+                    mutability: Mutability::Internal,
+                    short: None,
+                    default: None,
+                    env_var: None,
+                    visibility: CliVisibility::Hidden,
+                },
+            ],
+        },
+        operations: vec![],
+        presentation: PresentationDef::none(),
+    };
+    let mut fields = HashMap::new();
+    fields.insert("name".to_string(), "my-secret".to_string());
+    fields.insert("internal-token".to_string(), "tok_abc".to_string());
+    filter_readonly_fields(&def, &mut fields);
+    assert!(!fields.contains_key("internal-token"));
+    assert!(fields.contains_key("name"));
+}
+
+// ── Full pipeline integration ────────────────────────────
+// Simulate what dispatch does: validate_name -> validate_scope ->
+// validate_required_fields -> validate_field_types -> apply_defaults ->
+// filter_readonly_fields
+
+#[test]
+fn full_pipeline_valid_create() {
+    let def = widget_def();
+    let op = create_op(&def);
+    let name = Some("my-widget".to_string());
+    let mut scope = ScopeValues::default();
+    scope.set("org", "acme");
+    let mut fields = HashMap::new();
+    fields.insert("material".to_string(), "steel".to_string());
+    fields.insert("color".to_string(), "red".to_string());
+    fields.insert("size".to_string(), "medium".to_string());
+    fields.insert("id".to_string(), "should-be-stripped".to_string());
+
+    // Step 1: validate_name
+    validate_name(&name, &op.semantics).expect("name should be valid");
+
+    // Step 2: validate_scope
+    validate_scope(&def, op, &scope).expect("scope should be valid");
+
+    // Step 3: validate_required_fields
+    validate_required_fields(&def, op, &fields).expect("required fields present");
+
+    // Step 4: validate_field_types
+    validate_field_types(&def, op, &fields).expect("field types valid");
+
+    // Step 5: apply_defaults
+    apply_defaults(&def, op, &mut fields);
+    assert_eq!(
+        fields.get("count").map(|s| s.as_str()),
+        Some("1"),
+        "count should get default"
+    );
+
+    // Step 6: filter_readonly_fields
+    filter_readonly_fields(&def, &mut fields);
+    assert!(!fields.contains_key("id"), "id should be stripped");
+
+    // Final state: fields should have color, count, size, material
+    assert!(fields.contains_key("color"));
+    assert!(fields.contains_key("count"));
+    assert!(fields.contains_key("size"));
+    assert!(fields.contains_key("material"));
+}
+
+#[test]
+fn full_pipeline_rejects_early_on_bad_name() {
+    let def = widget_def();
+    let op = create_op(&def);
+    let name = Some("BAD".to_string());
+
+    // Should fail at step 1 — no need to check later steps.
+    let result = validate_name(&name, &op.semantics);
+    assert!(result.is_err());
+}
+
+#[test]
+fn full_pipeline_rejects_on_missing_scope() {
+    let def = widget_def();
+    let op = create_op(&def);
+    let name = Some("my-widget".to_string());
+    let scope = ScopeValues::default(); // missing --org
+
+    // Step 1 passes.
+    validate_name(&name, &op.semantics).expect("name ok");
+
+    // Step 2 fails.
+    let result = validate_scope(&def, op, &scope);
+    assert!(result.is_err());
+}
+
+// ── Error classification coverage (T4) ───────────────────
+// classify_anyhow is private to api::route_gen, so we test via the
+// public NaukaError constructors and ErrorCode mappings.
+
+#[test]
+fn error_classification_coverage() {
+    use nauka_core::error::{ErrorCode, NaukaError};
+
+    // ValidationError -> 400
+    let err = NaukaError::validation("bad input");
+    assert_eq!(err.code, ErrorCode::ValidationError);
+    assert_eq!(err.http_status(), 400);
+
+    // InvalidName -> 400
+    let err = NaukaError::invalid_name("BAD", "uppercase");
+    assert_eq!(err.code, ErrorCode::InvalidName);
+    assert_eq!(err.http_status(), 400);
+
+    // NotFound -> 404
+    let err = NaukaError::not_found("vpc", "web");
+    assert_eq!(err.code, ErrorCode::ResourceNotFound);
+    assert_eq!(err.http_status(), 404);
+
+    // AlreadyExists -> 409
+    let err = NaukaError::already_exists("vpc", "web");
+    assert_eq!(err.code, ErrorCode::ResourceAlreadyExists);
+    assert_eq!(err.http_status(), 409);
+
+    // PermissionDenied -> 403
+    let err = NaukaError::permission_denied("not allowed");
+    assert_eq!(err.code, ErrorCode::PermissionDenied);
+    assert_eq!(err.http_status(), 403);
+
+    // NotImplemented -> 501
+    let err = NaukaError::not_implemented("resize");
+    assert_eq!(err.code, ErrorCode::NotImplemented);
+    assert_eq!(err.http_status(), 501);
+}
+
+#[test]
+fn validation_errors_are_not_retryable() {
+    use nauka_core::error::NaukaError;
+
+    let err = NaukaError::validation("bad");
+    assert!(!err.is_retryable());
+
+    let err = NaukaError::invalid_name("x", "too short");
+    assert!(!err.is_retryable());
+
+    let err = NaukaError::not_found("vpc", "web");
+    assert!(!err.is_retryable());
+}


### PR DESCRIPTION
## Summary

- Centralize ALL pre-handler validation in `layers/core` so individual layers never duplicate validation logic
- Add API production-readiness features: real OpenAPI spec, PATCH routing, Content-Type validation, Location headers, structured logging, operation tracing, expanded error classification, and new lint rules
- Add 44 integration tests for the validation pipeline

## Changes

### Pre-handler validation pipeline (`validation.rs` — new)
- `validate_name()` — enforces DNS-label naming rules before handler
- `validate_scope()` — enforces required parent scope (org, vpc, etc.)
- `validate_required_fields()` — enforces required operation args + schema fields
- `validate_field_types()` — validates Enum, Integer, Port, Cidr, IpAddr, Flag values
- `apply_defaults()` — fills missing optional fields from schema defaults
- `filter_readonly_fields()` — strips ReadOnly/Internal fields from API input

Pipeline wired into both `dispatch.rs` (CLI) and `route_gen.rs` (API).

### API improvements
- **PATCH routing** for `Update` operations (was silently dropped)
- **Real OpenAPI spec** at `/openapi.json` with paths AND component schemas
- **Location header** on 201 Created responses
- **Content-Type validation** middleware — 415 on POST/PATCH without `application/json`
- **Structured error logging** — `tracing::error!`/`tracing::warn!` with error_code, http_status
- **Operation-level tracing** — `api_operation` spans with resource/operation fields
- **Expanded `classify_anyhow()`** — "missing required field", "is required", "invalid name" → 400

### Lint rules
- **E040** — `FromSchema` arg referencing nonexistent schema field
- **W080** — delete with multiple parents missing `required_on_resolve`

### Cleanup
- Removed dead `Pagination`/`PaginatedResponse` code from `middleware.rs`

## Test plan

- [x] 367 lib tests pass
- [x] 44 new integration tests (`validation_pipeline.rs`)
- [x] 13 doc tests pass
- [x] 0 clippy warnings
- [x] `cargo fmt` clean

Closes #174, closes #176.