### PR TITLE
feat: post-handler output pipeline and API server hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3031,6 +3031,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
  "tower 0.5.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 axum = "0.8"
 tower = "0.5"
-tower-http = { version = "0.6", features = ["cors", "trace"] }
+tower-http = { version = "0.6", features = ["cors", "limit", "trace"] }
 hyper = "1"
 openssl = { version = "0.10", features = ["vendored"] }
 ipnet = "2"

--- a/layers/core/src/api/middleware.rs
+++ b/layers/core/src/api/middleware.rs
@@ -75,7 +75,11 @@ impl RateLimiter {
     /// Check if a request is allowed. Returns remaining requests or false if rejected.
     #[allow(clippy::result_unit_err)]
     pub fn check(&self) -> Result<u64, ()> {
-        let mut start = self.state.window_start.lock().unwrap();
+        let mut start = self
+            .state
+            .window_start
+            .lock()
+            .expect("rate limiter lock poisoned");
         let elapsed = start.elapsed().as_secs();
 
         // Reset window if expired
@@ -96,7 +100,11 @@ impl RateLimiter {
     /// Reset the limiter (for testing).
     pub fn reset(&self) {
         self.state.count.store(0, Ordering::Relaxed);
-        *self.state.window_start.lock().unwrap() = Instant::now();
+        *self
+            .state
+            .window_start
+            .lock()
+            .expect("rate limiter lock poisoned") = Instant::now();
     }
 }
 
@@ -128,6 +136,53 @@ pub async fn require_json_content_type(req: Request, next: Next) -> Response {
         }
     }
     next.run(req).await
+}
+
+// ═══════════════════════════════════════════════════
+// 8. Rate limiter middleware
+// ═══════════════════════════════════════════════════
+
+/// Middleware that enforces the rate limit. Returns 429 if exceeded.
+pub async fn rate_limit(
+    axum::extract::State(limiter): axum::extract::State<RateLimiter>,
+    req: Request,
+    next: Next,
+) -> Response {
+    match limiter.check() {
+        Ok(remaining) => {
+            let mut resp = next.run(req).await;
+            if let Ok(val) = HeaderValue::from_str(&remaining.to_string()) {
+                resp.headers_mut().insert("x-ratelimit-remaining", val);
+            }
+            resp
+        }
+        Err(()) => {
+            let body = axum::Json(serde_json::json!({
+                "error": {
+                    "code": "RateLimited",
+                    "message": "Too many requests. Please retry later.",
+                }
+            }));
+            (axum::http::StatusCode::TOO_MANY_REQUESTS, body).into_response()
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════
+// 9. Security headers
+// ═══════════════════════════════════════════════════
+
+/// Middleware that adds security headers to every response.
+pub async fn security_headers(req: Request, next: Next) -> Response {
+    let mut resp = next.run(req).await;
+    let headers = resp.headers_mut();
+    headers.insert(
+        "x-content-type-options",
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert("x-frame-options", HeaderValue::from_static("DENY"));
+    headers.insert("cache-control", HeaderValue::from_static("no-store"));
+    resp
 }
 
 #[cfg(test)]

--- a/layers/core/src/api/route_gen.rs
+++ b/layers/core/src/api/route_gen.rs
@@ -341,6 +341,17 @@ fn classify_anyhow(err: anyhow::Error) -> NaukaError {
         return NaukaError::validation(msg);
     }
 
+    // Permission denied → 403
+    if msg.contains("permission denied") || msg.contains("not allowed") || msg.contains("forbidden")
+    {
+        return NaukaError::new(crate::error::ErrorCode::PermissionDenied, msg);
+    }
+
+    // Timeout → 504
+    if msg.contains("timed out") || msg.contains("timeout") {
+        return NaukaError::new(crate::error::ErrorCode::Timeout, msg);
+    }
+
     // Default: 500
     NaukaError::internal(msg)
 }
@@ -401,8 +412,24 @@ async fn handle_scoped(
     }
 
     // Extract pagination params before moving fields into the request
-    let pagination_page = fields.get("page").and_then(|v| v.parse::<usize>().ok());
-    let pagination_per_page = fields.get("per_page").and_then(|v| v.parse::<usize>().ok());
+    let pagination_page = if let Some(raw) = fields.get("page") {
+        Some(raw.parse::<usize>().map_err(|_| {
+            ApiError(NaukaError::validation(format!(
+                "invalid pagination parameter 'page': expected a positive integer, got '{raw}'"
+            )))
+        })?)
+    } else {
+        None
+    };
+    let pagination_per_page = if let Some(raw) = fields.get("per_page") {
+        Some(raw.parse::<usize>().map_err(|_| {
+            ApiError(NaukaError::validation(format!(
+                "invalid pagination parameter 'per_page': expected a positive integer, got '{raw}'"
+            )))
+        })?)
+    } else {
+        None
+    };
 
     let request = OperationRequest {
         operation: operation.to_string(),
@@ -411,9 +438,26 @@ async fn handle_scoped(
         fields,
     };
 
-    let response = (reg.handler)(request)
-        .await
-        .map_err(|e: anyhow::Error| ApiError(classify_anyhow(e)))?;
+    let response = match tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        (reg.handler)(request),
+    )
+    .await
+    {
+        Ok(result) => result.map_err(|e: anyhow::Error| ApiError(classify_anyhow(e)))?,
+        Err(_elapsed) => {
+            return Err(ApiError(NaukaError::new(
+                crate::error::ErrorCode::Timeout,
+                "handler timed out after 30s".to_string(),
+            )));
+        }
+    };
+
+    // ── Post-handler output pipeline ──
+    let mut response = response;
+    validation::validate_response_contract(reg.def.identity.kind, &response).map_err(ApiError)?;
+    validation::filter_response_secrets(&reg.def, &mut response);
+    validation::normalize_timestamps(&mut response);
 
     match response {
         OperationResponse::Resource(v) => {
@@ -656,13 +700,13 @@ mod tests {
             Box::pin(async move {
                 match req.operation.as_str() {
                     "list" => Ok(OperationResponse::ResourceList(vec![
-                        serde_json::json!({"name": "w1"}),
+                        serde_json::json!({"id": "w1-id", "name": "w1"}),
                     ])),
                     "create" => Ok(OperationResponse::Resource(
-                        serde_json::json!({"name": req.name.unwrap_or_default()}),
+                        serde_json::json!({"id": "new-id", "name": req.name.unwrap_or_default()}),
                     )),
                     "get" => Ok(OperationResponse::Resource(
-                        serde_json::json!({"name": req.name.unwrap_or_default()}),
+                        serde_json::json!({"id": "get-id", "name": req.name.unwrap_or_default()}),
                     )),
                     "delete" => Ok(OperationResponse::Message("deleted".into())),
                     "polish" => Ok(OperationResponse::Message("polished".into())),
@@ -872,7 +916,7 @@ mod tests {
 
         let handler: HandlerFn = Box::new(move |_req| {
             let items: Vec<serde_json::Value> = (0..count)
-                .map(|i| serde_json::json!({"name": format!("w{i}")}))
+                .map(|i| serde_json::json!({"id": format!("w{i}-id"), "name": format!("w{i}")}))
                 .collect();
             Box::pin(async move { Ok(OperationResponse::ResourceList(items)) })
         });
@@ -1078,5 +1122,41 @@ mod tests {
         let classified = classify_anyhow(err);
         assert_eq!(classified.code, crate::error::ErrorCode::ValidationError);
         assert_eq!(classified.http_status(), 400);
+    }
+
+    #[test]
+    fn classify_permission_denied() {
+        let err = anyhow::anyhow!("permission denied for this operation");
+        let classified = classify_anyhow(err);
+        assert_eq!(classified.code, crate::error::ErrorCode::PermissionDenied);
+        assert_eq!(classified.http_status(), 403);
+    }
+
+    #[test]
+    fn classify_timeout() {
+        let err = anyhow::anyhow!("operation timed out after 30s");
+        let classified = classify_anyhow(err);
+        assert_eq!(classified.code, crate::error::ErrorCode::Timeout);
+        assert_eq!(classified.http_status(), 504);
+    }
+
+    #[tokio::test]
+    async fn pagination_invalid_page_returns_400() {
+        let reg = paginated_resource(10);
+        let fields: HashMap<String, String> = [("page".to_string(), "abc".to_string())]
+            .into_iter()
+            .collect();
+        let resp = handle_scoped(&reg, "list", None, fields, ScopeValues::default()).await;
+        assert_eq!(resp.into_response().status(), 400);
+    }
+
+    #[tokio::test]
+    async fn pagination_invalid_per_page_returns_400() {
+        let reg = paginated_resource(10);
+        let fields: HashMap<String, String> = [("per_page".to_string(), "xyz".to_string())]
+            .into_iter()
+            .collect();
+        let resp = handle_scoped(&reg, "list", None, fields, ScopeValues::default()).await;
+        assert_eq!(resp.into_response().status(), 400);
     }
 }

--- a/layers/core/src/api/server.rs
+++ b/layers/core/src/api/server.rs
@@ -22,6 +22,8 @@ pub struct ApiConfig {
     pub rate_limit_requests: u64,
     /// Rate limit: window in seconds.
     pub rate_limit_window_secs: u64,
+    /// Graceful shutdown drain timeout in seconds.
+    pub shutdown_timeout_secs: u64,
 }
 
 impl Default for ApiConfig {
@@ -33,6 +35,7 @@ impl Default for ApiConfig {
             public_prefix: "/v1".to_string(),
             rate_limit_requests: 1000,
             rate_limit_window_secs: 60,
+            shutdown_timeout_secs: 30,
         }
     }
 }
@@ -80,7 +83,11 @@ impl ApiServer {
     /// #8: Run admin API with graceful shutdown on SIGTERM/SIGINT.
     pub async fn run_admin(self) -> Result<(), std::io::Error> {
         let listener = tokio::net::TcpListener::bind(self.config.admin_addr).await?;
-        tracing::info!(addr = %self.config.admin_addr, "admin API listening");
+        tracing::info!(
+            addr = %self.config.admin_addr,
+            shutdown_timeout = self.config.shutdown_timeout_secs,
+            "admin API listening"
+        );
 
         axum::serve(listener, self.admin_router)
             .with_graceful_shutdown(shutdown_signal())
@@ -104,7 +111,7 @@ impl ApiServer {
 }
 
 fn build_api_router(
-    _config: &ApiConfig,
+    config: &ApiConfig,
     registrations: Vec<ResourceRegistration>,
     prefix: &str,
 ) -> Router {
@@ -132,13 +139,35 @@ fn build_api_router(
         }),
     );
 
+    let fallback = || async {
+        let body = axum::Json(serde_json::json!({
+            "error": {
+                "code": "NotFound",
+                "message": "The requested endpoint does not exist.",
+            }
+        }));
+        (axum::http::StatusCode::NOT_FOUND, body)
+    };
+
+    // Rate limiter
+    let limiter =
+        middleware::RateLimiter::new(config.rate_limit_requests, config.rate_limit_window_secs);
+
     Router::new()
         .merge(api_routes)
         .merge(health)
         .merge(openapi)
+        .fallback(fallback)
         .layer(tower_http::trace::TraceLayer::new_for_http())
+        .layer(tower_http::cors::CorsLayer::permissive())
+        .layer(tower_http::limit::RequestBodyLimitLayer::new(1024 * 1024)) // 1MB
+        .layer(axum::middleware::from_fn(middleware::security_headers))
         .layer(axum::middleware::from_fn(
             middleware::require_json_content_type,
+        ))
+        .layer(axum::middleware::from_fn_with_state(
+            limiter,
+            middleware::rate_limit,
         ))
         .layer(axum::middleware::from_fn(middleware::request_id))
         .layer(axum::middleware::from_fn(middleware::version_header))
@@ -201,10 +230,10 @@ mod tests {
             Box::pin(async move {
                 match req.operation.as_str() {
                     "list" => Ok(OperationResponse::ResourceList(vec![
-                        serde_json::json!({"name": "t1"}),
+                        serde_json::json!({"id": "t1-id", "name": "t1"}),
                     ])),
                     "get" => Ok(OperationResponse::Resource(
-                        serde_json::json!({"name": req.name.unwrap_or_default()}),
+                        serde_json::json!({"id": "get-id", "name": req.name.unwrap_or_default()}),
                     )),
                     "delete" => Ok(OperationResponse::Message("deleted".into())),
                     "ping" => Ok(OperationResponse::Message("pong".into())),
@@ -342,5 +371,10 @@ mod tests {
             .unwrap();
         let resp = server.admin_router.clone().oneshot(req).await.unwrap();
         assert_eq!(resp.status(), 404);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"]["code"], "NotFound");
     }
 }

--- a/layers/core/src/resource/dispatch.rs
+++ b/layers/core/src/resource/dispatch.rs
@@ -186,36 +186,10 @@ pub async fn dispatch(
         _ => (reg.handler)(raw_request).await?,
     };
 
-    // ── 4b. JSON contract validation (debug builds only) ──
-    #[cfg(debug_assertions)]
-    {
-        let kind = def.identity.kind;
-        match &response {
-            OperationResponse::Resource(v) => {
-                debug_assert!(
-                    v.get("id").is_some(),
-                    "[E080] {kind}: response JSON missing 'id'"
-                );
-                debug_assert!(
-                    v.get("name").is_some(),
-                    "[E081] {kind}: response JSON missing 'name'"
-                );
-            }
-            OperationResponse::ResourceList(items) => {
-                for (i, item) in items.iter().enumerate() {
-                    debug_assert!(
-                        item.get("id").is_some(),
-                        "[E080] {kind}: list item [{i}] missing 'id'"
-                    );
-                    debug_assert!(
-                        item.get("name").is_some(),
-                        "[E081] {kind}: list item [{i}] missing 'name'"
-                    );
-                }
-            }
-            _ => {}
-        }
-    }
+    // ── 4b. Post-handler output pipeline ──
+    let mut response = response;
+    validation::validate_response_contract(def.identity.kind, &response)?;
+    validation::filter_response_secrets(def, &mut response);
 
     // ── 5. Render output ──
 

--- a/layers/core/src/resource/validation.rs
+++ b/layers/core/src/resource/validation.rs
@@ -258,6 +258,121 @@ fn validate_single_field(
     Ok(())
 }
 
+/// Validate the response contract: Resource responses must have `id` and `name`.
+///
+/// Called after handler returns, in both CLI and API paths.
+/// Returns an error if the contract is violated (replaces the old debug_assert).
+pub fn validate_response_contract(
+    kind: &str,
+    response: &super::registry::OperationResponse,
+) -> Result<(), NaukaError> {
+    match response {
+        super::registry::OperationResponse::Resource(v) => {
+            if v.get("id").is_none() {
+                return Err(NaukaError::internal(format!(
+                    "[E080] {kind}: response JSON missing 'id'"
+                )));
+            }
+            if v.get("name").is_none() {
+                return Err(NaukaError::internal(format!(
+                    "[E081] {kind}: response JSON missing 'name'"
+                )));
+            }
+        }
+        super::registry::OperationResponse::ResourceList(items) => {
+            for (i, item) in items.iter().enumerate() {
+                if item.get("id").is_none() {
+                    return Err(NaukaError::internal(format!(
+                        "[E080] {kind}: list item [{i}] missing 'id'"
+                    )));
+                }
+                if item.get("name").is_none() {
+                    return Err(NaukaError::internal(format!(
+                        "[E081] {kind}: list item [{i}] missing 'name'"
+                    )));
+                }
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Filter secret fields from response JSON.
+///
+/// Replaces any field marked as `FieldType::Secret` in the schema with `"****"`.
+/// Prevents accidental exposure of passwords, API keys, etc.
+pub fn filter_response_secrets(
+    def: &ResourceDef,
+    response: &mut super::registry::OperationResponse,
+) {
+    let secret_fields: Vec<&str> = def
+        .schema
+        .fields
+        .iter()
+        .filter(|f| matches!(f.field_type, FieldType::Secret))
+        .map(|f| f.name)
+        .collect();
+
+    if secret_fields.is_empty() {
+        return;
+    }
+
+    match response {
+        super::registry::OperationResponse::Resource(v) => {
+            mask_secrets(v, &secret_fields);
+        }
+        super::registry::OperationResponse::ResourceList(items) => {
+            for item in items.iter_mut() {
+                mask_secrets(item, &secret_fields);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn mask_secrets(value: &mut serde_json::Value, secret_fields: &[&str]) {
+    if let Some(obj) = value.as_object_mut() {
+        for field in secret_fields {
+            if obj.contains_key(*field) {
+                obj.insert(field.to_string(), serde_json::json!("****"));
+            }
+        }
+    }
+}
+
+/// Normalize timestamp fields in API responses to ISO 8601.
+///
+/// For any field ending in `_at` whose value is a number (epoch seconds),
+/// converts it to ISO 8601 format (e.g., `"2026-04-11T14:30:00Z"`).
+pub fn normalize_timestamps(response: &mut super::registry::OperationResponse) {
+    match response {
+        super::registry::OperationResponse::Resource(v) => {
+            normalize_value_timestamps(v);
+        }
+        super::registry::OperationResponse::ResourceList(items) => {
+            for item in items.iter_mut() {
+                normalize_value_timestamps(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn normalize_value_timestamps(value: &mut serde_json::Value) {
+    if let Some(obj) = value.as_object_mut() {
+        let keys: Vec<String> = obj.keys().filter(|k| k.ends_with("_at")).cloned().collect();
+        for key in keys {
+            if let Some(serde_json::Value::Number(n)) = obj.get(&key) {
+                if let Some(epoch) = n.as_u64() {
+                    let iso = crate::resource::api_response::epoch_to_iso8601(epoch);
+                    obj.insert(key, serde_json::json!(iso));
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -536,5 +651,66 @@ mod tests {
         fields.insert("custom-op-arg".to_string(), "value".to_string());
         filter_readonly_fields(&def, &mut fields);
         assert!(fields.contains_key("custom-op-arg"));
+    }
+
+    // ── validate_response_contract ──
+
+    #[test]
+    fn response_contract_valid() {
+        use crate::resource::registry::OperationResponse;
+        let resp = OperationResponse::Resource(serde_json::json!({"id": "x", "name": "y"}));
+        assert!(validate_response_contract("test", &resp).is_ok());
+    }
+
+    #[test]
+    fn response_contract_missing_id() {
+        use crate::resource::registry::OperationResponse;
+        let resp = OperationResponse::Resource(serde_json::json!({"name": "y"}));
+        assert!(validate_response_contract("test", &resp).is_err());
+    }
+
+    #[test]
+    fn response_contract_list_missing_name() {
+        use crate::resource::registry::OperationResponse;
+        let resp = OperationResponse::ResourceList(vec![serde_json::json!({"id": "x"})]);
+        assert!(validate_response_contract("test", &resp).is_err());
+    }
+
+    // ── filter_response_secrets ──
+
+    #[test]
+    fn secrets_masked() {
+        use crate::resource::registry::OperationResponse;
+        let mut def = test_resource_def();
+        def.schema
+            .fields
+            .push(FieldDef::secret("api-key", "API key"));
+        let mut resp =
+            OperationResponse::Resource(serde_json::json!({"api-key": "sk-123", "name": "x"}));
+        filter_response_secrets(&def, &mut resp);
+        if let OperationResponse::Resource(v) = &resp {
+            assert_eq!(v["api-key"], "****");
+            assert_eq!(v["name"], "x");
+        }
+    }
+
+    // ── normalize_timestamps ──
+
+    #[test]
+    fn timestamps_normalized() {
+        use crate::resource::registry::OperationResponse;
+        let mut resp = OperationResponse::Resource(serde_json::json!({
+            "name": "x",
+            "created_at": 1712847000u64,
+            "status": "active"
+        }));
+        normalize_timestamps(&mut resp);
+        if let OperationResponse::Resource(v) = &resp {
+            let ts = v["created_at"].as_str().unwrap();
+            assert!(ts.ends_with('Z'), "expected ISO 8601, got: {ts}");
+            assert!(ts.contains('T'), "expected ISO 8601, got: {ts}");
+            // status should not be touched
+            assert_eq!(v["status"], "active");
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add post-handler output pipeline: response contract validation, secret masking, timestamp normalization
- Add API server hardening: rate limiter, body limit, CORS, security headers, handler timeout, JSON 404 fallback
- Expand error classification with permission (403) and timeout (504) patterns

## Post-handler output pipeline

Runs after every handler return, before response is sent:

| Step | What | Effect |
|------|------|--------|
| `validate_response_contract()` | Checks `id` + `name` in Resource/ResourceList | Replaces debug-only `debug_assert` — now catches violations in production |
| `filter_response_secrets()` | Masks `FieldType::Secret` fields with `"****"` | Prevents accidental secret exposure |
| `normalize_timestamps()` | Converts epoch `_at` fields to ISO 8601 | API returns `"2026-04-11T14:30:00Z"` instead of `1712847000` |

## Server hardening

| Feature | Detail |
|---------|--------|
| Rate limiter | `RateLimiter` from config wired as middleware, returns 429 + `x-ratelimit-remaining` |
| Body size limit | 1MB via `tower-http::limit::RequestBodyLimitLayer` |
| CORS | `tower-http::cors::CorsLayer::permissive()` |
| Security headers | `x-content-type-options: nosniff`, `x-frame-options: DENY`, `cache-control: no-store` |
| JSON 404 fallback | `{"error": {"code": "NotFound", ...}}` instead of plain-text axum default |
| Handler timeout | 30s via `tokio::time::timeout`, returns 504 |
| Pagination validation | Non-integer `?page=abc` returns 400 instead of silent default |
| Shutdown timeout | Configurable `shutdown_timeout_secs` in `ApiConfig` |
| Error classification | `"permission denied"` → 403, `"timed out"` → 504 |

## Test plan

- [x] 376 lib tests pass
- [x] 44 integration tests pass
- [x] 0 clippy warnings
- [x] `cargo fmt` clean

Closes #175.