### PR TITLE
feat(P1.1): wire surrealdb with kv-surrealkv only as the prod default

### DIFF
--- a/layers/state/Cargo.toml
+++ b/layers/state/Cargo.toml
@@ -6,6 +6,14 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+# Off by default. Enable to compile the P0.3 spike binary, which needs the
+# kv-tikv backend on top of kv-surrealkv. The production build path (and CI's
+# default `cargo build -p nauka-state`) intentionally does NOT enable this —
+# Phase 1 is SurrealKV-only; kv-tikv comes back as a permanent feature in
+# Phase 2 (P2.1, sifrah/nauka#205).
+spike-tikv = ["surrealdb/kv-tikv"]
+
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
@@ -13,16 +21,19 @@ thiserror.workspace = true
 dirs = "5"
 tikv-client = "0.4"
 tokio.workspace = true
-# Force vendored OpenSSL into the build graph: surrealdb-tikv-client and the
-# existing tikv-client both pull openssl-sys via prometheus → reqwest →
-# native-tls. Without a vendored OpenSSL the musl cross-compile cannot find
-# system openssl. The workspace declaration already enables the `vendored`
-# feature.
+# Force vendored OpenSSL into the build graph: tikv-client (and, when the
+# `spike-tikv` feature is on, surrealdb-tikv-client) both pull openssl-sys via
+# prometheus → reqwest → native-tls. Without a vendored OpenSSL the musl
+# cross-compile cannot find system openssl. The workspace declaration already
+# enables the `vendored` feature. This stays until P2.16 (sifrah/nauka#220)
+# removes the legacy tikv-client.
 openssl.workspace = true
-# P0.1 spike: validate that the surrealdb SDK with kv-surrealkv + kv-tikv
-# can be linked into nauka-state and cross-compiled to musl. Not used by
-# any production code yet — that lands in P1.1 / P2.1.
-surrealdb = { version = "3.0.5", default-features = false, features = ["kv-surrealkv", "kv-tikv"] }
+# P1.1: surrealdb SDK with kv-surrealkv only. The kv-tikv backend is gated
+# behind the local `spike-tikv` feature so that production builds (the CI
+# default) do not pull surrealdb-tikv-client transitively. P2.1
+# (sifrah/nauka#205) flips kv-tikv on permanently when the cluster-side
+# integration lands.
+surrealdb = { version = "3.0.5", default-features = false, features = ["kv-surrealkv"] }
 
 [[bin]]
 name = "p0-1-spike"
@@ -31,6 +42,7 @@ path = "src/bin/p0_1_spike.rs"
 [[bin]]
 name = "p0-3-spike"
 path = "src/bin/p0_3_spike.rs"
+required-features = ["spike-tikv"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/layers/state/src/bin/p0_1_spike.rs
+++ b/layers/state/src/bin/p0_1_spike.rs
@@ -1,22 +1,25 @@
-//! Spike binary for P0.1 (#185).
+//! Spike binary for P0.1 (#185), kept around as a re-validation tool for the
+//! Phase 1 SurrealKV build chain.
 //!
-//! Goal: prove that `surrealdb` 3.0.5 with `kv-surrealkv` + `kv-tikv` features
-//! can be cross-compiled to `x86_64-unknown-linux-musl` and that the resulting
-//! binary runs on a real Hetzner Ubuntu host.
+//! Goal: prove that `surrealdb` 3.0.5 with the `kv-surrealkv` feature can be
+//! cross-compiled to `x86_64-unknown-linux-musl` and that the resulting
+//! statically-linked binary runs on a real Hetzner Ubuntu host.
 //!
 //! What this does:
 //! 1. Print build/runtime info (target, surrealdb version)
 //! 2. Open an in-process SurrealKV datastore at a temp path
 //! 3. Run a CRUD round-trip with SurrealQL
-//! 4. Confirm both code paths (`SurrealKv` engine marker + the `TiKv` import)
-//!    actually link into the binary
 //!
-//! It does NOT connect to TiKV — that's P0.3 (#187). Linking the symbol is
-//! enough to validate the build chain for the spike.
+//! Originally (P0.1) this binary also imported `surrealdb::engine::local::TiKv`
+//! purely to keep the linker symbol alive and prove both backends could
+//! coexist in the build graph. P1.1 (sifrah/nauka#191) drops `kv-tikv` from
+//! the production feature set, so the TiKv import is gone. The P0.3 spike
+//! (`p0-3-spike`) still exercises that backend, but it now requires the
+//! local `spike-tikv` feature to compile.
 
 use std::path::PathBuf;
 
-use surrealdb::engine::local::{SurrealKv, TiKv};
+use surrealdb::engine::local::SurrealKv;
 use surrealdb::types::SurrealValue;
 use surrealdb::Surreal;
 
@@ -32,12 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("target_arch    = {}", std::env::consts::ARCH);
     println!("target_os      = {}", std::env::consts::OS);
     println!("target_env     = {}", std::env::consts::FAMILY);
-    println!("surrealdb_dep  = 3.0.5 (kv-surrealkv + kv-tikv)");
-
-    // Force the TiKv marker to be referenced so the linker keeps the symbol.
-    // We don't actually open a TiKv connection (that needs a real cluster).
-    let _tikv_marker = std::any::type_name::<TiKv>();
-    println!("tikv_marker    = {_tikv_marker}");
+    println!("surrealdb_dep  = 3.0.5 (kv-surrealkv only — P1.1)");
 
     // Open a SurrealKV datastore at a temp path.
     let path: PathBuf = std::env::temp_dir().join("nauka-p0-1-spike.skv");


### PR DESCRIPTION
## Summary
- Phase 1 production build path enables only `kv-surrealkv` from the `surrealdb` crate, not `kv-tikv`.
- The previous P0.1 spike added both features at once just to validate the cross-compile chain — that was scaffolding, not the production wiring.
- The P0.3 spike binary (`p0-3-spike`) is preserved as a re-validation tool, gated behind a new local Cargo feature `spike-tikv` (`required-features = ["spike-tikv"]`).
- The default `cargo build -p nauka-state` no longer pulls `surrealdb-tikv-client` / `kv-tikv` into the dep graph at all (verified with `cargo tree`).
- P2.1 (#205) flips `kv-tikv` back on permanently when the production cluster integration lands.

## Acceptance criteria — all met
- [x] `surrealdb = { version = "3.0.5", default-features = false, features = ["kv-surrealkv"] }` added (literal match in `layers/state/Cargo.toml`)
- [x] `cargo build -p nauka-state` passes (locally + Hetzner)
- [x] No transitive features pulled accidentally — verified:
  - `cargo tree -p nauka-state -e features | grep surrealdb` shows only `surrealdb feature "kv-surrealkv"`
  - `cargo tree -p nauka-state | grep -E 'surrealdb-tikv-client|kv-tikv'` returns nothing
  - `cargo build -p nauka-state --bin p0-3-spike` correctly errors with `requires the features: spike-tikv`
  - `cargo build -p nauka-state --features spike-tikv --bin p0-3-spike` succeeds

## Test plan
- [x] Native build: `cargo build -p nauka-state` clean
- [x] `cargo test -p nauka-state` — 14 existing tests still pass
- [x] `cargo clippy -p nauka-state --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Cross-compile: `cargo build --target x86_64-unknown-linux-musl -p nauka-state --bin p0-1-spike --release` — 53MB statically-linked binary (down from 61MB after dropping the TiKV client)
- [x] Hetzner test: `scp` to `node-1`, `ldd` reports `statically linked`, binary completes the SurrealKV CRUD round-trip successfully
- [x] Verified that `cargo build -p nauka-state --features spike-tikv --bin p0-3-spike` still compiles, so the spike re-validation path remains available

## Files touched
- `layers/state/Cargo.toml` — drop `kv-tikv` from `surrealdb` features, add local `spike-tikv` feature, gate `p0-3-spike` behind it
- `layers/state/src/bin/p0_1_spike.rs` — drop the linker-symbol-only `TiKv` import, update doc comment + header

## Files NOT touched
- `Cargo.lock` — unchanged, because the workspace-level feature DAG still allows `surrealdb-tikv-client` to be reached via the `spike-tikv` opt-in
- `layers/state/src/bin/p0_3_spike.rs` — unchanged, still works under the spike-tikv feature
- `layers/state/src/lib.rs` / `cluster.rs` — out of scope for this issue, P1.2 (#192) introduces the actual `EmbeddedDb` wrapper

Closes #191.
Epic: #183