### PR TITLE
feat(P1.2): introduce EmbeddedDb wrapper for SurrealKV bootstrap state

### DIFF
--- a/layers/state/src/bin/p0_1_spike.rs
+++ b/layers/state/src/bin/p0_1_spike.rs
@@ -1,27 +1,31 @@
-//! Spike binary for P0.1 (#185), kept around as a re-validation tool for the
-//! Phase 1 SurrealKV build chain.
+//! Spike binary for P0.1 (sifrah/nauka#185), repurposed in P1.2 to be the
+//! Hetzner-side smoke test for [`nauka_state::EmbeddedDb`].
 //!
-//! Goal: prove that `surrealdb` 3.0.5 with the `kv-surrealkv` feature can be
-//! cross-compiled to `x86_64-unknown-linux-musl` and that the resulting
-//! statically-linked binary runs on a real Hetzner Ubuntu host.
+//! The spike's purpose evolves with each phase that touches the same code:
 //!
-//! What this does:
-//! 1. Print build/runtime info (target, surrealdb version)
-//! 2. Open an in-process SurrealKV datastore at a temp path
-//! 3. Run a CRUD round-trip with SurrealQL
+//! - **P0.1**: prove that `surrealdb` 3.0.5 with `kv-surrealkv` (+ `kv-tikv`)
+//!   cross-compiles to `x86_64-unknown-linux-musl` and runs as a
+//!   statically-linked binary on a real Hetzner Ubuntu host. ✅ done.
+//! - **P1.1**: drop `kv-tikv` from the production feature set. ✅ done.
+//! - **P1.2** (this version): exercise the new [`EmbeddedDb`] wrapper
+//!   end-to-end on Hetzner — open at a temp path, run a CRUD round-trip
+//!   via `db.client()`, shut down cleanly. The wrapper is the production
+//!   code path that all of Phase 1 builds on, so an actual run on Hetzner
+//!   is the strongest signal that the cross-compile + the wrapper + the
+//!   SDK still all agree about how to talk to SurrealKV.
 //!
-//! Originally (P0.1) this binary also imported `surrealdb::engine::local::TiKv`
-//! purely to keep the linker symbol alive and prove both backends could
-//! coexist in the build graph. P1.1 (sifrah/nauka#191) drops `kv-tikv` from
-//! the production feature set, so the TiKv import is gone. The P0.3 spike
-//! (`p0-3-spike`) still exercises that backend, but it now requires the
-//! local `spike-tikv` feature to compile.
+//! What this binary does on each run:
+//! 1. Print build / runtime info
+//! 2. `EmbeddedDb::open` at `$TMPDIR/nauka-p0-1-spike.skv`
+//! 3. CRUD round-trip via the wrapped client (`create`, `select id`,
+//!    `select all`)
+//! 4. `EmbeddedDb::shutdown`
+//! 5. Wipe the temp datastore so re-runs are clean
 
 use std::path::PathBuf;
 
-use surrealdb::engine::local::SurrealKv;
+use nauka_state::EmbeddedDb;
 use surrealdb::types::SurrealValue;
-use surrealdb::Surreal;
 
 #[derive(Debug, SurrealValue)]
 struct SpikeRecord {
@@ -31,38 +35,40 @@ struct SpikeRecord {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("== nauka p0-1 spike ==");
+    println!("== nauka p0-1 spike (P1.2 — EmbeddedDb wrapper) ==");
     println!("target_arch    = {}", std::env::consts::ARCH);
     println!("target_os      = {}", std::env::consts::OS);
     println!("target_env     = {}", std::env::consts::FAMILY);
-    println!("surrealdb_dep  = 3.0.5 (kv-surrealkv only — P1.1)");
+    println!("surrealdb_dep  = 3.0.5 (kv-surrealkv only)");
 
-    // Open a SurrealKV datastore at a temp path.
+    // Open the wrapper at a temp path.
     let path: PathBuf = std::env::temp_dir().join("nauka-p0-1-spike.skv");
-    let path_str = path.to_string_lossy().into_owned();
-    println!("skv_path       = {path_str}");
+    println!("skv_path       = {}", path.display());
 
-    let db = Surreal::new::<SurrealKv>(path_str.as_str()).await?;
-    db.use_ns("nauka").use_db("spike").await?;
+    let db = EmbeddedDb::open(&path).await?;
+    println!("ns/db          = nauka/bootstrap (auto-selected by EmbeddedDb::open)");
 
-    // Round-trip: create → select.
-    let created: Option<SpikeRecord> = db
+    // Round-trip via the underlying SDK client.
+    let client = db.client();
+
+    let created: Option<SpikeRecord> = client
         .create(("spike_record", "first"))
         .content(SpikeRecord {
             name: "p0-1".into(),
             answer: 42,
         })
         .await?;
-    println!("created        = {:?}", created);
+    println!("created        = {created:?}");
 
-    let fetched: Option<SpikeRecord> = db.select(("spike_record", "first")).await?;
-    println!("fetched        = {:?}", fetched);
+    let fetched: Option<SpikeRecord> = client.select(("spike_record", "first")).await?;
+    println!("fetched        = {fetched:?}");
 
-    let all: Vec<SpikeRecord> = db.select("spike_record").await?;
+    let all: Vec<SpikeRecord> = client.select("spike_record").await?;
     println!("all_count      = {}", all.len());
 
-    // Cleanup the temp dir so reruns are clean.
-    drop(db);
+    // Explicit shutdown via the wrapper, then wipe the datastore directory
+    // so re-running the spike on the same Hetzner box is idempotent.
+    db.shutdown().await?;
     let _ = std::fs::remove_dir_all(&path);
 
     println!("== p0-1 spike OK ==");

--- a/layers/state/src/embedded.rs
+++ b/layers/state/src/embedded.rs
@@ -1,0 +1,175 @@
+//! Embedded SurrealDB wrapper used for Nauka's local bootstrap state.
+//!
+//! Wraps `surrealdb::Surreal<Db>` with a Nauka-friendly lifecycle: a single
+//! `open` constructor that creates the on-disk SurrealKV datastore at a given
+//! path and selects the `nauka` / `bootstrap` namespace/database (per ADR
+//! 0003, sifrah/nauka#190), an accessor for the underlying SDK client, and
+//! an explicit `shutdown` step.
+//!
+//! This is the long-term replacement for [`crate::LocalDb`] (the
+//! JSON-file-backed bootstrap store). The migration of every existing
+//! `LocalDb` call site is tracked by P1.10 → P1.12 (sifrah/nauka#200,
+//! sifrah/nauka#201, sifrah/nauka#202). Until those land, both backends
+//! coexist.
+//!
+//! P1.2 (sifrah/nauka#192) introduces only the wrapper struct and its
+//! lifecycle. The companion deliverables — error mapping (P1.3,
+//! sifrah/nauka#193), default-path helpers (P1.4, sifrah/nauka#194),
+//! comprehensive CRUD/persistence tests (P1.5, sifrah/nauka#195), the
+//! initial `.surql` schema (P1.6, sifrah/nauka#196), and applying that
+//! schema at open time (P1.7, sifrah/nauka#197) — each ship as their own
+//! issue.
+//!
+//! # Example
+//!
+//! ```no_run
+//! # use nauka_state::EmbeddedDb;
+//! # use std::path::Path;
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let db = EmbeddedDb::open(Path::new("/var/lib/nauka/bootstrap.skv")).await?;
+//!
+//! // Use the underlying SurrealDB SDK directly:
+//! let _: Vec<surrealdb::types::Value> = db
+//!     .client()
+//!     .query("INFO FOR DB")
+//!     .await?
+//!     .take(0)?;
+//!
+//! db.shutdown().await?;
+//! # Ok(()) }
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use surrealdb::engine::local::{Db, SurrealKv};
+use surrealdb::Surreal;
+
+use crate::{Result, StateError, BOOTSTRAP_DB, NAUKA_NS};
+
+/// Embedded SurrealDB instance, persisted to disk via the SurrealKV backend.
+///
+/// Cheap to clone: every clone shares the same underlying `Surreal<Db>`
+/// connection (which itself uses an `Arc` internally).
+#[derive(Clone)]
+pub struct EmbeddedDb {
+    inner: Surreal<Db>,
+    path: PathBuf,
+}
+
+impl EmbeddedDb {
+    /// Open (or create) the SurrealKV-backed database at `path` and select
+    /// the `nauka` / `bootstrap` namespace/database.
+    ///
+    /// The parent directory is created if it doesn't exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StateError::Io`] if the parent directory cannot be created,
+    /// or [`StateError::Database`] if SurrealDB fails to open the datastore
+    /// or to switch to the configured namespace/database.
+    pub async fn open(path: &Path) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent)?;
+            }
+        }
+
+        let path_str = path.to_string_lossy().into_owned();
+        let inner = Surreal::new::<SurrealKv>(path_str.as_str())
+            .await
+            .map_err(|e| StateError::Database(format!("open {}: {e}", path.display())))?;
+
+        inner
+            .use_ns(NAUKA_NS)
+            .use_db(BOOTSTRAP_DB)
+            .await
+            .map_err(|e| StateError::Database(format!("use ns/db: {e}")))?;
+
+        Ok(Self {
+            inner,
+            path: path.to_path_buf(),
+        })
+    }
+
+    /// Borrow the underlying SurrealDB SDK client.
+    ///
+    /// All SurrealQL queries flow through this. The wrapper does not
+    /// re-export every SDK method — call sites that need the full SDK
+    /// surface go through `db.client().query(...)` etc.
+    pub fn client(&self) -> &Surreal<Db> {
+        &self.inner
+    }
+
+    /// Path of the on-disk SurrealKV datastore.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Shut down the wrapper, dropping the SDK client.
+    ///
+    /// Dropping the inner [`Surreal<Db>`] is what actually closes the
+    /// datastore — the SurrealDB SDK's background router task exits
+    /// when its sender side goes away, and the SurrealKV engine flushes
+    /// pending writes on drop. This method exists so call sites have an
+    /// explicit, named way to do that, instead of relying on `Drop` order.
+    ///
+    /// Returns `Ok(())` once the inner client has been dropped. Future
+    /// versions may flush, fsync, or wait for outstanding tasks here, so
+    /// the signature is async + `Result` even though the body is trivial
+    /// today.
+    pub async fn shutdown(self) -> Result<()> {
+        // Explicit drop of the inner client. The compiler would do this
+        // anyway when `self` goes out of scope, but naming the step makes
+        // the intent visible at every call site.
+        drop(self.inner);
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for EmbeddedDb {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EmbeddedDb")
+            .field("path", &self.path)
+            .field("ns", &NAUKA_NS)
+            .field("db", &BOOTSTRAP_DB)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// P1.2 smoke test: open the wrapper at a temp path and shut it down.
+    ///
+    /// Comprehensive CRUD / persistence tests live in P1.5
+    /// (sifrah/nauka#195). This one only covers the lifecycle skeleton
+    /// the issue actually adds.
+    #[tokio::test]
+    async fn open_and_shutdown_smoke() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("smoke.skv");
+
+        let db = EmbeddedDb::open(&path)
+            .await
+            .expect("open should succeed at a writable temp path");
+
+        assert_eq!(db.path(), path);
+
+        // The on-disk datastore should now exist (SurrealKV creates a
+        // directory at the given path).
+        assert!(path.exists(), "datastore path should exist after open");
+
+        // Confirm the SDK client returned a usable handle by issuing a
+        // no-side-effect query.
+        let _ = db
+            .client()
+            .query("INFO FOR DB")
+            .await
+            .expect("INFO FOR DB should succeed against the freshly-opened bootstrap db");
+
+        db.shutdown()
+            .await
+            .expect("shutdown should always succeed in P1.2");
+    }
+}

--- a/layers/state/src/lib.rs
+++ b/layers/state/src/lib.rs
@@ -1,13 +1,41 @@
 #![allow(clippy::result_large_err)]
 //! State persistence for Nauka.
 //!
-//! Two backends:
-//! - **`LocalDb`** — JSON file store for bootstrap state (fabric identity, WG keys).
-//!   Works before TiKV is up. Replaces the old redb-based `LayerDb`.
-//! - **`ClusterDb`** — TiKV-backed distributed KV store for everything else
-//!   (VMs, VPCs, users, subnets, etc.). Replicated across the mesh via Raft.
+//! Three backends, in increasing order of where they live:
+//! - **`EmbeddedDb`** — embedded SurrealDB on disk via the SurrealKV backend.
+//!   Used for **bootstrap** state that must be readable before any cluster
+//!   exists (mesh identity, hypervisor identity, peers, WireGuard keys).
+//!   This is the long-term replacement for `LocalDb`.
+//! - **`LocalDb`** — legacy JSON file store. Still in use; will be retired
+//!   by P1.10–P1.12 (sifrah/nauka#200 → sifrah/nauka#202).
+//! - **`ClusterDb`** — TiKV-backed distributed raw KV store for shared state
+//!   (orgs, projects, VMs, VPCs, etc.). Will be retired by P2.16
+//!   (sifrah/nauka#220) once the SurrealDB SDK in `kv-tikv` mode (P2.x) takes
+//!   over.
 //!
-//! # Usage
+//! # SurrealDB namespace / database conventions
+//!
+//! Per ADR 0003 (sifrah/nauka#190):
+//!
+//! - Local SurrealKV: namespace `nauka`, database `bootstrap`
+//! - Distributed TiKV (Phase 2): namespace `nauka`, database `cluster`
+//!
+//! These literals are exported as the [`NAUKA_NS`], [`BOOTSTRAP_DB`], and
+//! [`CLUSTER_DB`] constants so call sites never inline the strings.
+//!
+//! # Usage — `EmbeddedDb` (SurrealKV-backed bootstrap state)
+//!
+//! ```no_run
+//! # use nauka_state::EmbeddedDb;
+//! # use std::path::Path;
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let db = EmbeddedDb::open(Path::new("/var/lib/nauka/bootstrap.skv")).await?;
+//! db.client().query("INFO FOR DB").await?;
+//! db.shutdown().await?;
+//! # Ok(()) }
+//! ```
+//!
+//! # Usage — `LocalDb` (legacy JSON, to be retired)
 //!
 //! ```no_run
 //! use nauka_state::LocalDb;
@@ -22,6 +50,7 @@
 //! ```
 
 pub mod cluster;
+pub mod embedded;
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -31,6 +60,30 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 pub use cluster::ClusterDb;
+pub use embedded::EmbeddedDb;
+
+// ═══════════════════════════════════════════════════
+// SurrealDB namespace / database constants (ADR 0003)
+// ═══════════════════════════════════════════════════
+
+/// SurrealDB namespace used by all Nauka SurrealDB instances.
+///
+/// Per ADR 0003 (sifrah/nauka#190), Nauka writes only to this single
+/// namespace. Multi-tenancy lives at the row level inside the cluster
+/// database, not at the namespace level.
+pub const NAUKA_NS: &str = "nauka";
+
+/// SurrealDB database name for the local SurrealKV-backed bootstrap state.
+///
+/// Used by [`EmbeddedDb::open`].
+pub const BOOTSTRAP_DB: &str = "bootstrap";
+
+/// SurrealDB database name for the distributed TiKV-backed cluster state.
+///
+/// Reserved for the Phase 2 TiKV-backed `EmbeddedDb` constructor (P2.2,
+/// sifrah/nauka#206). Defined here in P1.2 so the constants live in one
+/// place and the cluster-side issue can refer to the existing symbol.
+pub const CLUSTER_DB: &str = "cluster";
 
 // ═══════════════════════════════════════════════════
 // Errors


### PR DESCRIPTION
## Summary
- Adds the long-term replacement for `LocalDb`: a thin async wrapper around `surrealdb::Surreal<Db>` (SurrealKV backend) with a Nauka-friendly lifecycle and the namespace/database conventions from ADR 0003 (#190) baked in.
- Introduces `NAUKA_NS = "nauka"`, `BOOTSTRAP_DB = "bootstrap"`, `CLUSTER_DB = "cluster"` constants in `lib.rs` so call sites (and the upcoming P2.x cluster code) never inline the namespace strings.
- Repurposes the existing `p0-1-spike` binary to exercise `EmbeddedDb` end-to-end on Hetzner — the spike now opens the wrapper at a temp path, runs a CRUD round-trip via `db.client()`, and shuts down through the wrapper. Validates that the cross-compile + the wrapper + the SDK + the SurrealKV backend still all agree about how to talk to disk.

## Acceptance criteria — all met
- [x] API: `EmbeddedDb::open(path) -> Result<Self>`, `client() -> &Surreal<Db>`, `shutdown(self) -> Result<()>` (plus a `path()` accessor for diagnostics)
- [x] Auto `use_ns("nauka").use_db("bootstrap")` at open time, sourced from the new `NAUKA_NS` / `BOOTSTRAP_DB` constants
- [x] Re-exported from `lib.rs` (`pub use embedded::EmbeddedDb;`)
- [x] Module documented with a `no_run` doctest example, plus an additional usage section in `lib.rs` showing both the new and the legacy backends in the order they're being phased in/out

## Out of scope (each tracked separately)
- **P1.3 (#193)** — `surrealdb::Error` → `StateError` mapping with proper variants (`NotFound`, `Schema`, etc.). For now, errors are converted via `format!` into `StateError::Database`.
- **P1.4 (#194)** — `nauka_db_path()` helper for CLI vs service mode default paths.
- **P1.5 (#195)** — comprehensive CRUD / persistence / multi-table / concurrent-clones / error-path test suite. This PR adds only one smoke test (`open_and_shutdown_smoke`) covering the lifecycle skeleton.
- **P1.6 (#196)** — initial `bootstrap.surql` schema (mesh, hypervisor, peer, wg_key tables).
- **P1.7 (#197)** — applying that schema at open time via `include_str!` + `db.query`.

## Test plan
- [x] `cargo build -p nauka-state` clean
- [x] `cargo test -p nauka-state` — **15 tests pass** (14 existing LocalDb tests + 1 new `embedded::tests::open_and_shutdown_smoke`)
- [x] `cargo test -p nauka-state` doctests — 4 pass (lib.rs × 2, embedded.rs, cluster.rs)
- [x] `cargo clippy -p nauka-state --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Cross-compile: `cargo build --target x86_64-unknown-linux-musl -p nauka-state --bin p0-1-spike --release` — clean
- [x] **Hetzner test** on `node-1`: `scp` the spike binary, `ldd` reports `statically linked`, the spike runs the full EmbeddedDb lifecycle (open → CRUD round-trip via `db.client()` → shutdown) and exits 0:
  ```
  == nauka p0-1 spike (P1.2 — EmbeddedDb wrapper) ==
  surrealdb_dep  = 3.0.5 (kv-surrealkv only)
  ns/db          = nauka/bootstrap (auto-selected by EmbeddedDb::open)
  created        = Some(SpikeRecord { name: "p0-1", answer: 42 })
  fetched        = Some(SpikeRecord { name: "p0-1", answer: 42 })
  all_count      = 1
  == p0-1 spike OK ==
  ```

## Files touched
- `layers/state/src/embedded.rs` — **new**: `EmbeddedDb` wrapper struct, lifecycle methods, module docs, smoke test
- `layers/state/src/lib.rs` — declare the `embedded` module, add the three constants, re-export `EmbeddedDb`, refresh the module-level docs to cover the three backends in their phase order
- `layers/state/src/bin/p0_1_spike.rs` — the spike now goes through `EmbeddedDb` instead of opening `Surreal::new::<SurrealKv>` directly

## Files NOT touched
- `layers/state/src/lib.rs` `LocalDb` impl block — unchanged. Both backends coexist until P1.10–P1.12 (#200 / #201 / #202) migrate the call sites and P1.12 deletes the legacy code.
- `layers/state/Cargo.toml` — no dep change, the `surrealdb` crate is already in place from P1.1 (#191).

Closes #192.
Epic: #183