### PR TITLE
feat(P1.3): map surrealdb errors into StateError variants

### DIFF
--- a/layers/state/src/embedded.rs
+++ b/layers/state/src/embedded.rs
@@ -44,7 +44,7 @@ use std::path::{Path, PathBuf};
 use surrealdb::engine::local::{Db, SurrealKv};
 use surrealdb::Surreal;
 
-use crate::{Result, StateError, BOOTSTRAP_DB, NAUKA_NS};
+use crate::{Result, BOOTSTRAP_DB, NAUKA_NS};
 
 /// Embedded SurrealDB instance, persisted to disk via the SurrealKV backend.
 ///
@@ -65,8 +65,11 @@ impl EmbeddedDb {
     /// # Errors
     ///
     /// Returns [`StateError::Io`] if the parent directory cannot be created,
-    /// or [`StateError::Database`] if SurrealDB fails to open the datastore
-    /// or to switch to the configured namespace/database.
+    /// or one of [`StateError::NotFound`] / [`StateError::Schema`] /
+    /// [`StateError::Database`] (depending on the underlying SurrealDB
+    /// failure mode) if SurrealDB cannot open the datastore or switch to
+    /// the configured namespace/database. The classification is done by the
+    /// `From<surrealdb::Error>` impl in `lib.rs` (P1.3, sifrah/nauka#193).
     pub async fn open(path: &Path) -> Result<Self> {
         if let Some(parent) = path.parent() {
             if !parent.as_os_str().is_empty() {
@@ -75,15 +78,9 @@ impl EmbeddedDb {
         }
 
         let path_str = path.to_string_lossy().into_owned();
-        let inner = Surreal::new::<SurrealKv>(path_str.as_str())
-            .await
-            .map_err(|e| StateError::Database(format!("open {}: {e}", path.display())))?;
+        let inner = Surreal::new::<SurrealKv>(path_str.as_str()).await?;
 
-        inner
-            .use_ns(NAUKA_NS)
-            .use_db(BOOTSTRAP_DB)
-            .await
-            .map_err(|e| StateError::Database(format!("use ns/db: {e}")))?;
+        inner.use_ns(NAUKA_NS).use_db(BOOTSTRAP_DB).await?;
 
         Ok(Self {
             inner,

--- a/layers/state/src/lib.rs
+++ b/layers/state/src/lib.rs
@@ -89,14 +89,69 @@ pub const CLUSTER_DB: &str = "cluster";
 // Errors
 // ═══════════════════════════════════════════════════
 
+/// Error type returned by every fallible nauka-state operation.
+///
+/// Variants are deliberately coarse-grained: callers either care about the
+/// specific failure mode (e.g. `NotFound` vs everything else) or they
+/// propagate the error opaquely. Anything finer than these four variants
+/// stays in the inner message string.
 #[derive(Debug, thiserror::Error)]
 pub enum StateError {
+    /// A SurrealDB-side or generic backend error: connection failures,
+    /// query errors, internal engine errors, anything that does not fit
+    /// the more specific variants below.
     #[error("database error: {0}")]
     Database(String),
+
+    /// A schema-level error: a `DEFINE TABLE` constraint was violated, an
+    /// `ASSERT` clause failed, a unique index conflicted, a SCHEMAFULL field
+    /// type mismatched, etc. The inner string is the human-readable detail.
+    ///
+    /// Mapped from `surrealdb::Error` variants where the engine reports
+    /// `is_validation()` (parse / invalid params / SCHEMAFULL violations) or
+    /// `is_already_exists()` (unique-index conflicts during writes).
+    #[error("schema error: {0}")]
+    Schema(String),
+
+    /// A "record / table / namespace / database does not exist" error.
+    ///
+    /// Mapped from `surrealdb::Error::is_not_found()`.
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    /// A serde / JSON serialization error from the legacy `LocalDb` and
+    /// `ClusterDb` paths. Will go away when those layers are deleted in
+    /// P1.12 (sifrah/nauka#202) and P2.16 (sifrah/nauka#220).
     #[error("serialization error: {0}")]
     Serialization(String),
+
+    /// A filesystem-level error.
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+}
+
+impl From<surrealdb::Error> for StateError {
+    /// Best-effort classification of `surrealdb::Error` into the right
+    /// `StateError` variant.
+    ///
+    /// The mapping is conservative: only `is_not_found()`, `is_validation()`,
+    /// and `is_already_exists()` get specific variants. Everything else
+    /// (query errors, connection errors, internal errors, thrown errors,
+    /// not-allowed, configuration, serialization-on-the-wire) becomes
+    /// `Database` because callers shouldn't need to distinguish them — they
+    /// either want to know "did the record exist?" / "did the schema
+    /// reject this?" or they propagate the error opaquely.
+    fn from(err: surrealdb::Error) -> Self {
+        let msg = format!("{err}");
+        let details = err.details();
+        if details.is_not_found() {
+            StateError::NotFound(msg)
+        } else if details.is_validation() || details.is_already_exists() {
+            StateError::Schema(msg)
+        } else {
+            StateError::Database(msg)
+        }
+    }
 }
 
 pub type Result<T> = std::result::Result<T, StateError>;
@@ -382,5 +437,102 @@ mod tests {
         let db2 = db.clone();
         let val: Option<String> = db2.get("k", "v").unwrap();
         assert_eq!(val, Some("value".into()));
+    }
+
+    // ─── Error mapping (P1.3, sifrah/nauka#193) ──────────────────────
+
+    #[test]
+    fn error_mapping_not_found() {
+        // surrealdb::Error::not_found is the canonical "record/table/ns/db
+        // does not exist" constructor. It must round-trip into our
+        // StateError::NotFound variant.
+        let surreal_err =
+            surrealdb::Error::not_found("record `vm:does_not_exist`".to_string(), None);
+        let state_err: StateError = surreal_err.into();
+        assert!(
+            matches!(state_err, StateError::NotFound(_)),
+            "expected NotFound, got: {state_err:?}"
+        );
+    }
+
+    #[test]
+    fn error_mapping_validation_to_schema() {
+        // SCHEMAFULL constraint failures, parse errors, and ASSERT failures
+        // all surface as `Error::validation`. They map to StateError::Schema
+        // because the caller's recourse is "fix the schema or the input",
+        // not "retry against the backend".
+        let surreal_err =
+            surrealdb::Error::validation("DEFINE FIELD ... ASSERT failed".to_string(), None);
+        let state_err: StateError = surreal_err.into();
+        assert!(
+            matches!(state_err, StateError::Schema(_)),
+            "expected Schema, got: {state_err:?}"
+        );
+    }
+
+    #[test]
+    fn error_mapping_already_exists_to_schema() {
+        // Unique-index conflicts on writes are also schema-level signals
+        // for the caller (the constraint exists, the input violates it).
+        let surreal_err =
+            surrealdb::Error::already_exists("unique index `vm_name` violated".to_string(), None);
+        let state_err: StateError = surreal_err.into();
+        assert!(
+            matches!(state_err, StateError::Schema(_)),
+            "expected Schema, got: {state_err:?}"
+        );
+    }
+
+    #[test]
+    fn error_mapping_internal_to_database() {
+        // Internal/connection/query/etc. errors all collapse to Database.
+        // Internal is the most "catch-all" of the surrealdb variants and
+        // is the right canary for the default-mapping path.
+        let surreal_err = surrealdb::Error::internal("transaction conflict".to_string());
+        let state_err: StateError = surreal_err.into();
+        assert!(
+            matches!(state_err, StateError::Database(_)),
+            "expected Database, got: {state_err:?}"
+        );
+    }
+
+    #[test]
+    fn error_mapping_connection_to_database() {
+        // Connection errors are operationally distinct ("the cluster is
+        // gone") but the call site doesn't get a different recovery path
+        // — it has to retry or surface the error to the user. Database
+        // is the right bucket.
+        let surreal_err = surrealdb::Error::connection("router uninitialised".to_string(), None);
+        let state_err: StateError = surreal_err.into();
+        assert!(
+            matches!(state_err, StateError::Database(_)),
+            "expected Database, got: {state_err:?}"
+        );
+    }
+
+    #[test]
+    fn error_mapping_question_mark_via_into() {
+        // Sanity check that the `?` operator picks up the From impl
+        // automatically (i.e. that it's a `From`, not a one-off helper).
+        fn returns_state_result() -> Result<()> {
+            Err(surrealdb::Error::not_found("missing".to_string(), None))?;
+            Ok(())
+        }
+        let err = returns_state_result().unwrap_err();
+        assert!(matches!(err, StateError::NotFound(_)));
+    }
+
+    #[test]
+    fn error_mapping_preserves_message() {
+        // The inner String of each variant should carry the original
+        // message so logs and CLI output stay readable.
+        let surreal_err =
+            surrealdb::Error::not_found("record `vm:abc` does not exist".to_string(), None);
+        let state_err: StateError = surreal_err.into();
+        let rendered = format!("{state_err}");
+        assert!(
+            rendered.contains("vm:abc"),
+            "rendered error should keep the original detail, got: {rendered}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Adds two new `StateError` variants — `Schema` and `NotFound` — alongside the existing `Database` / `Serialization` / `Io`.
- Adds a `From<surrealdb::Error> for StateError` impl that classifies SDK errors into the right bucket so call sites get useful pattern-matching without inspecting message strings.
- Refactors `EmbeddedDb::open` to use `?` (which now picks up the new `From` automatically) instead of the manual `map_err(|e| StateError::Database(format!(...)))` placeholder from P1.2 (#192).

## Mapping rules (best-effort, conservative)

| `surrealdb::Error` | → | `StateError` |
|---|---|---|
| `err.details().is_not_found()` | → | `NotFound` |
| `err.details().is_validation()` | → | `Schema` |
| `err.details().is_already_exists()` | → | `Schema` |
| anything else (`Internal`, `Connection`, `Query`, `NotAllowed`, `Configuration`, `Serialization`, `Thrown`) | → | `Database` (catch-all) |

The classification uses the **public** `is_*()` methods on `surrealdb_types::ErrorDetails` so it stays robust across SurrealDB point releases — we don't pattern-match on private variant shapes.

## Acceptance criteria — all met
- [x] Variants `StateError::Database`, `StateError::NotFound`, `StateError::Schema` (Database existed already, the other two are new)
- [x] `From<surrealdb::Error> for StateError` impl
- [x] Tests for error mapping (7 new tests, all passing)

## Test plan
- [x] `cargo test -p nauka-state` — **22 tests pass** (15 existing + 7 new)
  - `error_mapping_not_found`
  - `error_mapping_validation_to_schema`
  - `error_mapping_already_exists_to_schema`
  - `error_mapping_internal_to_database`
  - `error_mapping_connection_to_database`
  - `error_mapping_question_mark_via_into` — sanity check that `?` picks up the `From` automatically
  - `error_mapping_preserves_message` — the original detail string survives the conversion (checked via `format!("{state_err}")`)
- [x] `cargo clippy -p nauka-state --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Cross-compile musl x86_64 — incremental 2.20s
- [x] Hetzner test on `node-1`: spike binary completes the EmbeddedDb CRUD round-trip via the new error path, output unchanged from P1.2

## Files touched
- `layers/state/src/lib.rs` — add `Schema` + `NotFound` variants, add `From<surrealdb::Error>` impl, add 7 mapping tests
- `layers/state/src/embedded.rs` — refactor `open` to use `?` instead of `map_err`, drop the now-unused `StateError` import, update the doc comment

## Files NOT touched
- `Cargo.toml` — no dep change
- `cluster.rs` / `LocalDb` — these still produce their own legacy `StateError::Database` strings; they're going away in P1.12 (#202) and P2.16 (#220) so refactoring them now is wasted effort.

Closes #193.
Epic: #183