### PR TITLE
feat(P1.6): bootstrap.surql schema for the local SurrealKV instance

### DIFF
--- a/layers/state/schemas/bootstrap.surql
+++ b/layers/state/schemas/bootstrap.surql
@@ -1,0 +1,148 @@
+-- ============================================================================
+-- Nauka — bootstrap state schema
+-- ============================================================================
+-- Target: nauka / bootstrap (EmbeddedDb<SurrealKv>)
+--
+-- This is the schema for the **local, per-node** SurrealKV-backed database
+-- that holds everything Nauka needs to read *before* the cluster TiKV is up:
+-- mesh identity, this node's hypervisor identity, peer list, WireGuard keys.
+--
+-- It is the schema-driven replacement for the JSON store used by the legacy
+-- LocalDb. P1.7 (sifrah/nauka#197) wires this file into EmbeddedDb::open
+-- via include_str! so every node applies it idempotently at startup.
+-- P1.10 (sifrah/nauka#200) is the issue that actually migrates FabricState
+-- to read/write through these tables.
+--
+-- Idempotency: every DEFINE statement uses `IF NOT EXISTS` so re-running the
+-- whole script on an existing database is a no-op. SurrealDB SCHEMAFULL +
+-- IF NOT EXISTS lets us add fields in later phases without breaking
+-- already-applied schemas.
+--
+-- Field set: this file ships exactly the fields the P1.6 acceptance criteria
+-- ask for (sifrah/nauka#196). The full FabricState (regions, zones, ports,
+-- endpoints, runtime, ipv6 blocks, etc.) lands in P1.10 when the migration
+-- needs them — at that point this file gets extended with `DEFINE FIELD … IF
+-- NOT EXISTS` lines for the missing columns.
+--
+-- Multi-tenancy: this database holds *node-local* state, so there is no
+-- tenant boundary at this layer (per ADR 0003, sifrah/nauka#190). The
+-- per-org row-level permissions live on the cluster-side schemas (P2.5,
+-- sifrah/nauka#209), not here.
+-- ============================================================================
+
+
+-- ── mesh ─────────────────────────────────────────────────────────────────
+-- Singleton: there is exactly one mesh per Nauka deployment, so callers
+-- always read/write the well-known id `mesh:current`. SurrealDB doesn't
+-- have a native "singleton table" type — the convention is enforced in
+-- code, not schema.
+
+DEFINE TABLE IF NOT EXISTS mesh SCHEMAFULL;
+
+-- The /48 ULA prefix for this mesh, stored as a string (e.g.
+-- "fd54:7725:6b2a::/48"). SurrealDB has no native IPv6 type.
+DEFINE FIELD IF NOT EXISTS ipv6_ula ON mesh TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Hash of the mesh secret. The raw secret is *never* persisted to disk
+-- by P1.x — only the hash is, so peer joins can be verified without
+-- giving anyone the ability to forge new joins from a stolen
+-- bootstrap.skv file. Hex- or base64-encoded; the encoding choice is
+-- the migration's (P1.10) call.
+DEFINE FIELD IF NOT EXISTS secret_hash ON mesh TYPE string
+    ASSERT string::len($value) > 0;
+
+-- When the mesh was first created.
+DEFINE FIELD IF NOT EXISTS created_at ON mesh TYPE datetime;
+
+
+-- ── hypervisor ───────────────────────────────────────────────────────────
+-- Identity of this node within the mesh. Singleton in practice: the local
+-- bootstrap database holds exactly one row, keyed by the hypervisor's
+-- ULID via SurrealDB's record id (e.g. `hypervisor:hv-01HXXX`).
+--
+-- Note on `id`: the P1.6 issue (sifrah/nauka#196) lists `id` as a field,
+-- but SurrealDB reserves `id` as the record-id slot — defining a separate
+-- `id` field collides with the record id and breaks `CREATE hypervisor:foo
+-- SET id = ...`. The right thing in SurrealDB is to use the record id
+-- *as* the ULID. P1.10 (sifrah/nauka#200) will create rows with
+-- `CREATE hypervisor:<ulid> SET name = ..., ...` and read them back via
+-- `select(("hypervisor", &ulid_str))`. The acceptance criterion is met
+-- functionally: every hypervisor row is uniquely identified by its ULID
+-- via the SurrealDB record id.
+
+DEFINE TABLE IF NOT EXISTS hypervisor SCHEMAFULL;
+
+-- Human-readable name (defaults to hostname).
+DEFINE FIELD IF NOT EXISTS name ON hypervisor TYPE string
+    ASSERT string::len($value) > 0;
+
+-- This node's IPv6 address on the mesh, as a string.
+DEFINE FIELD IF NOT EXISTS mesh_ipv6 ON hypervisor TYPE string
+    ASSERT string::len($value) > 0;
+
+-- WireGuard public key (base64).
+DEFINE FIELD IF NOT EXISTS public_key ON hypervisor TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Coarse role within the mesh: e.g. "leader", "candidate", "member".
+-- Free-form string for now; a strict enum gets added (probably as an
+-- ASSERT $value INSIDE [...]) when the role state machine lands.
+DEFINE FIELD IF NOT EXISTS role ON hypervisor TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Index on the unique node name so name → id lookups are fast.
+DEFINE INDEX IF NOT EXISTS hypervisor_name ON hypervisor FIELDS name UNIQUE;
+
+-- Index on mesh_ipv6 (also unique per mesh).
+DEFINE INDEX IF NOT EXISTS hypervisor_mesh_ipv6 ON hypervisor
+    FIELDS mesh_ipv6 UNIQUE;
+
+
+-- ── peer ─────────────────────────────────────────────────────────────────
+-- Other nodes that this node knows about. Each row is one peer, keyed by
+-- the peer's mesh IPv6.
+
+DEFINE TABLE IF NOT EXISTS peer SCHEMAFULL;
+
+-- The peer's mesh IPv6 address (string form).
+DEFINE FIELD IF NOT EXISTS mesh_ipv6 ON peer TYPE string
+    ASSERT string::len($value) > 0;
+
+-- The peer's WireGuard public key (base64).
+DEFINE FIELD IF NOT EXISTS public_key ON peer TYPE string
+    ASSERT string::len($value) > 0;
+
+-- The peer's public WireGuard endpoint (e.g. "1.2.3.4:51820").
+-- Optional: peers can be reachable only via the mesh (no public IP) once
+-- they've completed an initial handshake.
+DEFINE FIELD IF NOT EXISTS endpoint ON peer TYPE option<string>;
+
+-- Last successful WireGuard handshake observed for this peer. Optional:
+-- a freshly added peer has no handshake yet.
+DEFINE FIELD IF NOT EXISTS last_seen ON peer TYPE option<datetime>;
+
+-- Index for fast peer lookup by mesh address (the natural key).
+DEFINE INDEX IF NOT EXISTS peer_mesh_ipv6 ON peer FIELDS mesh_ipv6 UNIQUE;
+
+-- Secondary index on public_key — used by the WireGuard reload path
+-- when reconciling actual peer state from `wg show`.
+DEFINE INDEX IF NOT EXISTS peer_public_key ON peer FIELDS public_key UNIQUE;
+
+
+-- ── wg_key ───────────────────────────────────────────────────────────────
+-- This node's WireGuard keypair. Singleton — there's exactly one local
+-- keypair per node. Keys are sensitive: file permissions on bootstrap.skv
+-- are the only thing protecting them, hence the 0o700 dir / 0o600 file
+-- requirement enforced by P1.4 (sifrah/nauka#194).
+
+DEFINE TABLE IF NOT EXISTS wg_key SCHEMAFULL;
+
+-- Base64-encoded WireGuard private key.
+DEFINE FIELD IF NOT EXISTS private_key ON wg_key TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Base64-encoded WireGuard public key (derivable from the private key,
+-- but stored explicitly for cheap reads in the hot path).
+DEFINE FIELD IF NOT EXISTS public_key ON wg_key TYPE string
+    ASSERT string::len($value) > 0;

--- a/layers/state/src/embedded.rs
+++ b/layers/state/src/embedded.rs
@@ -466,4 +466,95 @@ mod tests {
             "expected StateError::Io, got: {err:?}"
         );
     }
+
+    /// P1.6 — the bootstrap.surql schema must apply cleanly to a fresh
+    /// database, must be idempotent (re-applying is a no-op), and must
+    /// allow inserting one record into every table it defines.
+    ///
+    /// This test does NOT wire the schema into `EmbeddedDb::open` — that's
+    /// P1.7 (sifrah/nauka#197). It only validates the schema file's
+    /// correctness against a real SurrealKV instance.
+    #[tokio::test]
+    async fn bootstrap_schema_applies_cleanly() {
+        const SCHEMA: &str = include_str!("../schemas/bootstrap.surql");
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = EmbeddedDb::open(&dir.path().join("schema_test.skv"))
+            .await
+            .expect("open");
+
+        // First application — must succeed against an empty database.
+        db.client()
+            .query(SCHEMA)
+            .await
+            .expect("schema first apply")
+            .check()
+            .expect("schema first apply check");
+
+        // Second application — must be a no-op thanks to IF NOT EXISTS.
+        db.client()
+            .query(SCHEMA)
+            .await
+            .expect("schema second apply")
+            .check()
+            .expect("schema second apply check");
+
+        // Each table is reachable. Inserting a row exercises the field
+        // ASSERTs and confirms the SCHEMAFULL definitions accept the
+        // documented shapes. We use SurrealQL's `time::now()` directly so
+        // the test doesn't need a chrono dev-dep.
+        db.client()
+            .query(
+                "CREATE mesh:current SET ipv6_ula = $u, secret_hash = $h, \
+                 created_at = time::now()",
+            )
+            .bind(("u", "fdc5:8ba:9b14::/48"))
+            .bind(("h", "0123456789abcdef"))
+            .await
+            .expect("insert mesh")
+            .check()
+            .expect("insert mesh check");
+
+        // The record id `hypervisor:hv-01HXXX` IS the ULID — there's no
+        // separate `id` field in the schema (see schemas/bootstrap.surql
+        // for the rationale). P1.10 will create rows the same way:
+        // `CREATE hypervisor:<ulid> SET name = ..., ...`.
+        db.client()
+            .query(
+                "CREATE hypervisor:`hv-01HXXX` SET name = $n, mesh_ipv6 = $m, \
+                 public_key = $p, role = $r",
+            )
+            .bind(("n", "node-1"))
+            .bind(("m", "fdc5:8ba:9b14::1"))
+            .bind(("p", "BASE64=="))
+            .bind(("r", "leader"))
+            .await
+            .expect("insert hypervisor")
+            .check()
+            .expect("insert hypervisor check");
+
+        db.client()
+            .query(
+                "CREATE peer:p1 SET mesh_ipv6 = $m, public_key = $p, \
+                 endpoint = $e, last_seen = time::now()",
+            )
+            .bind(("m", "fdc5:8ba:9b14::2"))
+            .bind(("p", "PEERKEY=="))
+            .bind(("e", "1.2.3.4:51820"))
+            .await
+            .expect("insert peer")
+            .check()
+            .expect("insert peer check");
+
+        db.client()
+            .query("CREATE wg_key:current SET private_key = $k, public_key = $p")
+            .bind(("k", "PRIVKEY=="))
+            .bind(("p", "PUBKEY=="))
+            .await
+            .expect("insert wg_key")
+            .check()
+            .expect("insert wg_key check");
+
+        db.shutdown().await.expect("shutdown");
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `layers/state/schemas/bootstrap.surql`, the SCHEMAFULL definition for the four tables `EmbeddedDb<SurrealKv>` needs (per ADR 0003, #190): **mesh**, **hypervisor**, **peer**, **wg_key**.
- Every `DEFINE` statement uses `IF NOT EXISTS` so the file is fully idempotent — that's what makes the "apply on every open" pattern in P1.7 (#197) safe.
- Adds a test (`embedded::tests::bootstrap_schema_applies_cleanly`) that validates the schema against a real SurrealKV instance: applies it twice (idempotency) and inserts one record into every table to exercise the SCHEMAFULL constraints.

## Acceptance criteria — all met
- [x] File `layers/state/schemas/bootstrap.surql`
- [x] `DEFINE TABLE mesh SCHEMAFULL` (`ipv6_ula`, `secret_hash`, `created_at`)
- [x] `DEFINE TABLE hypervisor SCHEMAFULL` (`name`, `mesh_ipv6`, `public_key`, `role`) — see "Deliberate deviation on `id`" below
- [x] `DEFINE TABLE peer SCHEMAFULL` (`mesh_ipv6`, `public_key`, `endpoint`, `last_seen`)
- [x] `DEFINE TABLE wg_key SCHEMAFULL` (`private_key`, `public_key`)
- [x] All definitions use `IF NOT EXISTS` for idempotency

## Deliberate deviation: no `id` field on `hypervisor`

The acceptance criteria listed `id` as a field on the hypervisor table, but **SurrealDB reserves `id` as the record-id slot**: defining a separate `id` field collides with the record id and breaks `CREATE hypervisor:foo SET id = ...` with the error `Found 'foo' for the 'id' field, but a specific record has been specified`.

The right thing in SurrealDB is to use the record id *as* the ULID. P1.10 (#200) will create hypervisor rows with `CREATE hypervisor:<ulid> SET name = ..., ...` and read them back via `select(("hypervisor", &ulid_str))`. The acceptance criterion is met functionally — every hypervisor row is uniquely identified by its ULID — just via the SurrealDB record id rather than a separate `id` column.

The schema file documents this inline so the deviation is visible to anyone reading it without needing to consult the PR.

## Indexes added for forward-compat with P1.10

- `hypervisor_name` (UNIQUE) — name → record-id lookups
- `hypervisor_mesh_ipv6` (UNIQUE) — mesh address uniqueness
- `peer_mesh_ipv6` (UNIQUE) — peer natural key
- `peer_public_key` (UNIQUE) — `wg show` reconcile path

These are not strictly required by P1.6, but they cost nothing now and remove a follow-up nit during P1.10.

## Test plan
- [x] `cargo test -p nauka-state` — **28 lib tests pass** (27 existing + 1 new for the schema)
- [x] `cargo test -p nauka-state embedded::tests::bootstrap_schema_applies_cleanly` — pass
- [x] `cargo clippy -p nauka-state --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Cross-compile musl x86_64 — incremental
- [x] **Hetzner test** on `node-1`: re-running `p0-1-spike` confirms no runtime regression (the schema file isn't wired into `open` yet, so the spike still does what it did in P1.4 — Phase A + Phase B both pass with `state_dir_perms = 0o700` and `info_for_db = OK`).

## Files touched
- `layers/state/schemas/bootstrap.surql` — **new**: full SCHEMAFULL schema with inline rationale comments
- `layers/state/src/embedded.rs` — adds the `bootstrap_schema_applies_cleanly` test

## Files NOT touched
- `EmbeddedDb::open` — the schema is **not** wired into the open path here; that's P1.7 (#197). P1.6 only ships the schema file plus its validation harness.

Closes #196.
Epic: #183