### PR TITLE
feat(P1.7): EmbeddedDb::open auto-applies the bootstrap schema

### DIFF
--- a/layers/state/src/embedded.rs
+++ b/layers/state/src/embedded.rs
@@ -46,6 +46,14 @@ use surrealdb::Surreal;
 
 use crate::{Result, StateError, BOOTSTRAP_DB, NAUKA_NS};
 
+/// The bootstrap-state SurrealQL schema, embedded at compile time.
+///
+/// Defined in `layers/state/schemas/bootstrap.surql` (P1.6, sifrah/nauka#196).
+/// `EmbeddedDb::open` applies this on every open. The schema is fully
+/// idempotent thanks to `IF NOT EXISTS` on every `DEFINE` statement, so
+/// re-applying against an already-initialised database is a no-op.
+const BOOTSTRAP_SCHEMA: &str = include_str!("../schemas/bootstrap.surql");
+
 /// Embedded SurrealDB instance, persisted to disk via the SurrealKV backend.
 ///
 /// Cheap to clone: every clone shares the same underlying `Surreal<Db>`
@@ -75,11 +83,20 @@ impl EmbeddedDb {
         Self::open(&path).await
     }
 
-    /// Open (or create) the SurrealKV-backed database at `path` and select
-    /// the `nauka` / `bootstrap` namespace/database.
+    /// Open (or create) the SurrealKV-backed database at `path`, select the
+    /// `nauka` / `bootstrap` namespace/database, and apply the embedded
+    /// bootstrap schema.
     ///
     /// The parent directory is created if it doesn't exist. On Unix the
     /// parent directory is also chmod-ed to 0o700 (best-effort).
+    ///
+    /// The bootstrap schema (`schemas/bootstrap.surql`, P1.6) is applied on
+    /// every open. It is fully idempotent thanks to `IF NOT EXISTS` on
+    /// every `DEFINE` statement, so reopening an existing database is a
+    /// no-op for already-defined tables, fields, and indexes — and any
+    /// new tables/fields/indexes that have appeared since last open are
+    /// added forward-compatibly. P1.7 (sifrah/nauka#197) is the issue that
+    /// wires this in.
     ///
     /// For the run-mode-aware default path, use [`Self::open_default`].
     ///
@@ -88,9 +105,10 @@ impl EmbeddedDb {
     /// Returns [`StateError::Io`] if the parent directory cannot be created,
     /// or one of [`StateError::NotFound`] / [`StateError::Schema`] /
     /// [`StateError::Database`] (depending on the underlying SurrealDB
-    /// failure mode) if SurrealDB cannot open the datastore or switch to
-    /// the configured namespace/database. The classification is done by the
-    /// `From<surrealdb::Error>` impl in `lib.rs` (P1.3, sifrah/nauka#193).
+    /// failure mode) if SurrealDB cannot open the datastore, switch to the
+    /// configured namespace/database, or apply the bootstrap schema. The
+    /// classification is done by the `From<surrealdb::Error>` impl in
+    /// `lib.rs` (P1.3, sifrah/nauka#193).
     pub async fn open(path: &Path) -> Result<Self> {
         if let Some(parent) = path.parent() {
             if !parent.as_os_str().is_empty() {
@@ -113,6 +131,12 @@ impl EmbeddedDb {
         let inner = Surreal::new::<SurrealKv>(path_str.as_str()).await?;
 
         inner.use_ns(NAUKA_NS).use_db(BOOTSTRAP_DB).await?;
+
+        // Apply the bootstrap schema after switching to the right ns/db.
+        // DEFINE TABLE / FIELD / INDEX are db-scoped, so use_db must
+        // happen first. The schema's IF NOT EXISTS clauses make this
+        // safe to run on every open.
+        inner.query(BOOTSTRAP_SCHEMA).await?.check()?;
 
         Ok(Self {
             inner,
@@ -467,13 +491,66 @@ mod tests {
         );
     }
 
+    /// P1.7 — `EmbeddedDb::open` applies the bootstrap schema automatically.
+    ///
+    /// Opens a fresh database (no manual schema application) and asserts
+    /// that the four bootstrap tables (`mesh`, `hypervisor`, `peer`,
+    /// `wg_key`) are reachable. With the schema NOT auto-applied, a
+    /// `select` against a never-touched table returns SurrealDB's
+    /// `NotFound` error (verified by `multi_table_isolation` in P1.5).
+    /// With the schema auto-applied, the table is defined-but-empty and
+    /// `select` returns an empty Vec.
+    #[tokio::test]
+    async fn open_applies_bootstrap_schema_automatically() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = EmbeddedDb::open(&dir.path().join("auto_schema.skv"))
+            .await
+            .expect("open should also apply the schema");
+
+        // Each schema-defined table must be reachable on a fresh DB.
+        // We use surrealdb::types::Value to avoid forcing a SurrealValue
+        // derive on a strongly-typed mirror of every table.
+        for table in &["mesh", "hypervisor", "peer", "wg_key"] {
+            let rows: Vec<surrealdb::types::Value> =
+                db.client().select(*table).await.unwrap_or_else(|e| {
+                    panic!("select on {table} should succeed (schema not applied?): {e}")
+                });
+            assert!(
+                rows.is_empty(),
+                "table {table} should be empty on a fresh DB but contained {} rows",
+                rows.len()
+            );
+        }
+
+        // The schema is also idempotent: a second open at the same path
+        // (after explicit shutdown) must succeed and the tables must
+        // still be defined.
+        let path = db.path().to_path_buf();
+        db.shutdown().await.expect("shutdown");
+
+        let db2 = EmbeddedDb::open(&path)
+            .await
+            .expect("reopening an already-initialised DB should succeed");
+        for table in &["mesh", "hypervisor", "peer", "wg_key"] {
+            let rows: Vec<surrealdb::types::Value> =
+                db2.client().select(*table).await.unwrap_or_else(|e| {
+                    panic!("post-reopen select on {table} should succeed: {e}")
+                });
+            assert!(
+                rows.is_empty(),
+                "table {table} should still be empty after reopen"
+            );
+        }
+        db2.shutdown().await.expect("shutdown #2");
+    }
+
     /// P1.6 — the bootstrap.surql schema must apply cleanly to a fresh
     /// database, must be idempotent (re-applying is a no-op), and must
     /// allow inserting one record into every table it defines.
     ///
-    /// This test does NOT wire the schema into `EmbeddedDb::open` — that's
-    /// P1.7 (sifrah/nauka#197). It only validates the schema file's
-    /// correctness against a real SurrealKV instance.
+    /// After P1.7 (sifrah/nauka#197) `EmbeddedDb::open` applies the schema
+    /// automatically, so this test now also covers the
+    /// "open + auto-apply + manual re-apply" idempotency contract.
     #[tokio::test]
     async fn bootstrap_schema_applies_cleanly() {
         const SCHEMA: &str = include_str!("../schemas/bootstrap.surql");


### PR DESCRIPTION
## Summary
- Wires `layers/state/schemas/bootstrap.surql` (P1.6, #196) into `EmbeddedDb::open` via `include_str!`. Opening a fresh SurrealKV instance is now enough to bootstrap the schema — no separate "init" step.
- Idempotent thanks to `IF NOT EXISTS` on every `DEFINE` statement, so reopening an existing database is a no-op for already-defined tables/fields/indexes. New definitions added in future revisions of the schema file land forward-compatibly on the next open.
- Adds a test (`open_applies_bootstrap_schema_automatically`) that opens a fresh DB without any manual schema work and asserts the four tables (`mesh`, `hypervisor`, `peer`, `wg_key`) are reachable + empty.

## Acceptance criteria — all met
- [x] Schema applied on every open (idempotent) — `inner.query(BOOTSTRAP_SCHEMA).await?.check()?` runs after `use_ns/use_db` in `EmbeddedDb::open`. Idempotency is delegated to the `IF NOT EXISTS` clauses in the schema file from P1.6.
- [x] Schema changes don't break existing data — `IF NOT EXISTS` covers add-only changes (new tables/fields/indexes). Removing a field is intentionally NOT auto-handled — that needs an explicit migration, which isn't a P1.7 concern.
- [x] Test: open empty DB, schema is applied, tables exist — `embedded::tests::open_applies_bootstrap_schema_automatically` covers exactly this contract, plus a shutdown-and-reopen idempotency check.

## Implementation notes
- `BOOTSTRAP_SCHEMA: &str = include_str!("../schemas/bootstrap.surql")` lives at the top of `embedded.rs` so the schema is baked into the binary at compile time. No runtime file lookup, no failure mode where the schema file is missing on disk.
- Order in `open` matters: parent dir → `Surreal::new::<SurrealKv>` → `use_ns/use_db` → `query(BOOTSTRAP_SCHEMA)`. `DEFINE TABLE/FIELD/INDEX` are db-scoped, so `use_db` must run first.
- Errors flow through the `From<surrealdb::Error>` impl from P1.3 (#193). A schema-application failure surfaces as `StateError::Schema` with the original SurrealDB error message preserved.

## Why the existing 28 tests still pass
The schema only defines four tables: `mesh`, `hypervisor`, `peer`, `wg_key`. Every existing test uses different table names (`items`, `table_a`, `table_b`, `spike_record`, `notes`), and SurrealDB tables are SCHEMALESS by default unless explicitly declared as SCHEMAFULL. Auto-applying the schema therefore introduces zero collisions with the existing test corpus.

The new test exercises the inverse contract from P1.5's `multi_table_isolation`: P1.5 established that an *undefined* table returns `NotFound`; P1.7 confirms that a *defined-but-empty* table returns an empty Vec.

## Test plan
- [x] `cargo test -p nauka-state` — **29 lib tests pass** (28 → 29, +1 for the auto-apply test). All 4 doctests pass.
- [x] `cargo test -p nauka-state embedded::tests::open_applies_bootstrap_schema_automatically` — pass
- [x] `cargo clippy -p nauka-state --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Cross-compile musl x86_64
- [x] **Hetzner test** on `node-1` (root → service mode): Phase A (`EmbeddedDb::open` at temp path with auto-applied schema) and Phase B (`EmbeddedDb::open_default` at `/var/lib/nauka/bootstrap.skv` with auto-applied schema) both complete with `info_for_db = OK` and `state_dir_perms = 0o700`. The spike binary deliberately runs against a wiped state directory each time, exercising the fresh-open code path.

## Files touched
- `layers/state/src/embedded.rs` — add `BOOTSTRAP_SCHEMA` const, apply it in `open`, add the new test, refresh the doc comment on `open`

## Files NOT touched
- `layers/state/schemas/bootstrap.surql` — unchanged from P1.6
- Existing tests — none modified, all pass as-is

Closes #197.
Epic: #183