### PR TITLE
docs(P1.8): cross-compile reference + p0-1-spike --help

### DIFF
--- a/docs/cross-compile.md
+++ b/docs/cross-compile.md
@@ -1,0 +1,191 @@
+# Cross-compiling Nauka for Linux musl x86_64
+
+This is the operational reference for building Nauka binaries that can run on
+the Hetzner production target. Hetzner nodes are Ubuntu x86_64 but Nauka ships
+**statically linked musl** binaries to avoid glibc version drift between dev
+machines and prod.
+
+The original investigation lives in
+[docs/spikes/p0-1-musl-cross-compile.md](spikes/p0-1-musl-cross-compile.md)
+(P0.1, sifrah/nauka#185). This page is the durable how-to that survives once
+the P1.x migration is done — keep it up to date.
+
+## Toolchain requirements
+
+### macOS (dev workstation)
+
+Install once, with Homebrew:
+
+```bash
+brew install cmake          # required by aws-lc-sys (jsonwebtoken → surrealdb-core)
+brew install musl-cross     # provides x86_64-linux-musl-gcc, used as the linker
+rustup target add x86_64-unknown-linux-musl
+```
+
+The repo's `.cargo/config.toml` already wires the linker:
+
+```toml
+[target.x86_64-unknown-linux-musl]
+linker = "x86_64-linux-musl-gcc"
+```
+
+You should not need to set `CC` or `AR` env vars manually; `cc-rs` picks the
+right toolchain via the `x86_64-linux-musl-` prefix.
+
+### Linux (CI runners and dev VMs)
+
+On Debian / Ubuntu:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y musl-tools cmake build-essential
+rustup target add x86_64-unknown-linux-musl
+```
+
+The CI workflow (`.github/workflows/nightly.yml`) installs `musl-tools`
+already. `cmake` is also needed once a crate that pulls `aws-lc-sys` (which
+includes everything in `nauka-state` after P1.1) is built — that's tracked by
+P1.14 (sifrah/nauka#204).
+
+### Vendored OpenSSL is not optional
+
+Both `tikv-client 0.4` (legacy `ClusterDb`) and `surrealdb-tikv-client 0.3`
+(future P2 path, gated behind `spike-tikv` for now) transitively depend on
+`openssl-sys` via `prometheus → reqwest → native-tls`. Without vendored
+OpenSSL in the dependency graph, the cross-compile fails with:
+
+```
+Could not find directory of OpenSSL installation
+```
+
+The workspace `Cargo.toml` declares `openssl = { version = "0.10", features
+= ["vendored"] }`, but **each crate that needs it must opt in** with
+`openssl.workspace = true`. Today the crates that do are:
+
+- `bin/nauka` — for the existing musl release path
+- `layers/state` — added in P0.1 (sifrah/nauka#185) when `nauka-state`
+  started pulling SurrealDB
+
+If you add a new crate that ends up in the dependency closure of
+`tikv-client` or `surrealdb-tikv-client`, you must also add
+`openssl.workspace = true` to its `Cargo.toml`.
+
+## Building
+
+The canonical command for building the `nauka-state` library and its bins
+for musl:
+
+```bash
+cargo build --target x86_64-unknown-linux-musl -p nauka-state --release
+```
+
+For the full `nauka` binary (the one that ships to Hetzner):
+
+```bash
+cargo build --target x86_64-unknown-linux-musl -p nauka --release
+```
+
+The `nauka-state` build covers the `EmbeddedDb` wrapper plus the spike
+binaries. The `nauka` build covers the full CLI plus all dependent layers.
+
+The output binaries land at:
+
+```
+target/x86_64-unknown-linux-musl/release/nauka
+target/x86_64-unknown-linux-musl/release/p0-1-spike
+```
+
+## Verifying the binary is statically linked
+
+```bash
+file target/x86_64-unknown-linux-musl/release/p0-1-spike
+# expect: ELF 64-bit LSB pie executable, x86-64 [...] static-pie linked
+```
+
+On a Hetzner node:
+
+```bash
+ldd /root/p0-1-spike
+# expect: statically linked  (or "not a dynamic executable")
+```
+
+## Hetzner smoke test
+
+The standard "did the cross-compile work" smoke test, used by every Phase 1
+ticket:
+
+```bash
+TARGET_BINARY="target/x86_64-unknown-linux-musl/release/p0-1-spike"
+HETZNER_NODE="root@<node-ipv4>"
+
+scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+    -o LogLevel=ERROR \
+    "$TARGET_BINARY" "$HETZNER_NODE":/root/p0-1-spike
+
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+    -o LogLevel=ERROR "$HETZNER_NODE" '
+        chmod +x /root/p0-1-spike
+        /root/p0-1-spike --help    # exit-zero, no side effects
+        /root/p0-1-spike            # full Phase A + Phase B run
+        rm /root/p0-1-spike
+    '
+```
+
+If the binary loads, prints `--help`, then completes both phases (Phase A
+exercises `EmbeddedDb::open` at a temp path, Phase B exercises
+`EmbeddedDb::open_default` against `/var/lib/nauka/bootstrap.skv`), the
+cross-compile chain is healthy.
+
+## Common failures and what they mean
+
+### `Could not find directory of OpenSSL installation`
+
+A crate in your dependency closure pulls `openssl-sys` but no crate has
+opted into `openssl.workspace = true`. Add `openssl.workspace = true` to the
+`Cargo.toml` of the crate you're building (or any crate it depends on
+within the workspace).
+
+### `linker x86_64-linux-musl-gcc not found`
+
+`musl-cross` (macOS) or `musl-tools` (Debian/Ubuntu) is not installed.
+Install per "Toolchain requirements" above.
+
+### `no such file or directory: target/x86_64-unknown-linux-musl/...`
+
+The musl Rust target isn't installed. Run
+`rustup target add x86_64-unknown-linux-musl`.
+
+### `cmake: command not found` (during `aws-lc-sys` build)
+
+Install `cmake` per "Toolchain requirements" above. This is the
+direct trigger for the P1.14 issue (sifrah/nauka#204) on the CI side.
+
+### Build succeeds but `ldd` shows dynamic libraries on the Hetzner node
+
+You probably built for `x86_64-unknown-linux-gnu` instead of
+`x86_64-unknown-linux-musl`. Double-check the `--target` flag.
+
+## Build sizes (for context)
+
+| Binary | Features | Size |
+|---|---|---|
+| `p0-1-spike` (debug) | `kv-surrealkv` only | ~250 MB |
+| `p0-1-spike` (release) | `kv-surrealkv` only | ~53 MB |
+| `p0-1-spike` (release) | `kv-surrealkv` + `spike-tikv` | ~61 MB (P0.1 baseline) |
+
+The `~53 MB` release binary is dominated by SurrealDB's parser, query
+planner, and storage layer. It's not yet stripped or LTO-optimised; the
+real `nauka` shipping binary will be smaller after `[profile.release]
+lto = "fat"` and `strip = true` land — that's a P3+ concern, not a Phase 1
+blocker.
+
+## See also
+
+- ADR 0000 — BSL 1.1 license audit (sifrah/nauka#186): why we link
+  `surrealdb-core` despite it being source-available rather than fully OSI
+- ADR 0001 — TiKV API V1 (sifrah/nauka#188): which env vars / which surreal
+  features Nauka uses
+- P0.1 spike — original investigation (sifrah/nauka#185): more context on
+  why each toolchain piece is needed
+- P1.14 (sifrah/nauka#204): CI is missing `cmake`; this PR doesn't fix that
+  but the doc above is the authoritative reference for what to install

--- a/layers/state/src/bin/p0_1_spike.rs
+++ b/layers/state/src/bin/p0_1_spike.rs
@@ -40,8 +40,51 @@ struct SpikeRecord {
     answer: i32,
 }
 
+/// Print a short usage message and exit cleanly. Wired to `--help` / `-h`
+/// so the binary can be used as a smoke test for cross-compile validation
+/// (P1.8, sifrah/nauka#198) without producing side effects on disk.
+fn print_help() {
+    println!("nauka p0-1 spike — EmbeddedDb cross-compile + Hetzner smoke test");
+    println!();
+    println!("Exercises the EmbeddedDb<SurrealKv> wrapper end-to-end. Used by");
+    println!("the per-ticket workflow (compile → Hetzner → CI → merge) to");
+    println!("re-validate the build chain on every Phase 1 PR.");
+    println!();
+    println!("USAGE:");
+    println!("    p0-1-spike [FLAGS]");
+    println!();
+    println!("FLAGS:");
+    println!("    -h, --help    Print this help and exit (no side effects)");
+    println!();
+    println!("With no flags the binary runs in two phases against the actual");
+    println!("filesystem:");
+    println!("    Phase A — EmbeddedDb::open at $TMPDIR/nauka-p0-1-spike.skv");
+    println!("              and a CRUD round-trip via db.client().");
+    println!("    Phase B — EmbeddedDb::open_default() to exercise the");
+    println!("              run-mode-aware path picker (CLI → ~/.nauka,");
+    println!("              service mode → /var/lib/nauka), with INFO FOR DB");
+    println!("              and 0o700 perms verification on the parent.");
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Manual flag handling: only `--help` / `-h` need to be recognised at
+    // P1.8 time, so a tiny if-let is preferable to pulling clap into a
+    // spike binary.
+    if let Some(arg) = std::env::args().nth(1) {
+        match arg.as_str() {
+            "-h" | "--help" => {
+                print_help();
+                return Ok(());
+            }
+            other => {
+                eprintln!("error: unknown flag: {other}");
+                eprintln!("hint:  run `--help` for usage");
+                std::process::exit(2);
+            }
+        }
+    }
+
     println!("== nauka p0-1 spike (P1.4 — run-mode-aware paths) ==");
     println!("target_arch    = {}", std::env::consts::ARCH);
     println!("target_os      = {}", std::env::consts::OS);


### PR DESCRIPTION
## Summary
- Adds `docs/cross-compile.md`, the operational reference for building Nauka binaries for the Hetzner musl x86_64 target. The original investigation lives in the P0.1 spike report (#185) — this new file is the durable how-to that survives once Phase 1 is done.
- Adds a tiny `--help` / `-h` handler to `p0-1-spike` so the "smoke test: scp the binary and run `--help`" criterion has something concrete to invoke. Manual arg parsing rather than pulling clap into a spike binary.

## Acceptance criteria — all met
- [x] `cargo build --target x86_64-unknown-linux-musl -p nauka-state` succeeds — re-validated locally (debug 4m25s cold, release 2.29s incremental, 54MB statically-linked binary)
- [x] Required tools documented (`musl-tools`, `cmake`) — `docs/cross-compile.md` covers macOS (`brew install cmake musl-cross`) and Debian/Ubuntu (`apt-get install musl-tools cmake build-essential`), plus the Rust target install
- [x] **Smoke test**: scp the binary to a Hetzner box and run `--help` — validated on `node-1`:
  - `/root/p0-1-spike --help` exits **0** with no side effects, prints a usage message
  - `/root/p0-1-spike` (no flags) completes Phase A + Phase B successfully with `state_dir_perms = 0o700` and `info_for_db = OK`

## What `docs/cross-compile.md` covers
- Toolchain install for **macOS** (`cmake` + `musl-cross` via brew) and **Debian/Ubuntu** (`musl-tools` + `cmake`), plus `rustup target add x86_64-unknown-linux-musl`
- The `.cargo/config.toml` `linker = "x86_64-linux-musl-gcc"` wiring (already in main)
- Why `openssl.workspace = true` is **mandatory** on every crate that pulls `tikv-client` or `surrealdb-tikv-client` — both transitively pull `openssl-sys` via `prometheus → reqwest → native-tls`
- The canonical build commands for `nauka-state` and `bin/nauka`
- The Hetzner smoke test sequence (scp + `--help` + full run + cleanup)
- A "common failures and what they mean" section keyed on the **actual** error strings: `Could not find directory of OpenSSL installation`, `linker x86_64-linux-musl-gcc not found`, `cmake: command not found`, "ldd shows dynamic libraries"
- Build sizes for context (53 MB release with kv-surrealkv only)
- Cross-references to ADR 0000, ADR 0001, the P0.1 spike, and P1.14 (which is what makes CI install `cmake`)

## `p0-1-spike --help` output

```
nauka p0-1 spike — EmbeddedDb cross-compile + Hetzner smoke test

Exercises the EmbeddedDb<SurrealKv> wrapper end-to-end. Used by
the per-ticket workflow (compile → Hetzner → CI → merge) to
re-validate the build chain on every Phase 1 PR.

USAGE:
    p0-1-spike [FLAGS]

FLAGS:
    -h, --help    Print this help and exit (no side effects)

With no flags the binary runs in two phases against the actual
filesystem:
    Phase A — EmbeddedDb::open at $TMPDIR/nauka-p0-1-spike.skv
              and a CRUD round-trip via db.client().
    Phase B — EmbeddedDb::open_default() to exercise the
              run-mode-aware path picker (CLI → ~/.nauka,
              service mode → /var/lib/nauka), with INFO FOR DB
              and 0o700 perms verification on the parent.
```

Unknown flags exit with status 2 and a one-line hint pointing at `--help`.

## Test plan
- [x] `cargo test -p nauka-state` — **29 lib tests + 4 doctests pass**, no regression
- [x] `cargo clippy -p nauka-state --all-targets -- -D warnings` clean (after fixing a `never_loop` lint on the manual arg parser by switching from `for` over `args().skip(1)` to `if let Some(arg) = args().nth(1)`)
- [x] `cargo fmt --check` clean
- [x] `cargo build --target x86_64-unknown-linux-musl -p nauka-state` (debug) succeeds
- [x] `cargo build --target x86_64-unknown-linux-musl -p nauka-state --release` succeeds — 54 MB statically-linked `p0-1-spike`
- [x] **Hetzner test** on `node-1`: `--help` exits 0 cleanly, full run completes Phase A + Phase B with `state_dir_perms = 0o700`

## Files touched
- `docs/cross-compile.md` — **new**: operational reference for cross-compiling, intended to be the canonical "how-to" alive past the end of Phase 1
- `layers/state/src/bin/p0_1_spike.rs` — add `print_help()` + manual `--help` / `-h` handler

## Files NOT touched
- CI workflows — installing `cmake` in the GitHub Actions runners is tracked separately by P1.14 (#204). This PR documents what CI needs but doesn't change the workflows.

Closes #198.
Epic: #183