### PR TITLE
test(P1.9): Hetzner integration test for EmbeddedDb persistence across restart

### DIFF
--- a/docs/spikes/p1-9-hetzner-integration.md
+++ b/docs/spikes/p1-9-hetzner-integration.md
@@ -1,0 +1,200 @@
+# P1.9 — Hetzner integration test for `EmbeddedDb<SurrealKv>`
+
+**Issue:** sifrah/nauka#199
+**Epic:** sifrah/nauka#183
+**Status:** Done — all acceptance criteria met
+**Date:** 2026-04-12
+
+## Goal
+
+Run a real CRUD cycle on a freshly-provisioned Hetzner VM, exit the binary,
+re-launch it, and verify the data created by the first invocation is still
+there. This is the strongest proof that `EmbeddedDb<SurrealKv>` actually
+persists to disk on the production-target OS, not just in some long-lived
+in-memory buffer that the in-process P1.5 tests can't distinguish from real
+persistence.
+
+## Result
+
+| Criterion | Result |
+|---|---|
+| Provision an x86 Hetzner VM via `hcloud` | ✅ `node-p1-9` (cpx22 / ubuntu-24.04 / fsn1) |
+| Cross-compile, scp, run an integration test binary | ✅ 54 MB statically-linked musl x86_64 |
+| Cycle: open → create 3 records → select → restart → reopen → select returns same 3 records | ✅ Phase 1 (seed) + Phase 2 (verify) both exit 0 |
+| Cleanup: tear down VM after test | ✅ `hcloud server delete node-p1-9` |
+| Logs uploaded as artifact | ✅ this file (full captured stdout below) |
+
+## How the test ran
+
+The integration test binary `p1-9-integration` (in
+`layers/state/src/bin/p1_9_integration.rs`) takes a `<phase>` argument:
+
+- **`seed`** — opens `EmbeddedDb` at `/var/lib/nauka/p1-9-integration.skv`,
+  creates three fixture records (`alpha`, `beta`, `gamma`), in-process
+  selects them back, exits.
+- **`verify`** — opens the *same* path in a *new* process, lists every
+  record, asserts that all three are still there with their original
+  values, exits.
+
+The "restart" between the two phases is the binary process exiting and being
+re-invoked by the test runner. That's a real process boundary — the kernel
+reaps the seed process, then the runner starts the verify process from
+scratch with no shared in-memory state.
+
+## Test runner sequence
+
+```bash
+# Provision a fresh VM (cpx22 / ubuntu-24.04 / fsn1)
+hcloud server create --name node-p1-9 --type cpx22 --image ubuntu-24.04 \
+    --location fsn1 --ssh-key ifrah.sacha@gmail.com
+
+# Cross-compile to musl x86_64
+cargo build --target x86_64-unknown-linux-musl -p nauka-state \
+    --bin p1-9-integration --release
+
+# scp the binary
+scp target/x86_64-unknown-linux-musl/release/p1-9-integration \
+    root@$NEW_VM_IP:/root/p1-9-integration
+
+# Run the seed phase, then the verify phase, capturing stdout
+ssh root@$NEW_VM_IP 'set -e
+    rm -rf /var/lib/nauka/p1-9-integration.skv
+    chmod +x /root/p1-9-integration
+    /root/p1-9-integration seed                # Phase 1
+    ls -la /var/lib/nauka/p1-9-integration.skv/
+    /root/p1-9-integration verify              # Phase 2 (post-restart)
+    rm -rf /var/lib/nauka/p1-9-integration.skv
+    rm /root/p1-9-integration
+'
+
+# Tear down the VM
+hcloud server delete node-p1-9
+```
+
+## Captured logs (the artifact)
+
+```
+===== HOST INFO =====
+node-p1-9
+Linux node-p1-9 6.8.0-106-generic #106-Ubuntu SMP PREEMPT_DYNAMIC Fri Mar  6 07:58:08 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux
+PRETTY_NAME="Ubuntu 24.04.4 LTS"
+
+===== BINARY INSPECTION =====
+-rwxr-xr-x 1 root root 54M Apr 12 18:02 /root/p1-9-integration
+	statically linked
+
+===== ENSURE CLEAN STATE =====
+(no /var/lib/nauka/p1-9-integration.skv)
+
+===== PHASE 1: SEED =====
+== nauka p1-9 integration ==
+phase          = seed
+path           = /var/lib/nauka/p1-9-integration.skv
+target_arch    = x86_64
+target_os      = linux
+expected_count = 3
+opened         = /var/lib/nauka/p1-9-integration.skv
+created        = id=alpha name=first count=1
+created        = id=beta name=second count=2
+created        = id=gamma name=third count=3
+seed_count     = 3
+== p1-9 seed OK ==
+(seed exit: 0)
+
+===== INTERMEDIATE: ON-DISK STATE =====
+total 28
+drwxr-xr-x 6 root root 4096 Apr 12 18:02 .
+drwx------ 3 root root 4096 Apr 12 18:02 ..
+-rw-r--r-- 1 root root    5 Apr 12 18:02 LOCK
+drwxr-xr-x 2 root root 4096 Apr 12 18:02 manifest
+drwxr-xr-x 2 root root 4096 Apr 12 18:02 sstables
+drwxr-xr-x 2 root root 4096 Apr 12 18:02 vlog
+drwxr-x--- 2 root root 4096 Apr 12 18:02 wal
+perms=755 owner=root:root
+
+===== PHASE 2: VERIFY (post-restart) =====
+== nauka p1-9 integration ==
+phase          = verify
+path           = /var/lib/nauka/p1-9-integration.skv
+target_arch    = x86_64
+target_os      = linux
+expected_count = 3
+opened         = /var/lib/nauka/p1-9-integration.skv
+verify_count   = 3
+verified       = id=alpha name=first count=1
+verified       = id=beta name=second count=2
+verified       = id=gamma name=third count=3
+verify_status  = all 3 records intact across restart
+== p1-9 verify OK ==
+(verify exit: 0)
+
+===== CLEANUP =====
+done
+```
+
+## What the on-disk state shows
+
+After the seed phase exited, SurrealKV had laid down its actual on-disk
+structure under `/var/lib/nauka/p1-9-integration.skv/`:
+
+```
+LOCK         (5 bytes — datastore lock file released cleanly on exit)
+manifest/    (the SurrealKV manifest directory)
+sstables/    (sorted-string tables — where the records actually live)
+vlog/        (value log)
+wal/         (write-ahead log, mode 750 — protected)
+```
+
+The `LOCK` file was correctly released between phases — the verify phase
+opened the same path with no `Database is already locked` error. That's the
+P1.5 shutdown wait fix paying off in real conditions: the seed process drops
+the `Surreal<Db>` client, the SDK background router task exits, calls
+`Datastore::shutdown()` which flushes SurrealKV and removes the lock, all
+of that within the 50ms wait we baked into `EmbeddedDb::shutdown`.
+
+## Findings
+
+1. **Persistence works.** The data written by the seed process is observable
+   from a freshly-launched verify process. The bytes are on disk, not in
+   shared memory or in some long-lived tokio task buffer.
+
+2. **The shutdown wait holds up under real conditions.** The P1.5 fix to
+   `EmbeddedDb::shutdown` (drop + yield + 50ms sleep) is enough to release
+   the SurrealKV LOCK file between two binary invocations on a real
+   filesystem. No tweaks needed.
+
+3. **Default file perms on the SurrealKV-created files are 0o755 / 0o644.**
+   The `EmbeddedDb::open` parent-dir chmod from P1.4 sets the *containing*
+   `/var/lib/nauka/p1-9-integration.skv/` directory to the umask SurrealKV
+   inherits, which on this Hetzner box is `0o755`. The acceptance criterion
+   on P1.4 (#194) said "0700 dir, 0600 file", which we hit on the
+   `/var/lib/nauka/` parent (set by `ensure_nauka_state_dir`), but not on
+   the SurrealKV directory itself or its sstables. **Follow-up**: tighten
+   permissions on the SurrealKV directory in a future ticket — not a
+   blocker for P1.9, but worth tracking. The WAL subdir at `0o750` is the
+   most-protected piece of the on-disk state today.
+
+4. **Total binary size is 54 MB** for `kv-surrealkv` only, statically
+   linked, not stripped, not LTO. Consistent with the P0.1 baseline. Same
+   note as in `docs/cross-compile.md`: stripping + LTO will come in a
+   later phase.
+
+## What lands in the PR
+
+- `layers/state/src/bin/p1_9_integration.rs` — the integration binary
+- `layers/state/Cargo.toml` — `[[bin]]` entry for `p1-9-integration`
+- `docs/spikes/p1-9-hetzner-integration.md` — this file (the artifact)
+
+## What does NOT land
+
+- The VM. `node-p1-9` was deleted at the end of the test as required by the
+  cleanup criterion.
+- Any `dist-check`-style debug binary. P1.9 only ships the integration
+  binary itself.
+
+## Follow-ups
+
+- **Permissions on the SurrealKV directory.** The parent state dir is
+  `0o700` per P1.4, but the SurrealKV subdirectory and its contents inherit
+  the process umask (`0o755` / `0o644` on this Hetzner box). Tighten in a
+  future ticket — does not affect this PR's acceptance criteria.

--- a/layers/state/Cargo.toml
+++ b/layers/state/Cargo.toml
@@ -45,5 +45,9 @@ name = "p0-3-spike"
 path = "src/bin/p0_3_spike.rs"
 required-features = ["spike-tikv"]
 
+[[bin]]
+name = "p1-9-integration"
+path = "src/bin/p1_9_integration.rs"
+
 [dev-dependencies]
 tempfile = "3"

--- a/layers/state/src/bin/p1_9_integration.rs
+++ b/layers/state/src/bin/p1_9_integration.rs
@@ -1,0 +1,200 @@
+//! Hetzner integration test binary for P1.9 (sifrah/nauka#199).
+//!
+//! Demonstrates that data written by `EmbeddedDb<SurrealKv>` survives
+//! a process restart on a real Hetzner Ubuntu host. The same binary is
+//! invoked twice from the test runner:
+//!
+//! 1. **`p1-9-integration seed`** — open the datastore at
+//!    `/var/lib/nauka/p1-9-integration.skv`, create three records,
+//!    select them back to verify the in-process round-trip, exit.
+//! 2. **`p1-9-integration verify`** — re-open the *same* datastore
+//!    in a *new* process, list every record, assert that all three
+//!    survived the restart with their original values, exit.
+//!
+//! Between the two invocations the binary process exits, the
+//! kernel reaps it, and the test runner re-launches it. That gap is
+//! the "restart" that P1.5's in-process `persistence_across_reopen`
+//! test cannot exercise — only an actual process boundary proves
+//! the data is on disk and not just in some long-lived in-memory
+//! buffer.
+//!
+//! Cleanup is the test runner's job: provision the VM, run the
+//! binary in both phases, capture stdout, then delete the VM.
+
+use std::path::PathBuf;
+
+use nauka_state::EmbeddedDb;
+use surrealdb::types::SurrealValue;
+
+#[derive(Debug, Clone, PartialEq, SurrealValue)]
+struct Record {
+    name: String,
+    count: i64,
+}
+
+/// The fixed test fixture: three records the seed phase writes and the
+/// verify phase asserts on. Defined as a constant so any drift between
+/// the phases would be a compile error rather than a runtime mismatch.
+const RECORDS: &[(&str, &str, i64)] = &[
+    ("alpha", "first", 1),
+    ("beta", "second", 2),
+    ("gamma", "third", 3),
+];
+
+const TEST_PATH: &str = "/var/lib/nauka/p1-9-integration.skv";
+const TABLE: &str = "p1_9_record";
+
+fn print_help() {
+    println!("nauka p1-9 integration — EmbeddedDb<SurrealKv> persist-across-restart");
+    println!();
+    println!("Used by P1.9 (sifrah/nauka#199) to prove that data written via");
+    println!("EmbeddedDb<SurrealKv> survives a process restart on a real");
+    println!("Hetzner host. Run by the test runner in two phases.");
+    println!();
+    println!("USAGE:");
+    println!("    p1-9-integration <PHASE>");
+    println!();
+    println!("PHASES:");
+    println!("    seed     Open the datastore, create 3 records, select them");
+    println!("             back, exit. Datastore is at:");
+    println!("             {TEST_PATH}");
+    println!("    verify   Open the datastore in a fresh process, list all");
+    println!("             records, assert the 3 records from `seed` are");
+    println!("             still there with their original values, exit 0.");
+    println!("    -h       Print this help and exit.");
+    println!("    --help");
+    println!();
+    println!("The test runner is responsible for the surrounding ritual:");
+    println!("provision the VM, scp the binary, run `seed`, run `verify`, then");
+    println!("delete the VM. The binary itself does not touch hcloud.");
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let phase = match std::env::args().nth(1).as_deref() {
+        Some("-h") | Some("--help") => {
+            print_help();
+            return Ok(());
+        }
+        Some("seed") => "seed",
+        Some("verify") => "verify",
+        Some(other) => {
+            eprintln!("error: unknown phase: {other}");
+            eprintln!("hint:  run `--help` for usage");
+            std::process::exit(2);
+        }
+        None => {
+            eprintln!("error: phase required (seed | verify)");
+            eprintln!("hint:  run `--help` for usage");
+            std::process::exit(2);
+        }
+    };
+
+    let path = PathBuf::from(TEST_PATH);
+    println!("== nauka p1-9 integration ==");
+    println!("phase          = {phase}");
+    println!("path           = {}", path.display());
+    println!("target_arch    = {}", std::env::consts::ARCH);
+    println!("target_os      = {}", std::env::consts::OS);
+    println!("expected_count = {}", RECORDS.len());
+
+    let db = EmbeddedDb::open(&path).await?;
+    println!("opened         = {}", db.path().display());
+
+    match phase {
+        "seed" => seed(&db).await?,
+        "verify" => verify(&db).await?,
+        _ => unreachable!(),
+    }
+
+    db.shutdown().await?;
+    println!("== p1-9 {phase} OK ==");
+    Ok(())
+}
+
+async fn seed(db: &EmbeddedDb) -> Result<(), Box<dyn std::error::Error>> {
+    // The test runner is responsible for delivering a clean
+    // /var/lib/nauka/p1-9-integration.skv before invoking `seed` —
+    // attempting to pre-clean records here would actually error,
+    // because SurrealDB returns NotFound on `delete` against a
+    // never-touched table. Trust the runner.
+
+    // Create the three fixture records.
+    for (id, name, count) in RECORDS {
+        let created: Option<Record> = db
+            .client()
+            .create((TABLE, *id))
+            .content(Record {
+                name: (*name).into(),
+                count: *count,
+            })
+            .await?;
+        let created = created.expect("create returned None");
+        println!(
+            "created        = id={id} name={} count={}",
+            created.name, created.count
+        );
+    }
+
+    // In-process round-trip: select-by-id for each record and assert
+    // the round-trip works before we even consider the restart case.
+    for (id, name, count) in RECORDS {
+        let fetched: Option<Record> = db.client().select((TABLE, *id)).await?;
+        let fetched =
+            fetched.unwrap_or_else(|| panic!("seed: in-process select for id={id} returned None"));
+        assert_eq!(fetched.name, *name, "seed: name mismatch for id={id}");
+        assert_eq!(fetched.count, *count, "seed: count mismatch for id={id}");
+    }
+
+    let all: Vec<Record> = db.client().select(TABLE).await?;
+    println!("seed_count     = {}", all.len());
+    assert_eq!(
+        all.len(),
+        RECORDS.len(),
+        "seed: expected {} records, got {}",
+        RECORDS.len(),
+        all.len()
+    );
+    Ok(())
+}
+
+async fn verify(db: &EmbeddedDb) -> Result<(), Box<dyn std::error::Error>> {
+    // Cross-process verification: this binary was started fresh after
+    // the seed phase exited. Reading the same records here proves the
+    // data is on disk and not in some long-lived in-memory state.
+
+    let all: Vec<Record> = db.client().select(TABLE).await?;
+    println!("verify_count   = {}", all.len());
+    assert_eq!(
+        all.len(),
+        RECORDS.len(),
+        "verify: expected {} records after restart, got {}",
+        RECORDS.len(),
+        all.len()
+    );
+
+    for (id, name, count) in RECORDS {
+        let fetched: Option<Record> = db.client().select((TABLE, *id)).await?;
+        let fetched = fetched.unwrap_or_else(|| {
+            panic!("verify: post-restart select for id={id} returned None — data lost?")
+        });
+        assert_eq!(
+            fetched.name, *name,
+            "verify: name mismatch for id={id} (lost write?)"
+        );
+        assert_eq!(
+            fetched.count, *count,
+            "verify: count mismatch for id={id} (corrupted?)"
+        );
+        println!(
+            "verified       = id={id} name={} count={}",
+            fetched.name, fetched.count
+        );
+    }
+
+    println!(
+        "verify_status  = all {} records intact across restart",
+        RECORDS.len()
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Adds the P1.9 integration binary `p1-9-integration` and the captured artifact from a real two-phase run on a freshly-provisioned Hetzner VM (`node-p1-9`, cpx22 / ubuntu-24.04 / fsn1).
- Proves end-to-end that data written by `EmbeddedDb<SurrealKv>` survives a binary restart on a real Hetzner Ubuntu host. The "restart" between phases is the binary process exiting and being re-invoked — a real process boundary, not an in-process drop+reopen.

## How it ran

The binary takes a phase argument:

| Phase | What it does |
|---|---|
| `seed` | Open `EmbeddedDb` at `/var/lib/nauka/p1-9-integration.skv`, create 3 fixture records (`alpha`/`first`/`1`, `beta`/`second`/`2`, `gamma`/`third`/`3`), in-process select them back, exit. |
| `verify` | Open the **same** path in a **new** process, list every record, assert all three are still there with their original values, exit. |

```bash
hcloud server create --name node-p1-9 --type cpx22 --image ubuntu-24.04 --location fsn1 ...
cargo build --target x86_64-unknown-linux-musl -p nauka-state --bin p1-9-integration --release
scp .../p1-9-integration root@$IP:/root/p1-9-integration
ssh root@$IP 'rm -rf /var/lib/nauka/p1-9-integration.skv'
ssh root@$IP '/root/p1-9-integration seed'        # Phase 1 → exit 0
ssh root@$IP 'ls /var/lib/nauka/p1-9-integration.skv/'  # LOCK + manifest + sstables + vlog + wal
ssh root@$IP '/root/p1-9-integration verify'      # Phase 2 → exit 0
ssh root@$IP 'rm -rf /var/lib/nauka/p1-9-integration.skv && rm /root/p1-9-integration'
hcloud server delete node-p1-9                    # cleanup
```

## Acceptance criteria — all met
- [x] Provision an x86 Hetzner VM via `hcloud` — `node-p1-9` (cpx22 / ubuntu-24.04 / fsn1)
- [x] Cross-compile, scp, run an integration test binary — 54 MB statically-linked musl x86_64
- [x] Cycle: open → create 3 records → select → restart → reopen → select returns same 3 records — both phases exit 0, all 3 records intact across the process boundary
- [x] Cleanup: tear down VM after test — `hcloud server delete node-p1-9` confirmed
- [x] Logs uploaded as artifact — `docs/spikes/p1-9-hetzner-integration.md` (full captured stdout for both phases, plus the intermediate `ls` of the on-disk SurrealKV state)

## Highlights from the captured artifact

```
===== PHASE 1: SEED =====
created        = id=alpha name=first count=1
created        = id=beta name=second count=2
created        = id=gamma name=third count=3
seed_count     = 3
== p1-9 seed OK ==

===== INTERMEDIATE: ON-DISK STATE =====
LOCK         (5 bytes)
manifest/    sstables/    vlog/    wal/

===== PHASE 2: VERIFY (post-restart) =====
verify_count   = 3
verified       = id=alpha name=first count=1
verified       = id=beta name=second count=2
verified       = id=gamma name=third count=3
verify_status  = all 3 records intact across restart
== p1-9 verify OK ==
```

## Findings

1. **Persistence works.** Data written by the seed process is observable from a fresh verify process. The bytes are on disk, not in shared memory or a long-lived buffer.
2. **The P1.5 shutdown wait holds up.** The 50ms wait we added to `EmbeddedDb::shutdown` is enough to release the SurrealKV LOCK file between two binary invocations on a real filesystem — no `Database is already locked` error.
3. **Default umask on the SurrealKV-created files is 0o755 / 0o644** on this Hetzner box. The `/var/lib/nauka` parent dir is `0o700` per P1.4, but the SurrealKV subdirectory inherits the process umask. The WAL subdir at `0o750` is the most-protected piece. **Documented as a follow-up** in the artifact — not a blocker for P1.9 but worth a future ticket to tighten.

## Test plan
- [x] `cargo test -p nauka-state` — **29 lib tests + doctests pass**, no regression
- [x] `cargo clippy -p nauka-state --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Native build of `p1-9-integration` — clean
- [x] Cross-compile musl x86_64 — clean (54 MB binary, statically linked)
- [x] **Hetzner integration run** as documented above — both phases exit 0, full logs captured in `docs/spikes/p1-9-hetzner-integration.md`
- [x] VM destroyed after the test

## Files touched
- `layers/state/src/bin/p1_9_integration.rs` — **new**: integration binary with `seed` / `verify` / `--help` modes
- `layers/state/Cargo.toml` — `[[bin]] p1-9-integration` entry
- `docs/spikes/p1-9-hetzner-integration.md` — **new**: the captured stdout artifact + how-it-ran documentation + findings

## Files NOT touched
- The VM. `node-p1-9` was deleted at the end of the test as required by the cleanup criterion.

Closes #199.
Epic: #183