### PR TITLE
feat(P1.12): remove legacy LocalDb code and dirs dep from nauka-state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2901,7 +2901,6 @@ dependencies = [
 name = "nauka-state"
 version = "2.0.0"
 dependencies = [
- "dirs",
  "nauka-core",
  "openssl",
  "serde",

--- a/layers/state/Cargo.toml
+++ b/layers/state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nauka-state"
-description = "State persistence for Nauka — local JSON + distributed TiKV"
+description = "State persistence for Nauka — embedded SurrealDB (SurrealKV) + distributed TiKV"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -19,7 +19,6 @@ nauka-core = { path = "../core" }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-dirs = "5"
 tikv-client = "0.4"
 tokio.workspace = true
 # Force vendored OpenSSL into the build graph: tikv-client (and, when the

--- a/layers/state/src/embedded.rs
+++ b/layers/state/src/embedded.rs
@@ -148,9 +148,9 @@ impl EmbeddedDb {
         // `Other("Database at ... LOCK is already locked by another process")`.
         //
         // Before P1.11 (sifrah/nauka#201), this was masked because every
-        // CLI caller used the JSON-file `LocalDb` backend, which doesn't
-        // use an exclusive flock. P1.11 migrates every caller to
-        // `EmbeddedDb`, so the contention becomes real.
+        // CLI caller used the legacy JSON-file bootstrap backend, which
+        // did not take an exclusive flock. P1.11 migrated every caller
+        // to `EmbeddedDb`, so the contention became real.
         //
         // The fix: retry the open on "already locked" with exponential
         // backoff up to a 5-second deadline, matching the pattern used

--- a/layers/state/src/lib.rs
+++ b/layers/state/src/lib.rs
@@ -1,17 +1,22 @@
 #![allow(clippy::result_large_err)]
 //! State persistence for Nauka.
 //!
-//! Three backends, in increasing order of where they live:
+//! Two backends, in the order they appear at a node's lifetime:
+//!
 //! - **`EmbeddedDb`** — embedded SurrealDB on disk via the SurrealKV backend.
 //!   Used for **bootstrap** state that must be readable before any cluster
-//!   exists (mesh identity, hypervisor identity, peers, WireGuard keys).
-//!   This is the long-term replacement for `LocalDb`.
-//! - **`LocalDb`** — legacy JSON file store. Still in use; will be retired
-//!   by P1.10–P1.12 (sifrah/nauka#200 → sifrah/nauka#202).
+//!   exists (mesh identity, hypervisor identity, peers, WireGuard keys,
+//!   storage region registry). This is the single source of truth for
+//!   per-node state.
 //! - **`ClusterDb`** — TiKV-backed distributed raw KV store for shared state
 //!   (orgs, projects, VMs, VPCs, etc.). Will be retired by P2.16
 //!   (sifrah/nauka#220) once the SurrealDB SDK in `kv-tikv` mode (P2.x) takes
 //!   over.
+//!
+//! A legacy JSON-file bootstrap store shipped alongside `EmbeddedDb`
+//! through P1.2–P1.11. P1.11 (sifrah/nauka#201) migrated every caller
+//! to `EmbeddedDb`, and P1.12 (sifrah/nauka#202) removed the legacy
+//! code and its `dirs` dep from this crate.
 //!
 //! # SurrealDB namespace / database conventions
 //!
@@ -34,30 +39,9 @@
 //! db.shutdown().await?;
 //! # Ok(()) }
 //! ```
-//!
-//! # Usage — `LocalDb` (legacy JSON, to be retired)
-//!
-//! ```no_run
-//! use nauka_state::LocalDb;
-//! use serde::{Serialize, Deserialize};
-//!
-//! #[derive(Serialize, Deserialize)]
-//! struct Peer { name: String }
-//!
-//! let db = LocalDb::open("fabric").unwrap();
-//! db.set("state", "main", &Peer { name: "node-1".into() }).unwrap();
-//! let peer: Option<Peer> = db.get("state", "main").unwrap();
-//! ```
 
 pub mod cluster;
 pub mod embedded;
-
-use std::collections::HashMap;
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
-
-use serde::de::DeserializeOwned;
-use serde::Serialize;
 
 pub use cluster::ClusterDb;
 pub use embedded::EmbeddedDb;
@@ -119,9 +103,14 @@ pub enum StateError {
     #[error("not found: {0}")]
     NotFound(String),
 
-    /// A serde / JSON serialization error from the legacy `LocalDb` and
-    /// `ClusterDb` paths. Will go away when those layers are deleted in
-    /// P1.12 (sifrah/nauka#202) and P2.16 (sifrah/nauka#220).
+    /// A serde / JSON serialization error.
+    ///
+    /// Surfaced today by [`ClusterDb`] (which still serializes values as
+    /// raw JSON under TiKV) and by the JSON-bridge paths on `EmbeddedDb`
+    /// that round-trip Rust structs through `serde_json::Value` before
+    /// handing them to SurrealDB. Phase 2 (sifrah/nauka#220) retires the
+    /// `ClusterDb` half; Phase 3 codegen (sifrah/nauka#225 ff) retires
+    /// the JSON-bridge half, at which point this variant goes away.
     #[error("serialization error: {0}")]
     Serialization(String),
 
@@ -156,288 +145,9 @@ impl From<surrealdb::Error> for StateError {
 
 pub type Result<T> = std::result::Result<T, StateError>;
 
-// ═══════════════════════════════════════════════════
-// LocalDb — JSON file store for bootstrap state
-// ═══════════════════════════════════════════════════
-
-fn nauka_dir() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".nauka")
-}
-
-/// Store layout: `~/.nauka/{layer}.json`
-/// Internal format: `{ "table/key": <json_value>, ... }`
-type StoreMap = HashMap<String, serde_json::Value>;
-
-/// Local JSON file-backed store. Used for bootstrap state that must
-/// be available before TiKV starts (mesh identity, WG keys, peers).
-///
-/// Thread-safe via `Arc<Mutex<...>>`. Clone is cheap.
-#[derive(Clone, Debug)]
-pub struct LocalDb {
-    path: PathBuf,
-    data: Arc<Mutex<StoreMap>>,
-}
-
-impl LocalDb {
-    /// Open (or create) a local store for a layer.
-    /// Stores at `~/.nauka/{layer}.json`.
-    pub fn open(layer: &str) -> Result<Self> {
-        let dir = nauka_dir();
-        std::fs::create_dir_all(&dir)?;
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
-        }
-
-        let path = dir.join(format!("{layer}.json"));
-        Self::open_at(&path)
-    }
-
-    /// Open at a specific path.
-    pub fn open_at(path: &std::path::Path) -> Result<Self> {
-        let data = if path.exists() {
-            let contents = std::fs::read_to_string(path)?;
-            serde_json::from_str(&contents).map_err(|e| StateError::Serialization(e.to_string()))?
-        } else {
-            StoreMap::new()
-        };
-
-        #[cfg(unix)]
-        if path.exists() {
-            use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
-        }
-
-        Ok(Self {
-            path: path.to_path_buf(),
-            data: Arc::new(Mutex::new(data)),
-        })
-    }
-
-    /// Set a value (serialized to JSON).
-    pub fn set<T: Serialize>(&self, table: &str, key: &str, value: &T) -> Result<()> {
-        let json_value =
-            serde_json::to_value(value).map_err(|e| StateError::Serialization(e.to_string()))?;
-
-        let compound_key = format!("{table}/{key}");
-
-        let mut data = self.data.lock().unwrap_or_else(|e| e.into_inner());
-        data.insert(compound_key, json_value);
-        self.flush(&data)
-    }
-
-    /// Get a value (deserialized from JSON).
-    pub fn get<T: DeserializeOwned>(&self, table: &str, key: &str) -> Result<Option<T>> {
-        let compound_key = format!("{table}/{key}");
-        let data = self.data.lock().unwrap_or_else(|e| e.into_inner());
-
-        match data.get(&compound_key) {
-            Some(val) => {
-                let parsed = serde_json::from_value(val.clone())
-                    .map_err(|e| StateError::Serialization(e.to_string()))?;
-                Ok(Some(parsed))
-            }
-            None => Ok(None),
-        }
-    }
-
-    /// Delete a key.
-    pub fn delete(&self, table: &str, key: &str) -> Result<()> {
-        let compound_key = format!("{table}/{key}");
-        let mut data = self.data.lock().unwrap_or_else(|e| e.into_inner());
-        data.remove(&compound_key);
-        self.flush(&data)
-    }
-
-    /// Check if a key exists.
-    pub fn exists(&self, table: &str, key: &str) -> Result<bool> {
-        let compound_key = format!("{table}/{key}");
-        let data = self.data.lock().unwrap_or_else(|e| e.into_inner());
-        Ok(data.contains_key(&compound_key))
-    }
-
-    /// Flush to disk.
-    fn flush(&self, data: &StoreMap) -> Result<()> {
-        let json = serde_json::to_string_pretty(data)
-            .map_err(|e| StateError::Serialization(e.to_string()))?;
-        std::fs::write(&self.path, json)?;
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(&self.path, std::fs::Permissions::from_mode(0o600));
-        }
-
-        Ok(())
-    }
-}
-
-// Backward compat alias — hypervisor code uses LayerDb
-pub type LayerDb = LocalDb;
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde::{Deserialize, Serialize};
-
-    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-    struct TestPeer {
-        name: String,
-        zone: String,
-    }
-
-    #[test]
-    fn open_creates_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("test.json");
-        let db = LocalDb::open_at(&path).unwrap();
-        db.set(
-            "peers",
-            "n1",
-            &TestPeer {
-                name: "n1".into(),
-                zone: "fsn1".into(),
-            },
-        )
-        .unwrap();
-        assert!(path.exists());
-    }
-
-    #[test]
-    fn set_and_get() {
-        let dir = tempfile::tempdir().unwrap();
-        let db = LocalDb::open_at(&dir.path().join("test.json")).unwrap();
-
-        let peer = TestPeer {
-            name: "node-1".into(),
-            zone: "fsn1".into(),
-        };
-        db.set("peers", "n1", &peer).unwrap();
-
-        let loaded: Option<TestPeer> = db.get("peers", "n1").unwrap();
-        assert_eq!(loaded, Some(peer));
-    }
-
-    #[test]
-    fn get_missing() {
-        let dir = tempfile::tempdir().unwrap();
-        let db = LocalDb::open_at(&dir.path().join("test.json")).unwrap();
-        let result: Option<TestPeer> = db.get("peers", "nope").unwrap();
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn delete_key() {
-        let dir = tempfile::tempdir().unwrap();
-        let db = LocalDb::open_at(&dir.path().join("test.json")).unwrap();
-
-        db.set("peers", "n1", &"value").unwrap();
-        assert!(db.exists("peers", "n1").unwrap());
-
-        db.delete("peers", "n1").unwrap();
-        assert!(!db.exists("peers", "n1").unwrap());
-    }
-
-    #[test]
-    fn exists_check() {
-        let dir = tempfile::tempdir().unwrap();
-        let db = LocalDb::open_at(&dir.path().join("test.json")).unwrap();
-
-        assert!(!db.exists("peers", "n1").unwrap());
-        db.set("peers", "n1", &"value").unwrap();
-        assert!(db.exists("peers", "n1").unwrap());
-    }
-
-    #[test]
-    fn persistence_across_opens() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("test.json");
-
-        {
-            let db = LocalDb::open_at(&path).unwrap();
-            db.set(
-                "state",
-                "main",
-                &TestPeer {
-                    name: "n1".into(),
-                    zone: "fsn1".into(),
-                },
-            )
-            .unwrap();
-        }
-
-        {
-            let db = LocalDb::open_at(&path).unwrap();
-            let loaded: Option<TestPeer> = db.get("state", "main").unwrap();
-            assert_eq!(loaded.unwrap().name, "n1");
-        }
-    }
-
-    #[test]
-    fn overwrite_value() {
-        let dir = tempfile::tempdir().unwrap();
-        let db = LocalDb::open_at(&dir.path().join("test.json")).unwrap();
-
-        db.set("k", "v", &"first").unwrap();
-        db.set("k", "v", &"second").unwrap();
-
-        let val: Option<String> = db.get("k", "v").unwrap();
-        assert_eq!(val, Some("second".into()));
-    }
-
-    #[test]
-    fn multiple_tables() {
-        let dir = tempfile::tempdir().unwrap();
-        let db = LocalDb::open_at(&dir.path().join("test.json")).unwrap();
-
-        db.set("peers", "n1", &"peer-data").unwrap();
-        db.set("mesh", "id", &"mesh-data").unwrap();
-
-        let p: Option<String> = db.get("peers", "n1").unwrap();
-        let m: Option<String> = db.get("mesh", "id").unwrap();
-        assert_eq!(p, Some("peer-data".into()));
-        assert_eq!(m, Some("mesh-data".into()));
-    }
-
-    #[test]
-    fn serde_roundtrip_complex() {
-        let dir = tempfile::tempdir().unwrap();
-        let db = LocalDb::open_at(&dir.path().join("test.json")).unwrap();
-
-        let data = serde_json::json!({
-            "name": "node-1",
-            "peers": ["n2", "n3"],
-            "nested": { "key": "value" },
-        });
-        db.set("state", "main", &data).unwrap();
-
-        let loaded: Option<serde_json::Value> = db.get("state", "main").unwrap();
-        assert_eq!(loaded.unwrap()["name"], "node-1");
-    }
-
-    #[test]
-    fn open_empty_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("test.json");
-        // Don't create the file — open should create it
-        let db = LocalDb::open_at(&path).unwrap();
-        assert!(!db.exists("any", "key").unwrap());
-    }
-
-    #[test]
-    fn clone_is_cheap() {
-        let dir = tempfile::tempdir().unwrap();
-        let db = LocalDb::open_at(&dir.path().join("test.json")).unwrap();
-        db.set("k", "v", &"value").unwrap();
-
-        let db2 = db.clone();
-        let val: Option<String> = db2.get("k", "v").unwrap();
-        assert_eq!(val, Some("value".into()));
-    }
 
     // ─── Error mapping (P1.3, sifrah/nauka#193) ──────────────────────
 


### PR DESCRIPTION
## Summary

Closes sifrah/nauka#202. Epic: sifrah/nauka#183.

Deletes the JSON-file bootstrap store that shipped alongside `EmbeddedDb` through P1.2–P1.11. P1.11 (sifrah/nauka#256) migrated every caller to `EmbeddedDb` and left the legacy type in `layers/state/src/lib.rs` marked "to-be-deleted"; this change finishes that job.

## Removed

- `LocalDb` struct, `impl LocalDb`, and the `LayerDb` type alias
- The `nauka_dir()` helper and `StoreMap` type — only used by `LocalDb`
- 11 `LocalDb` unit tests
- The `# Usage — LocalDb` module-level doctest in `lib.rs`
- Historical doc references to `LocalDb` by name in `lib.rs` / `embedded.rs`
- `dirs = "5"` from `layers/state/Cargo.toml`

## Kept

- **`StateError::Serialization`** stays — `ClusterDb` still serializes values as raw JSON under TiKV, and the JSON-bridge paths on `EmbeddedDb` (`FabricState::save`, `RegionRegistry::save`) still round-trip Rust structs through `serde_json::Value` before handing them to SurrealDB. The variant's docstring is updated to reflect the two remaining users; Phase 2 (sifrah/nauka#220) retires the `ClusterDb` half, Phase 3 codegen (sifrah/nauka#225 ff) retires the JSON-bridge half, at which point the variant goes away.
- **`dirs`** is still a transitive dep via `nauka-core` (which uses it for CLI-mode path helpers). Only the direct `nauka-state → dirs` edge is removed; `cargo tree -p nauka-core -e normal` still shows `dirs 5.0.1` in place.

## Acceptance criteria (sifrah/nauka#202) — all met

- [x] Struct `LocalDb` removed
- [x] Alias `LayerDb` removed
- [x] `dirs = "5"` removed from `Cargo.toml`
- [x] Workspace builds and tests pass

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p nauka-state` — **19 unit + 3 doctests pass** (down from 30 unit + 4 doc in P1.11 by exactly the 11 `LocalDb` tests + 1 doctest this change deletes)
- [x] `cargo test --workspace -- --test-threads=1` — every crate green, except the pre-existing macOS-only `doctor::tests::disk_free_check` which is unrelated (documented in PR sifrah/nauka#255)
- [x] Cross-compile `x86_64-unknown-linux-musl` release — clean, statically linked
- [x] `grep -rn 'LocalDb\|LayerDb' layers/` — **zero hits**
- [x] Hetzner full lifecycle on a fresh `node-p1-12`: init → status / list / doctor (16 passed / 2 warnings / 0 errors) with a live forge + announce daemon → VM destroyed

## Stats

- **4 files changed, +22 / -314**
- `layers/state/src/lib.rs`, `layers/state/src/embedded.rs`, `layers/state/Cargo.toml`, `Cargo.lock`

## Follow-ups (tracked separately)

- **P1.13 (sifrah/nauka#203)** — rewrite `nauka-state` README and module docs.
- **P2.16 (sifrah/nauka#220)** — retire `ClusterDb` (raw TiKV) in favor of `EmbeddedDb<TiKv>`. Closes the second half of the serialization-variant justification above.
- **Phase 3 codegen (sifrah/nauka#225 ff)** — retire the SCHEMALESS `fabric` / `regions` JSON-blob tables by splitting them across SCHEMAFULL tables. Closes the first half.