### PR TITLE
ci(P1.14): install cmake in all GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,8 @@ jobs:
         crate: ${{ fromJson(needs.discover.outputs.crates) }}
     steps:
       - uses: actions/checkout@v4
+      - name: Install cmake
+        run: sudo apt-get update && sudo apt-get install -y cmake
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,6 +71,9 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
+      - name: Install cmake
+        run: sudo apt-get update && sudo apt-get install -y cmake
+
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,6 +45,8 @@ jobs:
     name: "e2e: ${{ matrix.crate }}"
     steps:
       - uses: actions/checkout@v4
+      - name: Install cmake
+        run: sudo apt-get update && sudo apt-get install -y cmake
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run E2E tests
@@ -55,6 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install cmake
+        run: sudo apt-get update && sudo apt-get install -y cmake
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build
@@ -71,6 +75,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install cmake
+        run: sudo apt-get update && sudo apt-get install -y cmake
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -87,6 +87,12 @@ jobs:
             os: macos-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install cmake (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y cmake
+      - name: Install cmake (macOS)
+        if: runner.os == 'macOS'
+        run: brew install cmake || brew upgrade cmake
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}


### PR DESCRIPTION
## Summary

SurrealDB v3 pulls in `aws-lc-sys` (via `jsonwebtoken`) and other native crates that need `cmake` on the build host. GitHub Actions hosted runners do not ship `cmake` by default. CI has been getting away with it because `aws-lc-sys` ships pre-built variants, but the project owner wants the dependency made explicit so future build configurations don't break silently.

This PR adds an `Install cmake` step to every CI job that compiles Rust code, immediately after `actions/checkout@v4` and before any cargo invocation.

## Files changed

- `.github/workflows/ci.yml` — `check` job (clippy + per-crate test matrix)
- `.github/workflows/e2e.yml` — `e2e`, `cli`, `unit` jobs
- `.github/workflows/nightly.yml` — `build` job, with `runner.os` conditional for the mixed Ubuntu/macOS matrix
- `.github/workflows/docs.yml` — `build` job (`cargo run --bin nauka-openapi` + `cargo doc`)

Untouched (no Rust compilation):
- `ci.yml`: `secrets`, `gitignore`, `fmt`, `discover`
- `e2e.yml`: `discover`
- `nightly.yml`: `version`, `release`
- `docs.yml`: `resolve`, `deploy`
- `promote.yml`: tag/release shuffler only

## Install pattern

Linux:
```yaml
- name: Install cmake
  run: sudo apt-get update && sudo apt-get install -y cmake
```

macOS (`nightly.yml` only):
```yaml
- name: Install cmake (macOS)
  if: runner.os == 'macOS'
  run: brew install cmake || brew upgrade cmake
```

## Dependencies

Built on top of #256 (P1.11) and #257 (P1.12), both now merged into main.

## Test plan

- [x] All workflow YAML files parse with yaml.safe_load
- [x] Local cargo build --workspace still succeeds
- [x] CI runs on this PR exercise every touched workflow with cmake available
- [ ] Build CI passes on main after merge

Closes sifrah/nauka#204