### PR TITLE
docs(P1.13): rewrite nauka-state README and module docs around EmbeddedDb

### DIFF
--- a/layers/state/README.md
+++ b/layers/state/README.md
@@ -1,13 +1,176 @@
 # nauka-state
 
-State persistence for Nauka.
+State persistence for Nauka. This crate is the only place in the workspace
+that knows how Nauka's data is laid out on disk, and it exposes two
+storage backends — one local, one distributed — that together cover every
+piece of state a Nauka deployment needs.
 
-- `EmbeddedDb` — embedded SurrealDB over the SurrealKV engine, used for
-  node-local bootstrap state (mesh identity, peers, WireGuard keys).
-- `ClusterDb` — TiKV-backed distributed KV for shared cluster state
-  (orgs, VPCs, VMs, ...). Being replaced by `EmbeddedDb<TiKv>` in Phase 2.
+- [`EmbeddedDb`](src/embedded.rs) — embedded SurrealDB over the SurrealKV
+  on-disk engine. Per-node bootstrap state.
+- [`ClusterDb`](src/cluster.rs) — TiKV-backed raw KV store for shared
+  cluster state. Replaced by `EmbeddedDb` over the `kv-tikv` backend in
+  Phase 2 (sifrah/nauka#206 / sifrah/nauka#220).
 
-See `src/embedded.rs` for the current API surface and `schemas/bootstrap.surql`
-for the bootstrap schema that `EmbeddedDb::open` applies at startup.
+The two backends never hold the same data: bootstrap state lives locally
+on each node, everything else lives in the cluster store. There is no
+synchronization or conflict resolution between the tiers.
 
-A full rewrite of this document lands in sifrah/nauka#203 (P1.13).
+## Backend 1 — `EmbeddedDb` over SurrealKV
+
+`EmbeddedDb` is the single source of truth for everything a node needs
+to read **before** the mesh is up: mesh identity, hypervisor identity,
+the WireGuard keypair, the peer list, and the storage region registry.
+It is a thin wrapper around `surrealdb::Surreal<Db>` that adds a
+Nauka-friendly lifecycle (`open` / `client` / `shutdown`), a fixed
+`nauka` / `bootstrap` namespace/database (per ADR 0003,
+sifrah/nauka#190), and automatic application of the bootstrap schema.
+
+### On-disk layout
+
+The datastore is a directory of SurrealKV files. Its location depends on
+how the binary is invoked:
+
+| Run mode    | Path                              |
+|-------------|-----------------------------------|
+| CLI mode    | `~/.nauka/bootstrap.skv/`         |
+| Service mode (root) | `/var/lib/nauka/bootstrap.skv/` |
+
+The two-mode resolution is performed by
+[`nauka_core::process::nauka_db_path`](../core/src/process.rs). Use
+[`EmbeddedDb::open_default`](src/embedded.rs) to get the right path
+automatically; use [`EmbeddedDb::open`](src/embedded.rs) when you need to
+target a specific directory (for example in tests).
+
+The parent state directory is created with mode `0o700` so that only
+the owning user can read it. This matters because the database holds
+WireGuard private keys and the mesh secret hash.
+
+### Schema
+
+The bootstrap schema lives in [`schemas/bootstrap.surql`](schemas/bootstrap.surql)
+and is embedded into the binary at compile time via `include_str!`.
+`EmbeddedDb::open` runs it on every open. Every `DEFINE` statement uses
+`IF NOT EXISTS`, so re-applying against an already-initialised database
+is a no-op and adding new fields in later releases is forward-compatible.
+
+The schema currently defines four SCHEMAFULL tables:
+
+- `mesh` — singleton row at `mesh:current` with the mesh's IPv6 ULA
+  prefix, a hash of the mesh secret, and creation timestamp.
+- `hypervisor` — this node's identity, keyed by its ULID record id.
+  Holds name, mesh IPv6, WireGuard public key, and role.
+- `peer` — every other node this one knows about, keyed by mesh IPv6.
+  Holds public key, optional public endpoint, and last-seen handshake.
+- `wg_key` — this node's WireGuard private/public keypair (singleton).
+
+A SCHEMALESS `fabric` table backs the JSON-bridge `FabricState` used by
+the hypervisor layer, and a SCHEMALESS `regions` table backs the storage
+region registry.
+
+### Concurrency
+
+SurrealKV holds an OS-level exclusive flock on `<path>/LOCK` while a
+`Datastore` is open, so only one process can hold the database at a
+time. Nauka has multiple short-lived consumers of the same
+`bootstrap.skv` (ad-hoc CLI calls, the `nauka-forge` reconcile loop,
+the announce listener), so `EmbeddedDb::open` retries on flock
+contention with exponential backoff up to a 5-second deadline, and
+`EmbeddedDb::shutdown` polls the same flock until the previous handle's
+`Datastore::shutdown()` chain has run to completion. Both deadlines
+match the "fast timeout" budget Nauka uses for health checks.
+
+### Code example
+
+```rust
+use nauka_state::EmbeddedDb;
+use std::path::Path;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Open (or create) the SurrealKV datastore. The bootstrap schema
+    // is applied automatically. Use `EmbeddedDb::open_default()` to
+    // pick up the run-mode-aware default path instead.
+    let db = EmbeddedDb::open(Path::new("/var/lib/nauka/bootstrap.skv")).await?;
+
+    // Drop down to the SurrealDB SDK for queries. The wrapper
+    // intentionally does not re-export every SDK method.
+    let _: Vec<surrealdb::types::Value> = db
+        .client()
+        .query("SELECT * FROM peer")
+        .await?
+        .take(0)?;
+
+    // Always shut down explicitly. `shutdown()` waits for SurrealKV's
+    // background router to release the flock so a subsequent open at
+    // the same path will succeed and every committed write is durably
+    // on disk before this returns.
+    db.shutdown().await?;
+    Ok(())
+}
+```
+
+## Backend 2 — `ClusterDb` over TiKV
+
+`ClusterDb` is a raw key-value client for a TiKV cluster reachable over
+the mesh. It serializes values as JSON under compound keys of the form
+`{namespace}/{key}` and is the current home for all shared state that
+must be visible across every node: orgs, projects, VMs, VPCs, subnets,
+volumes, and so on.
+
+This backend is **transitional**. Phase 2 replaces it with an
+`EmbeddedDb` instance configured with the SurrealDB SDK's `kv-tikv`
+backend (P2.1 / sifrah/nauka#205, P2.16 / sifrah/nauka#220). After
+that migration, both bootstrap and cluster state will go through the
+same `EmbeddedDb` API and `ClusterDb` will be deleted. New code should
+prefer SurrealQL-flavoured patterns over raw KV ones to make that
+transition cheap.
+
+`ClusterDb::connect` takes one or more PD endpoints (TiKV's coordination
+service) on the mesh's IPv6 ULA range. PD is responsible for shard
+discovery and request routing — callers point at PD, not at individual
+TiKV nodes. A typical endpoint looks like `http://[fd01::1]:2379`.
+
+## Errors
+
+Every fallible call returns [`Result<T, StateError>`](src/lib.rs). The
+variants are deliberately coarse:
+
+- `StateError::Database` — connection failures, query errors, internal
+  engine errors, anything that does not fit the more specific variants.
+- `StateError::Schema` — SCHEMAFULL violations, `ASSERT` failures, and
+  unique-index conflicts. Mapped from `surrealdb::Error::is_validation()`
+  and `is_already_exists()`.
+- `StateError::NotFound` — record / table / namespace / database does
+  not exist. Mapped from `surrealdb::Error::is_not_found()`.
+- `StateError::Serialization` — serde / JSON serialization errors,
+  surfaced today by the `ClusterDb` JSON layer and the `EmbeddedDb`
+  JSON-bridge tables.
+- `StateError::Io` — filesystem-level errors (`From<std::io::Error>`).
+
+The classification of `surrealdb::Error` into these variants is
+conservative: only the three explicit predicates above get specific
+variants, everything else collapses to `Database`.
+
+## Constants
+
+The SurrealDB namespace and database names are exported as constants so
+no call site inlines the string literal:
+
+- `NAUKA_NS = "nauka"` — the only namespace Nauka writes to.
+- `BOOTSTRAP_DB = "bootstrap"` — the local SurrealKV database.
+- `CLUSTER_DB = "cluster"` — reserved for the Phase 2 TiKV-backed
+  `EmbeddedDb` constructor.
+
+## File layout
+
+```
+layers/state/
+├── README.md
+├── Cargo.toml
+├── schemas/
+│   └── bootstrap.surql      # SCHEMAFULL DDL applied by EmbeddedDb::open
+└── src/
+    ├── lib.rs               # StateError, constants, re-exports
+    ├── embedded.rs          # EmbeddedDb (SurrealKV)
+    └── cluster.rs           # ClusterDb (TiKV, transitional)
+```

--- a/layers/state/src/cluster.rs
+++ b/layers/state/src/cluster.rs
@@ -1,9 +1,19 @@
 //! Distributed state backed by TiKV.
 //!
-//! Provides a key/value API over TiKV for distributed, replicated state
-//! across the mesh.
+//! Provides a raw key/value API over a TiKV cluster for shared state that
+//! must be visible across every node in the mesh: orgs, projects, VMs,
+//! VPCs, subnets, volumes, and so on. Values are JSON-serialized; keys
+//! are partitioned by namespace via the compound form `{namespace}/{key}`.
 //!
-//! Keys are prefixed by namespace: `{namespace}/{key}` to partition data.
+//! # Status
+//!
+//! `ClusterDb` is **transitional**. Phase 2 (sifrah/nauka#206 /
+//! sifrah/nauka#220) replaces it with [`EmbeddedDb`](crate::EmbeddedDb)
+//! configured with the SurrealDB SDK's `kv-tikv` backend, after which
+//! both bootstrap and cluster state will go through the same wrapper
+//! and `ClusterDb` will be deleted. New call sites should prefer
+//! SurrealQL-flavoured patterns where possible to make that transition
+//! cheap.
 //!
 //! # Usage
 //!

--- a/layers/state/src/embedded.rs
+++ b/layers/state/src/embedded.rs
@@ -3,37 +3,38 @@
 //! Wraps `surrealdb::Surreal<Db>` with a Nauka-friendly lifecycle: a single
 //! `open` constructor that creates the on-disk SurrealKV datastore at a given
 //! path and selects the `nauka` / `bootstrap` namespace/database (per ADR
-//! 0003, sifrah/nauka#190), an accessor for the underlying SDK client, and
-//! an explicit `shutdown` step.
+//! 0003, sifrah/nauka#190), an accessor for the underlying SDK client, an
+//! explicit `shutdown` step that waits for SurrealKV's background router to
+//! release its OS-level flock, and automatic application of the bootstrap
+//! schema (`schemas/bootstrap.surql`) on every open.
 //!
-//! This is the production backend for Nauka's bootstrap state. The legacy
-//! JSON-file store shipped alongside it during P1.2–P1.10; P1.11
-//! (sifrah/nauka#201) migrated every caller to `EmbeddedDb`, and P1.12
-//! (sifrah/nauka#202) will delete the legacy code outright.
-//!
-//! P1.2 (sifrah/nauka#192) introduces only the wrapper struct and its
-//! lifecycle. The companion deliverables — error mapping (P1.3,
-//! sifrah/nauka#193), default-path helpers (P1.4, sifrah/nauka#194),
-//! comprehensive CRUD/persistence tests (P1.5, sifrah/nauka#195), the
-//! initial `.surql` schema (P1.6, sifrah/nauka#196), and applying that
-//! schema at open time (P1.7, sifrah/nauka#197) — each ship as their own
-//! issue.
+//! This is the single source of truth for everything a node needs to read
+//! before the cluster is reachable: mesh identity, hypervisor identity, peer
+//! list, WireGuard keypair, and the storage region registry. See the crate
+//! [`README`](https://github.com/sifrah/nauka/blob/main/layers/state/README.md)
+//! for the full guide and on-disk layout.
 //!
 //! # Example
 //!
 //! ```no_run
-//! # use nauka_state::EmbeddedDb;
-//! # use std::path::Path;
+//! use nauka_state::EmbeddedDb;
+//! use std::path::Path;
+//!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! // Open (or create) the SurrealKV datastore. The bootstrap schema
+//! // is applied automatically. Use `EmbeddedDb::open_default()` to
+//! // pick up the run-mode-aware default path instead.
 //! let db = EmbeddedDb::open(Path::new("/var/lib/nauka/bootstrap.skv")).await?;
 //!
-//! // Use the underlying SurrealDB SDK directly:
+//! // Drop down to the SurrealDB SDK for queries.
 //! let _: Vec<surrealdb::types::Value> = db
 //!     .client()
-//!     .query("INFO FOR DB")
+//!     .query("SELECT * FROM peer")
 //!     .await?
 //!     .take(0)?;
 //!
+//! // Shut down explicitly so the SurrealKV flock is released and a
+//! // subsequent `EmbeddedDb::open` at the same path can succeed.
 //! db.shutdown().await?;
 //! # Ok(()) }
 //! ```
@@ -146,11 +147,6 @@ impl EmbeddedDb {
         // open that happens to collide with another process's brief
         // write window would fail with
         // `Other("Database at ... LOCK is already locked by another process")`.
-        //
-        // Before P1.11 (sifrah/nauka#201), this was masked because every
-        // CLI caller used the legacy JSON-file bootstrap backend, which
-        // did not take an exclusive flock. P1.11 migrated every caller
-        // to `EmbeddedDb`, so the contention became real.
         //
         // The fix: retry the open on "already locked" with exponential
         // backoff up to a 5-second deadline, matching the pattern used

--- a/layers/state/src/lib.rs
+++ b/layers/state/src/lib.rs
@@ -1,22 +1,23 @@
 #![allow(clippy::result_large_err)]
 //! State persistence for Nauka.
 //!
-//! Two backends, in the order they appear at a node's lifetime:
+//! Two backends, one local and one distributed, that together cover every
+//! piece of state a Nauka deployment needs. The two never hold the same
+//! data: bootstrap state lives locally on each node, everything else lives
+//! in the cluster store.
 //!
-//! - **`EmbeddedDb`** — embedded SurrealDB on disk via the SurrealKV backend.
-//!   Used for **bootstrap** state that must be readable before any cluster
-//!   exists (mesh identity, hypervisor identity, peers, WireGuard keys,
-//!   storage region registry). This is the single source of truth for
-//!   per-node state.
-//! - **`ClusterDb`** — TiKV-backed distributed raw KV store for shared state
-//!   (orgs, projects, VMs, VPCs, etc.). Will be retired by P2.16
-//!   (sifrah/nauka#220) once the SurrealDB SDK in `kv-tikv` mode (P2.x) takes
-//!   over.
+//! - [`EmbeddedDb`] — embedded SurrealDB on disk via the SurrealKV backend.
+//!   The single source of truth for per-node bootstrap state that must be
+//!   readable before any cluster exists: mesh identity, hypervisor identity,
+//!   peers, WireGuard keys, and the storage region registry.
+//! - [`ClusterDb`] — TiKV-backed distributed raw KV store for shared state
+//!   (orgs, projects, VMs, VPCs, etc.). Transitional: Phase 2
+//!   (sifrah/nauka#206 / sifrah/nauka#220) replaces it with `EmbeddedDb`
+//!   over the SurrealDB SDK's `kv-tikv` backend, after which the two
+//!   stores share the same API.
 //!
-//! A legacy JSON-file bootstrap store shipped alongside `EmbeddedDb`
-//! through P1.2–P1.11. P1.11 (sifrah/nauka#201) migrated every caller
-//! to `EmbeddedDb`, and P1.12 (sifrah/nauka#202) removed the legacy
-//! code and its `dirs` dep from this crate.
+//! See [`README.md`](https://github.com/sifrah/nauka/blob/main/layers/state/README.md)
+//! for the full crate guide.
 //!
 //! # SurrealDB namespace / database conventions
 //!
@@ -31,11 +32,13 @@
 //! # Usage — `EmbeddedDb` (SurrealKV-backed bootstrap state)
 //!
 //! ```no_run
-//! # use nauka_state::EmbeddedDb;
-//! # use std::path::Path;
+//! use nauka_state::EmbeddedDb;
+//! use std::path::Path;
+//!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let db = EmbeddedDb::open(Path::new("/var/lib/nauka/bootstrap.skv")).await?;
-//! db.client().query("INFO FOR DB").await?;
+//! let _: Vec<surrealdb::types::Value> =
+//!     db.client().query("SELECT * FROM peer").await?.take(0)?;
 //! db.shutdown().await?;
 //! # Ok(()) }
 //! ```


### PR DESCRIPTION
## Summary

Full rewrite of `layers/state/README.md` (was a 13-line P1.11 placeholder pointing at this ticket) and a tightening pass on the module-level rustdoc on `lib.rs`, `embedded.rs`, and `cluster.rs`. **Documentation only — no code changes.**

Closes sifrah/nauka#203.

## What changed

### `layers/state/README.md` (rewritten end-to-end, 176 lines)

- New top-level intro framing the crate as the only place that knows how Nauka's data is laid out on disk, plus the two-backend split.
- **Backend 1 — `EmbeddedDb` over SurrealKV** section covering: the source of truth (mesh identity, hypervisor identity, WG keypair, peer list, region registry), on-disk layout (CLI vs service mode paths, `0o700` perms), the bootstrap schema (the four SCHEMAFULL tables + the two SCHEMALESS bridge tables), and the SurrealKV flock concurrency model.
- Working `EmbeddedDb::open(...).await` -> `client().query(...)` -> `shutdown().await` example wrapped in `#[tokio::main]`, mirroring the `no_run` doctest in `embedded.rs`.
- **Backend 2 — `ClusterDb` over TiKV** section: explicitly transitional, forward-looking note about Phase 2 (sifrah/nauka#206 / sifrah/nauka#220) replacing it with `EmbeddedDb` over `kv-tikv`, PD endpoint shape on the mesh ULA range.
- Errors section enumerating every `StateError` variant and the `surrealdb::Error` predicates each one maps from.
- Constants section + file-layout tree at the bottom.

### Rustdoc

- `lib.rs` `//!` block: drops the P1.2-P1.12 migration narrative (legacy JSON-file store, "P1.11 migrated every caller", "P1.12 removed the legacy code"), points at the new README, tightens the bullet list, and rewrites the example so it's copy-pasteable without the doctest `#`-prefix tricks.
- `embedded.rs` `//!` block: drops the same historical narrative, reframes around what the wrapper does today (lifecycle, schema auto-apply, source of truth), and rewrites the `# Example` block to mirror the README. Strips the "Before P1.11..." paragraph from the in-function `// ` comment block in `open` while keeping the technical rationale for the retry loop.
- `cluster.rs` `//!` block: gets a proper `# Status` section that flags it as transitional and points at the Phase 2 issues.

## Acceptance criteria (sifrah/nauka#203)

- [x] README explains the two backends (SurrealKv local, TiKv distributed in Phase 2)
- [x] Code example for opening + querying
- [x] All references to `LocalDb` JSON removed (`grep -rn "LocalDb\|LayerDb" layers/` returns zero hits)

## Dependencies

This PR sits on top of two prerequisites that are not yet on `main`:

- **PR #256** — feat(P1.11): migrate all remaining LocalDb call sites to EmbeddedDb (merged at `dd5e7694`)
- **PR #257** — feat(P1.12): remove legacy LocalDb code and dirs dep from nauka-state (the parent commit `0a1167f0` of this branch)

Once #257 lands on `main`, this PR rebases cleanly to a single doc-only commit on top.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p nauka-state` — 19 tests pass, 0 fail
- [x] `cargo test -p nauka-state --doc` — 3 doctests pass
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p nauka-state --no-deps` clean
- [x] `grep -rn "LocalDb\|LayerDb" layers/` returns zero hits
- [ ] CI green on this PR

## Out of scope

- `layers/state/schemas/bootstrap.surql` SurrealQL `--` comments still mention "JSON store that Nauka shipped with during P1.2-P1.10". They reference the migration without naming `LocalDb`/`LayerDb`, the grep AC is satisfied, and the task scope is explicitly README + rustdoc. Follow-up issue if anyone wants those scrubbed too.