### PR TITLE
feat(P2.1): enable kv-tikv feature in nauka-state

### DIFF
--- a/layers/state/Cargo.toml
+++ b/layers/state/Cargo.toml
@@ -6,14 +6,6 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
-[features]
-# Off by default. Enable to compile the P0.3 spike binary, which needs the
-# kv-tikv backend on top of kv-surrealkv. The production build path (and CI's
-# default `cargo build -p nauka-state`) intentionally does NOT enable this —
-# Phase 1 is SurrealKV-only; kv-tikv comes back as a permanent feature in
-# Phase 2 (P2.1, sifrah/nauka#205).
-spike-tikv = ["surrealdb/kv-tikv"]
-
 [dependencies]
 nauka-core = { path = "../core" }
 serde.workspace = true
@@ -21,19 +13,19 @@ serde_json.workspace = true
 thiserror.workspace = true
 tikv-client = "0.4"
 tokio.workspace = true
-# Force vendored OpenSSL into the build graph: tikv-client (and, when the
-# `spike-tikv` feature is on, surrealdb-tikv-client) both pull openssl-sys via
-# prometheus → reqwest → native-tls. Without a vendored OpenSSL the musl
+# Force vendored OpenSSL into the build graph: tikv-client and
+# surrealdb-tikv-client (pulled in by `surrealdb/kv-tikv`) both pull openssl-sys
+# via prometheus → reqwest → native-tls. Without a vendored OpenSSL the musl
 # cross-compile cannot find system openssl. The workspace declaration already
 # enables the `vendored` feature. This stays until P2.16 (sifrah/nauka#220)
 # removes the legacy tikv-client.
 openssl.workspace = true
-# P1.1: surrealdb SDK with kv-surrealkv only. The kv-tikv backend is gated
-# behind the local `spike-tikv` feature so that production builds (the CI
-# default) do not pull surrealdb-tikv-client transitively. P2.1
-# (sifrah/nauka#205) flips kv-tikv on permanently when the cluster-side
-# integration lands.
-surrealdb = { version = "3.0.5", default-features = false, features = ["kv-surrealkv"] }
+# P2.1 (sifrah/nauka#205): surrealdb SDK with both kv-surrealkv and kv-tikv
+# permanently enabled. kv-surrealkv is the embedded backend used by every
+# hypervisor; kv-tikv is the distributed backend used when the production
+# binary talks to a shared TiKV cluster via the SurrealDB SDK. The former
+# P1-era `spike-tikv` gate is gone — kv-tikv is now always on.
+surrealdb = { version = "3.0.5", default-features = false, features = ["kv-surrealkv", "kv-tikv"] }
 
 [[bin]]
 name = "p0-1-spike"
@@ -42,7 +34,6 @@ path = "src/bin/p0_1_spike.rs"
 [[bin]]
 name = "p0-3-spike"
 path = "src/bin/p0_3_spike.rs"
-required-features = ["spike-tikv"]
 
 [[bin]]
 name = "p1-9-integration"


### PR DESCRIPTION
## Summary

Flip `surrealdb/kv-tikv` from a dev-only gated feature to a **permanent** one on `nauka-state`, alongside `kv-surrealkv`. This is what the production binary needs to talk to a shared TiKV cluster via the SurrealDB SDK in the upcoming P2 tickets.

Closes sifrah/nauka#205
Refs sifrah/nauka#183 (epic)

## Changes (`layers/state/Cargo.toml` only)

- `surrealdb` features: `["kv-surrealkv"]` → `["kv-surrealkv", "kv-tikv"]`.
- Removed the `[features]` table entirely — the `spike-tikv = ["surrealdb/kv-tikv"]` gate is now redundant and gone.
- Removed `required-features = ["spike-tikv"]` from the `[[bin]] p0-3-spike` block so the binary is always available (no Rust source change was needed — the spike binary already imports `surrealdb::engine::local::TiKv` unconditionally).
- Comments refreshed: the `openssl.workspace = true` comment now references `surrealdb/kv-tikv` directly, and the `surrealdb` comment calls out P2.1 flipping kv-tikv on permanently.

No Rust source files touched. No new files. No CI/workflow files touched.

## Cross-compile result

The critical concern in the ticket: would the new `surrealdb-tikv-client v0.3.0-surreal.4` dep tree (and its transitive native-tls / reqwest / prometheus chain) break the existing `x86_64-unknown-linux-musl` static-pie build path validated by P0.1?

**Answer: it builds cleanly.** The vendored-openssl setup (already in place from P1.x) absorbs the new openssl-sys pull-in from `surrealdb-tikv-client`, and no new cmake/native deps showed up that weren't already in the `tikv-client`/`surrealdb` graph.

Exact command run:
```
CC_x86_64_unknown_linux_musl=x86_64-linux-musl-gcc \
CXX_x86_64_unknown_linux_musl=x86_64-linux-musl-g++ \
AR_x86_64_unknown_linux_musl=x86_64-linux-musl-ar \
cargo build --target x86_64-unknown-linux-musl --release -p nauka
```

Result: `Finished release profile [optimized] target(s) in 5m 53s`, produces a ~97 MB ELF64 static-pie musl binary at `target/x86_64-unknown-linux-musl/release/nauka`. (Larger than the pre-P2.1 baseline, as expected — `surrealdb-tikv-client` and friends are not small.)

## Test plan

- [x] `cargo build -p nauka-state` clean
- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p nauka-state` — 19 unit tests + 3 doc-tests, all passing
- [x] Cross-compile `x86_64-unknown-linux-musl --release -p nauka` succeeds
- [x] `p0-3-spike` binary now compiles unconditionally (no more `required-features` gate)
- [ ] CI green on all pipelines