### PR TITLE
feat(P2.5): SCHEMAFULL .surql definitions for cluster resources

### DIFF
--- a/layers/compute/schemas/vm.surql
+++ b/layers/compute/schemas/vm.surql
@@ -1,0 +1,199 @@
+-- ============================================================================
+-- Nauka — cluster state schema: vm
+-- ============================================================================
+-- Target: nauka / cluster (SurrealDB on top of kv-tikv)
+--
+-- Distributed cluster-state representation of a `Vm` — the core compute
+-- resource. Today VMs are written through
+-- `nauka_compute::vm::store::VmStore` into raw TiKV via `ClusterDb`
+-- under the `vm` / `vm-idx` namespaces. Phase 2 (sifrah/nauka#220)
+-- migrates the storage onto SurrealDB; Phase 3 codegen
+-- (sifrah/nauka#225 ff) will generate the Rust type / store / handlers
+-- from this file.
+--
+-- Source of truth: `layers/compute/src/vm/types.rs` (`struct Vm`), which
+-- embeds `ResourceMeta` via `#[serde(flatten)]` and carries the full
+-- owning scope (`org_id`/`org_name`, `project_id`/`project_name`,
+-- `env_id`/`env_name`), network placement (`vpc_id`/`vpc_name`,
+-- `subnet_id`/`subnet_name`), hardware specs (`vcpus`, `memory_mb`,
+-- `disk_gb`, `image`), physical placement (`region`, `zone`,
+-- `hypervisor_id`, `private_ip`), and a lifecycle FSM in `state:
+-- VmState`.
+--
+-- Idempotency: every DEFINE statement uses `IF NOT EXISTS` so re-applying
+-- the file against an initialised cluster database is a no-op.
+--
+-- Multi-tenancy: `vm` is the deepest tenant-scoped resource. Every row
+-- carries the full `(org, project, env)` path explicitly so row-level
+-- authz filters don't need joins. The natural key is `(env, name)` —
+-- the same VM name can exist in different environments.
+--
+-- Foreign keys: every reference is a plain `string` record id for now.
+-- See `org.surql` for the rationale — P3 codegen may upgrade to typed
+-- `record<…>` links.
+-- ============================================================================
+
+
+-- ── vm ───────────────────────────────────────────────────────────────────
+-- A virtual machine instance, scheduled onto a single hypervisor. The
+-- full provisioning path (resolve org/project/env/vpc/subnet → check
+-- uniqueness → allocate IP via IPAM → schedule onto a hypervisor →
+-- persist the row) lives in today's `VmStore::create`; this schema just
+-- describes the persisted shape.
+
+DEFINE TABLE IF NOT EXISTS vm SCHEMAFULL;
+
+-- Human-readable name. Unique within the owning environment.
+DEFINE FIELD IF NOT EXISTS name ON vm TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Resource lifecycle status — distinct from the VM-specific `state`
+-- field below. `status` is Nauka's generic resource status
+-- ("active" / "deleting" / …) used for cross-resource list filtering;
+-- `state` is the domain-specific VM FSM (pending / running / stopped /
+-- …). Both exist today in `Vm` via the flattened `ResourceMeta` plus
+-- the standalone `state: VmState` field.
+DEFINE FIELD IF NOT EXISTS status ON vm TYPE string
+    ASSERT string::len($value) > 0;
+
+-- User-defined labels.
+DEFINE FIELD IF NOT EXISTS labels ON vm TYPE object DEFAULT {};
+
+-- ── scope ───────────────────────────────────────────────────────────
+
+-- Owning organisation — record id of the `org` row.
+DEFINE FIELD IF NOT EXISTS org ON vm TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Denormalised org name.
+DEFINE FIELD IF NOT EXISTS org_name ON vm TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Owning project — record id of the `project` row.
+DEFINE FIELD IF NOT EXISTS project ON vm TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Denormalised project name.
+DEFINE FIELD IF NOT EXISTS project_name ON vm TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Owning environment — record id of the `env` row. The natural key
+-- `(env, name)` is enforced by the `vm_env_name` index below.
+DEFINE FIELD IF NOT EXISTS env ON vm TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Denormalised env name.
+DEFINE FIELD IF NOT EXISTS env_name ON vm TYPE string
+    ASSERT string::len($value) > 0;
+
+-- ── network ─────────────────────────────────────────────────────────
+
+-- Owning VPC — record id of the `vpc` row.
+DEFINE FIELD IF NOT EXISTS vpc ON vm TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Denormalised VPC name.
+DEFINE FIELD IF NOT EXISTS vpc_name ON vm TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Owning subnet — record id of the `subnet` row.
+DEFINE FIELD IF NOT EXISTS subnet ON vm TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Denormalised subnet name.
+DEFINE FIELD IF NOT EXISTS subnet_name ON vm TYPE string
+    ASSERT string::len($value) > 0;
+
+-- ── hardware specs ──────────────────────────────────────────────────
+
+-- Virtual CPU count. `> 0` because a 0-vCPU VM is meaningless.
+DEFINE FIELD IF NOT EXISTS vcpus ON vm TYPE int
+    ASSERT $value > 0;
+
+-- Memory in MiB. `> 0` — zero-memory VMs are meaningless.
+DEFINE FIELD IF NOT EXISTS memory_mb ON vm TYPE int
+    ASSERT $value > 0;
+
+-- Root disk size in GiB. `> 0` to reject zero-sized disks.
+DEFINE FIELD IF NOT EXISTS disk_gb ON vm TYPE int
+    ASSERT $value > 0;
+
+-- Image reference. Today this is a free-form identifier resolved by
+-- the image registry (`nauka-compute::image`); format validation
+-- happens there, not in the schema.
+DEFINE FIELD IF NOT EXISTS image ON vm TYPE string
+    ASSERT string::len($value) > 0;
+
+-- ── placement ───────────────────────────────────────────────────────
+
+-- Region the VM lives in (e.g. "eu-west"). Non-empty.
+DEFINE FIELD IF NOT EXISTS region ON vm TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Zone within the region (e.g. "eu-west-1a"). Non-empty.
+DEFINE FIELD IF NOT EXISTS zone ON vm TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Private IP assigned by the subnet IPAM. Optional because a
+-- freshly-created row has no IP until `VmStore::create` allocates one
+-- (today both ends happen in the same transaction, but the schema has
+-- to allow the intermediate state for migrations and recovery). Stored
+-- as a string for now — P3 codegen may upgrade to a native inet type
+-- once SurrealDB grows one.
+DEFINE FIELD IF NOT EXISTS private_ip ON vm TYPE option<string>;
+
+-- ID of the hypervisor this VM was scheduled onto. Optional — a VM
+-- can exist in the `pending` / `creating` state before the scheduler
+-- assigns a host. Stored as a plain string: the same `HypervisorId`
+-- shape used elsewhere in the tree (e.g. `hv-01J…`).
+DEFINE FIELD IF NOT EXISTS hypervisor ON vm TYPE option<string>;
+
+-- ── lifecycle ───────────────────────────────────────────────────────
+
+-- Domain-specific VM state machine. Mirrors the `VmState` enum in
+-- `layers/compute/src/vm/types.rs`, serialised with `#[serde(rename_all
+-- = "lowercase")]`. The ASSERT pins the allowed values so an
+-- unexpected state literal is rejected at insert time rather than
+-- surfacing as a deserialisation failure.
+DEFINE FIELD IF NOT EXISTS state ON vm TYPE string
+    ASSERT $value INSIDE [
+        "pending",
+        "creating",
+        "running",
+        "stopped",
+        "deleting",
+        "deleted"
+    ];
+
+-- Creation timestamp.
+DEFINE FIELD IF NOT EXISTS created_at ON vm TYPE datetime;
+
+-- Last-update timestamp. Mutated on every state transition today
+-- (`VmStore::update_state` rewrites `meta.updated_at`).
+DEFINE FIELD IF NOT EXISTS updated_at ON vm TYPE datetime;
+
+-- Composite unique index on `(env, name)`. Mirrors the `env_id/name`
+-- index key used by today's TiKV-backed `VmStore::create`.
+DEFINE INDEX IF NOT EXISTS vm_env_name ON vm
+    FIELDS env, name UNIQUE;
+
+-- Private IP must be unique within a subnet — the IPAM allocator
+-- already enforces this at write time, but modelling it at the schema
+-- level guards the invariant against future races. The index is
+-- *partial in effect* because `private_ip` is `option<string>`: rows
+-- in the `pending` state with no IP do not collide with one another.
+-- SurrealDB's unique indexes already treat `NONE` values as distinct,
+-- so no extra WHERE clause is needed here.
+DEFINE INDEX IF NOT EXISTS vm_subnet_private_ip ON vm
+    FIELDS subnet, private_ip UNIQUE;
+
+-- Secondary (non-unique) indexes on the common tenant-scoped list
+-- paths. The CLI's default `nauka vm list --org <o> --project <p>
+-- --env <e>` wants to walk exactly one of these indexes.
+DEFINE INDEX IF NOT EXISTS vm_org ON vm FIELDS org;
+DEFINE INDEX IF NOT EXISTS vm_project ON vm FIELDS project;
+DEFINE INDEX IF NOT EXISTS vm_env ON vm FIELDS env;
+
+-- Scheduler-side index: "which VMs live on this hypervisor?" — the
+-- query the fabric reconciler runs on every reconcile cycle.
+DEFINE INDEX IF NOT EXISTS vm_hypervisor ON vm FIELDS hypervisor;

--- a/layers/network/schemas/subnet.surql
+++ b/layers/network/schemas/subnet.surql
@@ -1,0 +1,94 @@
+-- ============================================================================
+-- Nauka — cluster state schema: subnet
+-- ============================================================================
+-- Target: nauka / cluster (SurrealDB on top of kv-tikv)
+--
+-- Distributed cluster-state representation of a `Subnet` — a contiguous
+-- CIDR block carved out of an owning VPC's address space. Today
+-- subnets are written through
+-- `nauka_network::vpc::subnet::store::SubnetStore` into raw TiKV via
+-- `ClusterDb`; Phase 2 (sifrah/nauka#220) migrates the storage onto
+-- SurrealDB; Phase 3 codegen (sifrah/nauka#225 ff) will generate the
+-- Rust type / store / handlers from this file.
+--
+-- Source of truth: `layers/network/src/vpc/subnet/types.rs`
+-- (`struct Subnet`), which embeds `ResourceMeta` via `#[serde(flatten)]`
+-- and carries `cidr`, `gateway`, and the owning `vpc_id` / `vpc_name`
+-- pair.
+--
+-- Idempotency: every DEFINE statement uses `IF NOT EXISTS` so re-applying
+-- the file against an initialised cluster database is a no-op.
+--
+-- Multi-tenancy: subnets inherit their tenant from the owning VPC. The
+-- `(vpc, name)` pair is the natural key — a VPC cannot have two
+-- subnets with the same name, but two different VPCs may each have a
+-- `web` subnet. An `org` column is NOT carried on this table yet
+-- (today's `Subnet` struct doesn't denormalise it either); tenant
+-- filtering walks up through `vpc`.
+--
+-- Foreign keys: `vpc` is a plain `string` record id for now. See
+-- `org.surql` for the rationale.
+-- ============================================================================
+
+
+-- ── subnet ───────────────────────────────────────────────────────────────
+-- A subnet belongs to exactly one VPC. Created today via
+-- `nauka subnet create <name> --vpc <vpc> --cidr <cidr>`.
+
+DEFINE TABLE IF NOT EXISTS subnet SCHEMAFULL;
+
+-- Human-readable name. Unique per VPC.
+DEFINE FIELD IF NOT EXISTS name ON subnet TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Resource lifecycle status.
+DEFINE FIELD IF NOT EXISTS status ON subnet TYPE string
+    ASSERT string::len($value) > 0;
+
+-- User-defined labels.
+DEFINE FIELD IF NOT EXISTS labels ON subnet TYPE object DEFAULT {};
+
+-- IPv4 CIDR, e.g. "10.0.1.0/24". Must be strictly contained in the
+-- owning VPC's CIDR; that invariant is enforced at write time by
+-- `nauka_network::validate::subnet_within_vpc`, not by this schema.
+DEFINE FIELD IF NOT EXISTS cidr ON subnet TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Gateway address for this subnet, as a string like "10.0.1.1".
+-- Computed by `nauka_network::validate::gateway` from the CIDR at
+-- write time. Always populated — there is no scenario today where a
+-- subnet exists without a gateway.
+DEFINE FIELD IF NOT EXISTS gateway ON subnet TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Owning VPC — SurrealDB record id of the `vpc` row. Tenant scoping
+-- and the `(vpc, name)` composite index both read this column.
+DEFINE FIELD IF NOT EXISTS vpc ON subnet TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Denormalised VPC name from `Subnet.vpc_name`.
+DEFINE FIELD IF NOT EXISTS vpc_name ON subnet TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Creation timestamp.
+DEFINE FIELD IF NOT EXISTS created_at ON subnet TYPE datetime;
+
+-- Last-update timestamp.
+DEFINE FIELD IF NOT EXISTS updated_at ON subnet TYPE datetime;
+
+-- Composite unique index on `(vpc, name)`. Mirrors the `vpc_id/name`
+-- index key used by today's TiKV-backed `SubnetStore::create`.
+DEFINE INDEX IF NOT EXISTS subnet_vpc_name ON subnet
+    FIELDS vpc, name UNIQUE;
+
+-- Subnet CIDRs must be unique per VPC: two subnets in the same VPC
+-- cannot overlap, which includes "cannot share a CIDR". Overlap is
+-- enforced at write time by `no_overlap` in the validator, but
+-- modelling exact-equality uniqueness at the schema level guards the
+-- simplest failure mode (two writers racing to create the same CIDR).
+DEFINE INDEX IF NOT EXISTS subnet_vpc_cidr ON subnet
+    FIELDS vpc, cidr UNIQUE;
+
+-- Secondary (non-unique) index on `vpc` for "list subnets in this VPC"
+-- scans — the most common read pattern.
+DEFINE INDEX IF NOT EXISTS subnet_vpc ON subnet FIELDS vpc;

--- a/layers/network/schemas/vpc.surql
+++ b/layers/network/schemas/vpc.surql
@@ -1,0 +1,102 @@
+-- ============================================================================
+-- Nauka — cluster state schema: vpc
+-- ============================================================================
+-- Target: nauka / cluster (SurrealDB on top of kv-tikv)
+--
+-- Distributed cluster-state representation of a `Vpc` — the top-level
+-- networking resource. Today VPCs are written through
+-- `nauka_network::vpc::store::VpcStore` into raw TiKV via `ClusterDb`
+-- under the `vpc` / `vpc-idx` namespaces. Phase 2 (sifrah/nauka#220)
+-- migrates the storage onto SurrealDB; Phase 3 codegen
+-- (sifrah/nauka#225 ff) will generate the Rust type / store / handlers
+-- from this file.
+--
+-- Source of truth: `layers/network/src/vpc/types.rs` (`struct Vpc`),
+-- which embeds `ResourceMeta` via `#[serde(flatten)]` and carries
+-- `cidr`, `vni`, the owning `org_id` / `org_name`, and optional
+-- `project_id` / `env_id` fields.
+--
+-- Idempotency: every DEFINE statement uses `IF NOT EXISTS` so re-applying
+-- the file against an initialised cluster database is a no-op.
+--
+-- Multi-tenancy: `vpc` is tenant-scoped on `(org, name)`. A VPC may
+-- optionally also be scoped to a specific project or environment
+-- within the owning org — those fields are `option<string>` because
+-- today's `Vpc` struct marks them `Option<ProjectId>` / `Option<EnvId>`.
+--
+-- Foreign keys: `org`, `project`, `env` are plain `string` record ids
+-- for now. See `org.surql` for the rationale — P3 codegen may upgrade
+-- them to typed `record<…>` links.
+-- ============================================================================
+
+
+-- ── vpc ──────────────────────────────────────────────────────────────────
+-- A Virtual Private Cloud. Every VPC belongs to exactly one org, and
+-- the pair `(org, name)` is the natural key. Created today via
+-- `nauka vpc create <name> --org <org> --cidr <cidr>`.
+
+DEFINE TABLE IF NOT EXISTS vpc SCHEMAFULL;
+
+-- Human-readable name. Unique per org.
+DEFINE FIELD IF NOT EXISTS name ON vpc TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Resource lifecycle status.
+DEFINE FIELD IF NOT EXISTS status ON vpc TYPE string
+    ASSERT string::len($value) > 0;
+
+-- User-defined labels.
+DEFINE FIELD IF NOT EXISTS labels ON vpc TYPE object DEFAULT {};
+
+-- IPv4 CIDR for the VPC's private address space, as a string like
+-- "10.0.0.0/16". Format validation lives in the application layer
+-- (`nauka_network::validate::private_cidr`) — the schema just asserts
+-- non-empty so obviously-wrong inserts are rejected.
+DEFINE FIELD IF NOT EXISTS cidr ON vpc TYPE string
+    ASSERT string::len($value) > 0;
+
+-- VXLAN Network Identifier (VNI). Allocated monotonically by the
+-- `VpcStore::next_vni` counter in today's store, starting at 100. The
+-- VNI is a u24 in hardware (valid range 1..=2^24-1); the ASSERT
+-- enforces positivity and the u24 ceiling so nonsensical values never
+-- reach the data plane.
+DEFINE FIELD IF NOT EXISTS vni ON vpc TYPE int
+    ASSERT $value > 0 AND $value < 16777216;
+
+-- Owning organisation — SurrealDB record id of the `org` row. Tenant
+-- scoping and the `(org, name)` composite index both read this column.
+DEFINE FIELD IF NOT EXISTS org ON vpc TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Denormalised org name from `Vpc.org_name`.
+DEFINE FIELD IF NOT EXISTS org_name ON vpc TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Optional owning project. Present in `Vpc` as `project_id:
+-- Option<ProjectId>` so some VPCs are org-wide and some are pinned to a
+-- single project. Modelled as `option<string>` here; P3 codegen may
+-- upgrade to `option<record<project>>`.
+DEFINE FIELD IF NOT EXISTS project ON vpc TYPE option<string>;
+
+-- Optional owning environment — same story as `project` above.
+DEFINE FIELD IF NOT EXISTS env ON vpc TYPE option<string>;
+
+-- Creation timestamp.
+DEFINE FIELD IF NOT EXISTS created_at ON vpc TYPE datetime;
+
+-- Last-update timestamp.
+DEFINE FIELD IF NOT EXISTS updated_at ON vpc TYPE datetime;
+
+-- Composite unique index on `(org, name)`. Mirrors the `org_id/name`
+-- index key used by today's TiKV-backed `VpcStore::create`.
+DEFINE INDEX IF NOT EXISTS vpc_org_name ON vpc
+    FIELDS org, name UNIQUE;
+
+-- VNI must be unique cluster-wide — the monotonic counter enforces
+-- this at allocation time, but modelling the uniqueness in the schema
+-- guards against future races (parallel allocators, backfill scripts,
+-- …) and lets the data plane trust the invariant.
+DEFINE INDEX IF NOT EXISTS vpc_vni ON vpc FIELDS vni UNIQUE;
+
+-- Secondary (non-unique) index on `org` for tenant-scoped list scans.
+DEFINE INDEX IF NOT EXISTS vpc_org ON vpc FIELDS org;

--- a/layers/org/schemas/env.surql
+++ b/layers/org/schemas/env.surql
@@ -1,0 +1,88 @@
+-- ============================================================================
+-- Nauka — cluster state schema: env
+-- ============================================================================
+-- Target: nauka / cluster (SurrealDB on top of kv-tikv)
+--
+-- Distributed cluster-state representation of an `Environment` — the
+-- third level of Nauka's tenant hierarchy (`org → project → env`).
+-- Today envs are written through
+-- `nauka_org::project::env::store::EnvStore` into raw TiKV via
+-- `ClusterDb`; Phase 2 (sifrah/nauka#220) migrates the storage onto
+-- SurrealDB, and Phase 3 codegen (sifrah/nauka#225 ff) will generate
+-- the Rust type / store / handlers from this file.
+--
+-- Source of truth: `layers/org/src/project/env/types.rs`
+-- (`struct Environment`), which embeds `ResourceMeta` via
+-- `#[serde(flatten)]` and carries the full owning path:
+-- `project_id`, `project_name`, `org_id`, `org_name`.
+--
+-- Idempotency: every DEFINE statement uses `IF NOT EXISTS` so re-applying
+-- the file against an initialised cluster database is a no-op.
+--
+-- Multi-tenancy: `env` is tenant-scoped. The primary natural key is
+-- `(project, name)` — an env name is unique within a project, not within
+-- an org. The `org` column is denormalised for fast row-level authz
+-- filtering ("all envs visible to tenant X") without a second JOIN.
+--
+-- Foreign keys: `project` and `org` are both plain `string` record ids
+-- for now. See `org.surql` for the rationale — P3 codegen may upgrade
+-- them to typed `record<project>` / `record<org>` links.
+-- ============================================================================
+
+
+-- ── env ──────────────────────────────────────────────────────────────────
+-- An environment belongs to exactly one project (and transitively to
+-- exactly one org). The `(project, name)` tuple is the natural key.
+-- Created today via `nauka env create <name> --project <proj> --org <org>`.
+
+DEFINE TABLE IF NOT EXISTS env SCHEMAFULL;
+
+-- Human-readable name. Unique per project.
+DEFINE FIELD IF NOT EXISTS name ON env TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Resource lifecycle status.
+DEFINE FIELD IF NOT EXISTS status ON env TYPE string
+    ASSERT string::len($value) > 0;
+
+-- User-defined labels.
+DEFINE FIELD IF NOT EXISTS labels ON env TYPE object DEFAULT {};
+
+-- Owning project — SurrealDB record id of the `project` row (e.g.
+-- `project:01j…`), stored as a string for P2.5.
+DEFINE FIELD IF NOT EXISTS project ON env TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Denormalised project name from `Environment.project_name`.
+DEFINE FIELD IF NOT EXISTS project_name ON env TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Owning organisation — SurrealDB record id of the `org` row. Carried
+-- on every env row so tenant-scoped list queries can filter without
+-- walking up through the project table.
+DEFINE FIELD IF NOT EXISTS org ON env TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Denormalised org name from `Environment.org_name`.
+DEFINE FIELD IF NOT EXISTS org_name ON env TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Creation timestamp. See the note in `org.surql`.
+DEFINE FIELD IF NOT EXISTS created_at ON env TYPE datetime;
+
+-- Last-update timestamp.
+DEFINE FIELD IF NOT EXISTS updated_at ON env TYPE datetime;
+
+-- Composite unique index on `(project, name)`. Mirrors the
+-- `project_id/name` index key used by today's TiKV-backed
+-- `EnvStore::create`.
+DEFINE INDEX IF NOT EXISTS env_project_name ON env
+    FIELDS project, name UNIQUE;
+
+-- Secondary (non-unique) index on `project` for "list envs in this
+-- project" scans.
+DEFINE INDEX IF NOT EXISTS env_project ON env FIELDS project;
+
+-- Secondary (non-unique) index on `org` for tenant-scoped "list every
+-- env belonging to this tenant" scans.
+DEFINE INDEX IF NOT EXISTS env_org ON env FIELDS org;

--- a/layers/org/schemas/org.surql
+++ b/layers/org/schemas/org.surql
@@ -1,0 +1,88 @@
+-- ============================================================================
+-- Nauka — cluster state schema: org
+-- ============================================================================
+-- Target: nauka / cluster (SurrealDB on top of kv-tikv)
+--
+-- This file defines the distributed cluster-state representation of the
+-- top-level `Org` resource. Today every org is written through
+-- `nauka_org::store::OrgStore` into raw TiKV via `ClusterDb` under the
+-- `org` / `org-idx` namespaces. Phase 2 (sifrah/nauka#220) migrates that
+-- storage onto SurrealDB with a `kv-tikv` backend. Phase 3 codegen
+-- (sifrah/nauka#225 ff) will in turn generate the Rust `Org` type, the
+-- store, and the API handlers directly from this file — P2.5
+-- (sifrah/nauka#209) only ships the schema, no code generation yet.
+--
+-- Source of truth: `layers/org/src/types.rs` (`struct Org`), which embeds
+-- `nauka_core::resource::ResourceMeta` via `#[serde(flatten)]`. The fields
+-- below mirror the on-the-wire JSON shape produced by that struct minus
+-- the `id` field (see the note at the end of this comment).
+--
+-- Idempotency: every DEFINE statement uses `IF NOT EXISTS` so applying
+-- this file against an already-initialised cluster database is a no-op.
+-- New columns added in later phases land as additional
+-- `DEFINE FIELD … IF NOT EXISTS` lines without breaking existing data.
+--
+-- Multi-tenancy: `org` is the root of Nauka's tenant hierarchy — every
+-- other cluster resource (project, env, vpc, subnet, vm, …) carries an
+-- `org` reference and the per-tenant row-level isolation lives on those
+-- child tables. The `org` table itself is the tenant registry, so there
+-- is no parent scope to filter by here.
+--
+-- Foreign keys: P2.5 ships references as plain `string` record-id
+-- fields (e.g. `"org:01j…"`) rather than SurrealDB native `record<T>`
+-- links. P3 codegen may upgrade them to typed links once the Rust side
+-- knows how to read/write both representations.
+--
+-- Note on the `id` field: `ResourceMeta` has an `id: String` field (the
+-- ULID-prefixed resource id, e.g. `org-01J…`). SurrealDB reserves `id` as
+-- the record-id slot and defining a separate `id` field collides with it.
+-- P3 will persist the ULID as the SurrealDB record id itself — rows will
+-- be created with `CREATE org:<ulid> SET name = ..., ...` — so the
+-- acceptance criterion ("unique resource id") is still met, but via the
+-- record id rather than a standalone field. The bootstrap schema
+-- (`layers/state/schemas/bootstrap.surql`) uses the same convention for
+-- the same reason.
+-- ============================================================================
+
+
+-- ── org ──────────────────────────────────────────────────────────────────
+-- Top-level tenant / organisation. Every other cluster resource is owned
+-- by exactly one org. Created via `nauka org create <name>` today; after
+-- P3 codegen lands, rows will be created by the generated handler with
+-- `CREATE org:<ulid> SET name = $name, status = "active", …`.
+
+DEFINE TABLE IF NOT EXISTS org SCHEMAFULL;
+
+-- Human-readable name. Unique across the whole cluster; enforced both by
+-- the `org_name` index below and by the `OrgStore::create` path which
+-- refuses to overwrite an existing name.
+DEFINE FIELD IF NOT EXISTS name ON org TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Resource lifecycle status (e.g. "active", "deleting"). Free-form today;
+-- a stricter `$value INSIDE [...]` ASSERT gets added when the resource
+-- lifecycle FSM lands.
+DEFINE FIELD IF NOT EXISTS status ON org TYPE string
+    ASSERT string::len($value) > 0;
+
+-- User-defined key → value labels. Copied over from
+-- `ResourceMeta.labels: HashMap<String, String>` — SurrealDB `object`
+-- is the natural home for an open-ended string map. Defaults to an empty
+-- object so new rows never carry a null here.
+DEFINE FIELD IF NOT EXISTS labels ON org TYPE object DEFAULT {};
+
+-- Creation timestamp. `ResourceMeta.created_at` is a Unix-epoch `u64`
+-- today; P3 codegen will bridge it to SurrealDB's native `datetime` so
+-- the schema-side type is correct from day one.
+DEFINE FIELD IF NOT EXISTS created_at ON org TYPE datetime;
+
+-- Last-update timestamp. Same story as `created_at`. Mutated on every
+-- write-through the generated handler.
+DEFINE FIELD IF NOT EXISTS updated_at ON org TYPE datetime;
+
+-- Unique index on `name` so name → record-id lookups (the fast path for
+-- the CLI, which takes `<org_name>` in every command) stay O(1) and so
+-- the uniqueness check in `OrgStore::create` is enforced at the schema
+-- level — no more "check, then insert" race windows once the migration
+-- lands.
+DEFINE INDEX IF NOT EXISTS org_name ON org FIELDS name UNIQUE;

--- a/layers/org/schemas/project.surql
+++ b/layers/org/schemas/project.surql
@@ -1,0 +1,79 @@
+-- ============================================================================
+-- Nauka — cluster state schema: project
+-- ============================================================================
+-- Target: nauka / cluster (SurrealDB on top of kv-tikv)
+--
+-- Distributed cluster-state representation of a `Project` — the second
+-- level of Nauka's tenant hierarchy (`org → project → env`). Today
+-- projects are written through `nauka_org::project::store::ProjectStore`
+-- into raw TiKV via `ClusterDb`; Phase 2 (sifrah/nauka#220) migrates the
+-- storage onto SurrealDB, and Phase 3 codegen (sifrah/nauka#225 ff)
+-- will generate the Rust type / store / handlers from this file.
+--
+-- Source of truth: `layers/org/src/project/types.rs` (`struct Project`),
+-- which embeds `ResourceMeta` via `#[serde(flatten)]` and carries an
+-- owning `org_id` / `org_name` pair.
+--
+-- Idempotency: every DEFINE statement uses `IF NOT EXISTS` so this file
+-- can be re-applied against an initialised cluster database as a no-op.
+--
+-- Multi-tenancy: `project` is tenant-scoped. Every row carries the id of
+-- its owning `org`, and the natural key is `(org, name)` rather than
+-- `name` alone — two different orgs may both have a project called
+-- `web`. Row-level authorisation (P3+) filters by the `org` field.
+--
+-- Foreign keys: `org` is a plain `string` holding a SurrealDB record id
+-- like `org:01j…`. See `org.surql` for why P2.5 deliberately does not
+-- use SurrealDB's typed `record<org>` links yet.
+-- ============================================================================
+
+
+-- ── project ──────────────────────────────────────────────────────────────
+-- A project belongs to exactly one org. The `(org, name)` tuple is the
+-- natural key. Created today via `nauka project create <name> --org <org>`
+-- and looked up by the same pair.
+
+DEFINE TABLE IF NOT EXISTS project SCHEMAFULL;
+
+-- Human-readable name. Unique per org, not globally — the composite
+-- `project_org_name` index below enforces that.
+DEFINE FIELD IF NOT EXISTS name ON project TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Resource lifecycle status. Same semantics as on `org`; free-form today.
+DEFINE FIELD IF NOT EXISTS status ON project TYPE string
+    ASSERT string::len($value) > 0;
+
+-- User-defined key → value labels. Defaults to `{}` so the column is
+-- never null in practice.
+DEFINE FIELD IF NOT EXISTS labels ON project TYPE object DEFAULT {};
+
+-- Owning organisation — SurrealDB record id of the `org` row, stored as
+-- a string for now (P3 codegen may upgrade to `record<org>`). Tenant
+-- scoping and the `(org, name)` composite index both read this column.
+DEFINE FIELD IF NOT EXISTS org ON project TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Denormalised org name copied from the parent at write time. Present in
+-- today's `Project` struct (`org_name: String`) because the CLI surface
+-- wants a human-readable org name without a second fetch. Kept here so
+-- the schema round-trips the existing JSON exactly.
+DEFINE FIELD IF NOT EXISTS org_name ON project TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Creation timestamp. See the `created_at` note in `org.surql`.
+DEFINE FIELD IF NOT EXISTS created_at ON project TYPE datetime;
+
+-- Last-update timestamp.
+DEFINE FIELD IF NOT EXISTS updated_at ON project TYPE datetime;
+
+-- Composite unique index on `(org, name)`: two different orgs may use
+-- the same project name, but within a single org the name is unique.
+-- Mirrors the `org_id/name` index key used by today's TiKV-backed
+-- `ProjectStore::create`.
+DEFINE INDEX IF NOT EXISTS project_org_name ON project
+    FIELDS org, name UNIQUE;
+
+-- Secondary (non-unique) index on `org` for fast "list all projects in
+-- this org" scans — the most common read pattern.
+DEFINE INDEX IF NOT EXISTS project_org ON project FIELDS org;

--- a/layers/org/schemas/user.surql
+++ b/layers/org/schemas/user.surql
@@ -1,0 +1,70 @@
+-- ============================================================================
+-- Nauka — cluster state schema: user
+-- ============================================================================
+-- Target: nauka / cluster (SurrealDB on top of kv-tikv)
+--
+-- Distributed cluster-state representation of an authenticated Nauka
+-- user. Unlike the other schemas in this ticket, P2.5 (sifrah/nauka#209)
+-- is the **first** schema for this resource: there is no corresponding
+-- Rust type in the tree yet (`grep -r "struct User" layers/` returns
+-- nothing as of commit cdffcddf). The acceptance criteria for P2.5
+-- still require a user schema, so this file ships a minimal, forward-
+-- compatible definition that P3 codegen can grow as the authentication
+-- subsystem lands.
+--
+-- Idempotency: every DEFINE statement uses `IF NOT EXISTS` so re-applying
+-- the file against an initialised cluster database is a no-op. New
+-- fields added later — password hash, MFA settings, SSH keys, API
+-- tokens, tenant memberships, etc. — land as additional
+-- `DEFINE FIELD … IF NOT EXISTS` statements without breaking existing
+-- rows.
+--
+-- Multi-tenancy: a user is **not** org-scoped at this layer — users are
+-- global identities and their membership in orgs is modelled elsewhere
+-- (probably a separate `membership` or `org_user` edge table once the
+-- authentication issue lands). If the eventual design makes users
+-- tenant-scoped, the schema gains an `org` column and the unique index
+-- changes to `(org, email)`; every DEFINE here still uses IF NOT
+-- EXISTS, so that migration is forward-compatible.
+-- ============================================================================
+
+
+-- ── user ─────────────────────────────────────────────────────────────────
+-- A single identity that can authenticate against Nauka. Keyed by the
+-- SurrealDB record id (a ULID-prefixed string like `user:01j…`, the
+-- same convention as every other resource in this tree). `email` is the
+-- human-visible natural key.
+
+DEFINE TABLE IF NOT EXISTS user SCHEMAFULL;
+
+-- Login email. Unique across the cluster — enforced by `user_email`
+-- below. The ASSERT is a minimum length sanity check, not a full RFC
+-- 5321 validator; full format validation lives in the application layer
+-- where it can emit a useful error message.
+DEFINE FIELD IF NOT EXISTS email ON user TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Human-readable display name. Optional because early-stage accounts
+-- may only carry the email; the generated handler will default it to
+-- the local-part of the email when callers omit it.
+DEFINE FIELD IF NOT EXISTS display_name ON user TYPE option<string>;
+
+-- Resource lifecycle status ("active", "suspended", "deleting", …).
+-- Mirrors the `status` field used by every other cluster resource.
+DEFINE FIELD IF NOT EXISTS status ON user TYPE string
+    ASSERT string::len($value) > 0;
+
+-- User-defined labels — same semantics as on `org`.
+DEFINE FIELD IF NOT EXISTS labels ON user TYPE object DEFAULT {};
+
+-- Creation timestamp.
+DEFINE FIELD IF NOT EXISTS created_at ON user TYPE datetime;
+
+-- Last-update timestamp.
+DEFINE FIELD IF NOT EXISTS updated_at ON user TYPE datetime;
+
+-- Unique index on `email` so (a) login-by-email is O(1) and (b) two
+-- accounts can never share the same email. The uniqueness guarantee is
+-- enforced at the schema level so application-side "check then insert"
+-- races can't produce duplicate emails.
+DEFINE INDEX IF NOT EXISTS user_email ON user FIELDS email UNIQUE;

--- a/layers/state/src/embedded.rs
+++ b/layers/state/src/embedded.rs
@@ -862,4 +862,73 @@ mod tests {
 
         db.shutdown().await.expect("shutdown");
     }
+
+    /// P2.5 — every cluster-state `.surql` schema parses cleanly and is
+    /// fully idempotent against a fresh SurrealKV database.
+    ///
+    /// P2.5 (sifrah/nauka#209) ships SCHEMAFULL definitions for the
+    /// cluster-side resources (org, project, env, user, vpc, subnet, vm)
+    /// under `layers/{org,network,compute}/schemas/`. No Rust code reads
+    /// them yet — Phase 3 codegen (sifrah/nauka#225 ff) will consume them
+    /// to generate types and handlers — but we still need a CI-visible
+    /// guarantee that the files are valid SurrealQL and that every
+    /// `DEFINE` is idempotent.
+    ///
+    /// Strategy: open a throwaway `EmbeddedDb` at a tempdir, apply each
+    /// cluster schema twice in sequence via `client().query(SCHEMA)`,
+    /// and assert `.check()` on both passes. The first pass exercises a
+    /// real `DEFINE TABLE/FIELD/INDEX` path against an empty db; the
+    /// second pass exercises the `IF NOT EXISTS` idempotency promise.
+    /// Any parse error, `ASSERT` typo, reserved-word collision, or
+    /// missing `IF NOT EXISTS` surfaces as a test failure.
+    ///
+    /// The schemas define `cluster`-scoped tables (`org`, `project`, …)
+    /// that do not collide with the already-applied bootstrap tables
+    /// (`mesh`, `hypervisor`, `peer`, `wg_key`), so they can safely share
+    /// the same SurrealDB instance here.
+    #[tokio::test]
+    async fn cluster_schemas_parse_cleanly() {
+        // Compile-time-embedded copies of every P2.5 schema. `include_str!`
+        // resolves relative to *this* source file (`layers/state/src/embedded.rs`),
+        // so the paths climb out of `state/src` and back down into each
+        // sibling layer's `schemas/` directory.
+        const SCHEMAS: &[(&str, &str)] = &[
+            ("org", include_str!("../../org/schemas/org.surql")),
+            ("project", include_str!("../../org/schemas/project.surql")),
+            ("env", include_str!("../../org/schemas/env.surql")),
+            ("user", include_str!("../../org/schemas/user.surql")),
+            ("vpc", include_str!("../../network/schemas/vpc.surql")),
+            ("subnet", include_str!("../../network/schemas/subnet.surql")),
+            ("vm", include_str!("../../compute/schemas/vm.surql")),
+        ];
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = EmbeddedDb::open(&dir.path().join("cluster_schemas.skv"))
+            .await
+            .expect("open");
+
+        for (name, schema) in SCHEMAS {
+            // First application — must succeed against a fresh db. The
+            // bootstrap schema has already been applied by `open`, but
+            // these files define different tables so there's no conflict.
+            db.client()
+                .query(*schema)
+                .await
+                .unwrap_or_else(|e| panic!("{name} schema first apply failed: {e}"))
+                .check()
+                .unwrap_or_else(|e| panic!("{name} schema first apply check failed: {e}"));
+
+            // Second application — `IF NOT EXISTS` must make this a
+            // no-op. Any statement without `IF NOT EXISTS` blows up here
+            // with an "already exists" error.
+            db.client()
+                .query(*schema)
+                .await
+                .unwrap_or_else(|e| panic!("{name} schema second apply failed: {e}"))
+                .check()
+                .unwrap_or_else(|e| panic!("{name} schema idempotency check failed: {e}"));
+        }
+
+        db.shutdown().await.expect("shutdown");
+    }
 }


### PR DESCRIPTION
## Summary

Ships seven SCHEMAFULL SurrealQL schema files describing the distributed cluster state that today lives in raw TiKV via `ClusterDb`. Phase 2 (sifrah/nauka#220) will migrate the storage onto SurrealDB and Phase 3 codegen (sifrah/nauka#225 ff) will generate the Rust types, stores, and handlers from these files. **P2.5 ships only the schemas — no Rust migration, no codegen, no caller changes.**

Closes sifrah/nauka#209
Epic: sifrah/nauka#183

## Files added

| Schema file | Derived from |
| --- | --- |
| `layers/org/schemas/org.surql` | `layers/org/src/types.rs` (`struct Org`) |
| `layers/org/schemas/project.surql` | `layers/org/src/project/types.rs` (`struct Project`) |
| `layers/org/schemas/env.surql` | `layers/org/src/project/env/types.rs` (`struct Environment`) |
| `layers/org/schemas/user.surql` | _No Rust type yet_ — minimal forward-compatible schema, documented in the file header. Grows as the authentication subsystem lands. |
| `layers/network/schemas/vpc.surql` | `layers/network/src/vpc/types.rs` (`struct Vpc`) |
| `layers/network/schemas/subnet.surql` | `layers/network/src/vpc/subnet/types.rs` (`struct Subnet`) |
| `layers/compute/schemas/vm.surql` | `layers/compute/src/vm/types.rs` (`struct Vm`) |

Each schema was derived by reading the corresponding `types.rs` struct and the matching `store.rs` to see which fields are actually written/read today via `ClusterDb`, then transcribing that shape into SCHEMAFULL SurrealQL with appropriate ASSERTs and unique indexes.

## Conventions followed

All schemas mirror the template established by `layers/state/schemas/bootstrap.surql` (P1.6, sifrah/nauka#196):

- Header comment block: purpose, Rust source of truth, idempotency story, multi-tenancy notes, P3 codegen forward note
- Every table is `SCHEMAFULL` (never SCHEMALESS)
- Every field has an explicit TYPE
- String fields that must be non-empty assert `string::len($value) > 0`
- Integer fields with natural bounds assert `> 0` (plus upper bound where known — e.g. VPC VNI is constrained to the u24 range)
- Optional fields use `option<T>`
- Timestamps use `datetime`
- Labels use `object DEFAULT {}` so rows never carry a null label map
- Foreign keys are plain `string` record ids like `"org:01j…"` — not SurrealDB native `record<T>` links (documented in each file header; P3 codegen may upgrade)
- Natural keys carry unique indexes, scoped by parent where applicable:
  - `org`: unique on `name`
  - `project`: composite unique on `(org, name)`
  - `env`: composite unique on `(project, name)`
  - `user`: unique on `email`
  - `vpc`: composite unique on `(org, name)`, plus a second unique index on `vni` (VPC VNI is cluster-unique)
  - `subnet`: composite unique on `(vpc, name)`, plus `(vpc, cidr)` unique to guard the no-overlap invariant
  - `vm`: composite unique on `(env, name)`, plus `(subnet, private_ip)` unique to guard IPAM allocations
- Secondary (non-unique) indexes on common tenant-scoped list paths (`project.org`, `env.project`, `env.org`, `vpc.org`, `subnet.vpc`, `vm.org` / `vm.project` / `vm.env` / `vm.hypervisor`)
- Every `DEFINE` uses `IF NOT EXISTS` — re-applying any file is a no-op

## Deviations and rationale

- **No `id` field** on any table. SurrealDB reserves `id` as the record-id slot; defining a separate `id` field collides with it. P3 will persist the ULID-prefixed resource id as the SurrealDB record id itself (e.g. `CREATE org:01j… SET name = ..., ...`). This matches the convention already used by `bootstrap.surql` and is documented in each file's header.
- **`status` stored as plain `string`** (not an `$value INSIDE [...]` enum). The resource lifecycle FSM is not yet formalised across layers; pinning the enum here would force a churn once the full state set lands. The one exception is `vm.state`, which **does** carry an `INSIDE [...]` assert pinning the six variants from `VmState`.
- **`created_at` / `updated_at` typed as `datetime`** even though today's `ResourceMeta` uses `u64` Unix-epoch seconds. P3 codegen will bridge the two representations at generate time; shipping the schema-side type as `datetime` from day one avoids a second migration.
- **`user.surql` has no matching Rust type** yet. Documented in the file header: the schema is intentionally minimal (`email`, `display_name`, `status`, `labels`, `created_at`, `updated_at`) so it can grow as the authentication subsystem lands. The unique index lives on `email`.
- **Denormalised fields preserved**. Today's Rust structs carry denormalised parent names (`org_name`, `project_name`, `env_name`, `vpc_name`, `subnet_name`) alongside the ids. The schemas ship both so the wire shape round-trips exactly. Removing the denormalised columns is a P3 cleanup, not a P2.5 concern.
- **`vm.subnet_private_ip` unique index** is a new constraint not enforced at the TiKV level today (the IPAM allocator enforces it at write time instead). Modelling it at the schema level guards against future races — see the comment in `vm.surql`. SurrealDB's unique indexes already treat `NONE` values as distinct, so `pending`-state VMs with no IP don't collide.

## Verification

New `cluster_schemas_parse_cleanly` test in `layers/state/src/embedded.rs`:

- Opens a throwaway `EmbeddedDb` at a tempdir
- Loads every cluster schema via `include_str!` and applies it twice in sequence
- First pass exercises real `DEFINE TABLE/FIELD/INDEX` against an empty db (parse validation)
- Second pass exercises the `IF NOT EXISTS` idempotency promise (any missing `IF NOT EXISTS` surfaces as an "already exists" error)

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo build --workspace` clean
- [x] `cargo test -p nauka-state` clean — all 20 tests pass, including the new `cluster_schemas_parse_cleanly` test
- [ ] CI green on the pushed branch