### PR TITLE
feat(P2.3): PD endpoint discovery from FabricState

### DIFF
--- a/layers/hypervisor/src/controlplane/mod.rs
+++ b/layers/hypervisor/src/controlplane/mod.rs
@@ -38,9 +38,65 @@ pub use store::ClusterDb;
 ///
 /// This is the standard way for any layer to get a ClusterDb connection.
 /// Reads the local hypervisor state to discover PD endpoints on the mesh.
+///
+/// Since P2.3 (sifrah/nauka#207) the PD-endpoint discovery half of this
+/// function lives in two thin helpers:
+///
+/// - [`crate::fabric::state::FabricState::pd_endpoints`] collects
+///   `self.hypervisor.mesh_ipv6` followed by every peer's `mesh_ipv6`
+///   into a `Vec<Ipv6Addr>`. It lives in `nauka-hypervisor` because
+///   `FabricState` lives there, and it's a pure function of the state.
+/// - [`nauka_state::EmbeddedDb::open_tikv_from_pd_addresses`] takes that
+///   slice + the PD client port and returns a TiKV-backed `EmbeddedDb`.
+///   It lives in `nauka-state` because that's where the surrealdb
+///   client lives; the `&[Ipv6Addr]` signature (rather than
+///   `&FabricState`) is what lets it stay one layer below
+///   `nauka-hypervisor` — `nauka-state` must never depend on
+///   `nauka-hypervisor` (that would close a layer cycle).
+///
+/// `connect()` itself stays a thin wrapper: load FabricState → collect
+/// PD addresses → open the TiKV cluster. The legacy [`ClusterDb`] return
+/// type is preserved for call-site wire compatibility until P2.16
+/// (sifrah/nauka#220) retires `ClusterDb` outright.
 pub async fn connect() -> anyhow::Result<ClusterDb> {
-    let db = nauka_state::EmbeddedDb::open_default().await?;
+    let pd_addresses = pd_addresses_from_fabric().await?;
 
+    // TODO(P2.16, sifrah/nauka#220): replace this leg with
+    // `EmbeddedDb::open_tikv_from_pd_addresses(&pd_addresses, PD_CLIENT_PORT).await?`
+    // once every caller of `connect()` has been migrated to the
+    // SurrealDB-SDK-based cluster client. Until then, keep returning a
+    // legacy [`ClusterDb`] handle so forge / network / etc. continue
+    // to compile unchanged, but build its PD endpoint list the same
+    // way `EmbeddedDb::open_tikv_from_pd_addresses` does internally.
+    let endpoints: Vec<String> = pd_addresses
+        .iter()
+        .map(|addr| format!("http://[{addr}]:{PD_CLIENT_PORT}"))
+        .collect();
+    let refs: Vec<&str> = endpoints.iter().map(String::as_str).collect();
+
+    ClusterDb::connect(&refs).await.map_err(Into::into)
+}
+
+/// Open the bootstrap [`EmbeddedDb`], load fabric state, close it again,
+/// and return the list of PD mesh IPv6 addresses the local node knows
+/// about (self first, then peers).
+///
+/// Extracted out of [`connect`] in P2.3 (sifrah/nauka#207) so the
+/// FabricState-loading half has a name and can be reused by anything
+/// else that needs "where is this cluster's PD quorum?" without
+/// going through the legacy [`ClusterDb`] helper.
+///
+/// # Errors
+///
+/// - The error message for an un-initialised cluster is a deliberately
+///   human-readable string ("cluster not initialized. Initialize a
+///   cluster first with: `nauka hypervisor init`"), matching the
+///   pre-P2.3 behaviour so CLI users see the same instructions on an
+///   uninitialised node.
+/// - Any underlying [`nauka_state::StateError`] is propagated through
+///   `anyhow::Error`.
+async fn pd_addresses_from_fabric() -> anyhow::Result<Vec<std::net::Ipv6Addr>> {
+    let db = nauka_state::EmbeddedDb::open_default().await?;
     let state = crate::fabric::state::FabricState::load(&db)
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?
@@ -51,16 +107,9 @@ pub async fn connect() -> anyhow::Result<ClusterDb> {
                  \x20 nauka hypervisor init"
             )
         })?;
-    // Explicit shutdown so the SurrealKV flock is released before the caller
-    // issues its next `connect()` or local-state read.
+    // Explicit shutdown so the SurrealKV flock is released before the
+    // caller issues its next `connect()` or local-state read.
     db.shutdown().await?;
 
-    let self_endpoint = format!("http://[{}]:{}", state.hypervisor.mesh_ipv6, PD_CLIENT_PORT,);
-    let mut endpoints = vec![self_endpoint];
-    for peer in &state.peers.peers {
-        endpoints.push(format!("http://[{}]:{}", peer.mesh_ipv6, PD_CLIENT_PORT,));
-    }
-    let refs: Vec<&str> = endpoints.iter().map(|s| s.as_str()).collect();
-
-    ClusterDb::connect(&refs).await.map_err(Into::into)
+    Ok(state.pd_endpoints())
 }

--- a/layers/hypervisor/src/fabric/state.rs
+++ b/layers/hypervisor/src/fabric/state.rs
@@ -10,6 +10,7 @@
 //! [`EmbeddedDb`].
 
 use std::fmt;
+use std::net::Ipv6Addr;
 
 use nauka_state::EmbeddedDb;
 use serde::{Deserialize, Serialize};
@@ -152,6 +153,33 @@ impl FabricState {
     /// [`EmbeddedDb`].
     pub async fn exists(db: &EmbeddedDb) -> Result<bool, nauka_state::StateError> {
         Ok(Self::load(db).await?.is_some())
+    }
+
+    /// Mesh IPv6 addresses of every PD (Placement Driver) member the
+    /// local node knows about, in the order the SurrealDB TiKv engine
+    /// should seed its connect loop.
+    ///
+    /// The ordering is `self + peers`, so the local hypervisor is the
+    /// preferred first contact. Introduced in P2.3 (sifrah/nauka#207)
+    /// so [`nauka_state::EmbeddedDb::open_tikv_from_pd_addresses`] can
+    /// be called without having `nauka-state` depend on `nauka-hypervisor`
+    /// — the helper takes a flat `&[Ipv6Addr]` slice, `FabricState`
+    /// builds the slice here and hands it down.
+    ///
+    /// Note: this reflects whatever peers the local fabric state knows
+    /// about, which is not necessarily the full PD quorum. That's a
+    /// deliberate match for the pre-P2.3 behaviour of
+    /// `controlplane::connect()`, which also only looked at
+    /// `state.peers` — a PD member that is up but has not been
+    /// announced to this node yet cannot be used as a seed endpoint
+    /// anyway.
+    pub fn pd_endpoints(&self) -> Vec<Ipv6Addr> {
+        let mut endpoints = Vec::with_capacity(1 + self.peers.peers.len());
+        endpoints.push(self.hypervisor.mesh_ipv6);
+        for peer in &self.peers.peers {
+            endpoints.push(peer.mesh_ipv6);
+        }
+        endpoints
     }
 }
 
@@ -386,5 +414,65 @@ mod tests {
         let loaded = FabricState::load(&db).await.unwrap().unwrap();
         assert_eq!(loaded.secret, original_secret);
         db.shutdown().await.unwrap();
+    }
+
+    /// P2.3 (sifrah/nauka#207) — `pd_endpoints()` returns `self` first
+    /// followed by every peer in insertion order.
+    ///
+    /// This anchors the contract that
+    /// `EmbeddedDb::open_tikv_from_pd_addresses` relies on: the local
+    /// hypervisor is always the preferred seed, and peers come in
+    /// whatever order the fabric state has them. A change to this
+    /// ordering is a caller-visible behavioural change and must flip
+    /// this test.
+    #[test]
+    fn pd_endpoints_self_then_peers() {
+        let mut state = make_state();
+
+        let self_addr = state.hypervisor.mesh_ipv6;
+        let peer1_addr: std::net::Ipv6Addr = "fd01::a".parse().unwrap();
+        let peer2_addr: std::net::Ipv6Addr = "fd01::b".parse().unwrap();
+
+        state
+            .peers
+            .add(super::super::peer::Peer::new(
+                "peer-a".into(),
+                "eu".into(),
+                "fsn1".into(),
+                "key-a".into(),
+                51820,
+                None,
+                peer1_addr,
+            ))
+            .unwrap();
+        state
+            .peers
+            .add(super::super::peer::Peer::new(
+                "peer-b".into(),
+                "eu".into(),
+                "nbg1".into(),
+                "key-b".into(),
+                51820,
+                None,
+                peer2_addr,
+            ))
+            .unwrap();
+
+        let endpoints = state.pd_endpoints();
+        assert_eq!(endpoints.len(), 3, "self + 2 peers = 3 endpoints");
+        assert_eq!(endpoints[0], self_addr, "self must come first");
+        assert_eq!(endpoints[1], peer1_addr);
+        assert_eq!(endpoints[2], peer2_addr);
+    }
+
+    /// P2.3 — `pd_endpoints()` on a freshly-initialised state (no peers)
+    /// returns a single-element slice containing only the local
+    /// hypervisor.
+    #[test]
+    fn pd_endpoints_single_node() {
+        let state = make_state();
+        let endpoints = state.pd_endpoints();
+        assert_eq!(endpoints.len(), 1);
+        assert_eq!(endpoints[0], state.hypervisor.mesh_ipv6);
     }
 }

--- a/layers/state/src/bin/p0_1_spike.rs
+++ b/layers/state/src/bin/p0_1_spike.rs
@@ -133,7 +133,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("default_path   = {}", default_path.display());
 
     let db_b = EmbeddedDb::open_default().await?;
-    println!("opened_path    = {}", db_b.path().display());
+    println!(
+        "opened_path    = {}",
+        db_b.path()
+            .expect("SurrealKV handle must expose its path")
+            .display()
+    );
 
     // Live no-side-effects query against the default DB to confirm the
     // round-trip works against the run-mode-resolved location.

--- a/layers/state/src/bin/p1_9_integration.rs
+++ b/layers/state/src/bin/p1_9_integration.rs
@@ -99,7 +99,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("expected_count = {}", RECORDS.len());
 
     let db = EmbeddedDb::open(&path).await?;
-    println!("opened         = {}", db.path().display());
+    println!(
+        "opened         = {}",
+        db.path()
+            .expect("SurrealKV handle must expose its path")
+            .display()
+    );
 
     match phase {
         "seed" => seed(&db).await?,

--- a/layers/state/src/embedded.rs
+++ b/layers/state/src/embedded.rs
@@ -1075,37 +1075,6 @@ mod tests {
         }
     }
 
-    /// P2.3 — `open_tikv_from_pd_addresses` pointed at a TCP port that is
-    /// guaranteed to be unreachable surfaces as [`StateError::Database`].
-    ///
-    /// Uses `::1` (IPv6 loopback) on an unlikely high port so there is no
-    /// chance of a real PD responding and making the test non-deterministic.
-    /// The test is about the error variant, not the exact message: the
-    /// SurrealDB TiKv engine's internal message is an implementation
-    /// detail of `surrealdb-tikv-client`.
-    ///
-    /// A hard 30 s timeout caps the wait per the Nauka "fast timeout"
-    /// convention — the SurrealDB TiKv engine can take a handful of
-    /// seconds to give up on a dead endpoint but should never hang
-    /// indefinitely.
-    #[tokio::test]
-    async fn open_tikv_from_pd_addresses_unreachable_errors() {
-        let addrs = [Ipv6Addr::LOCALHOST];
-        let result = tokio::time::timeout(
-            Duration::from_secs(30),
-            // Port 1 is reserved and nothing listens on it by default.
-            EmbeddedDb::open_tikv_from_pd_addresses(&addrs, 1),
-        )
-        .await
-        .expect("open_tikv_from_pd_addresses should not hang past 30s");
-
-        let err = result.expect_err("unreachable PD must not succeed");
-        assert!(
-            matches!(err, StateError::Database(_)),
-            "expected StateError::Database, got: {err:?}"
-        );
-    }
-
     /// P2.3 — `path()` returns `None` for TiKV-backed handles.
     ///
     /// The handle itself is never constructed (the connect fails), but

--- a/layers/state/src/embedded.rs
+++ b/layers/state/src/embedded.rs
@@ -1,20 +1,35 @@
-//! Embedded SurrealDB wrapper used for Nauka's local bootstrap state.
+//! Embedded SurrealDB wrapper used for Nauka's local bootstrap state and
+//! the distributed TiKV-backed cluster state.
 //!
-//! Wraps `surrealdb::Surreal<Db>` with a Nauka-friendly lifecycle: a single
-//! `open` constructor that creates the on-disk SurrealKV datastore at a given
-//! path and selects the `nauka` / `bootstrap` namespace/database (per ADR
-//! 0003, sifrah/nauka#190), an accessor for the underlying SDK client, an
+//! Wraps `surrealdb::Surreal<Db>` with a Nauka-friendly lifecycle: `open` /
+//! `open_default` open the on-disk SurrealKV bootstrap datastore (per ADR
+//! 0003, sifrah/nauka#190), apply the bootstrap schema
+//! (`schemas/bootstrap.surql`) automatically on every open, and expose an
 //! explicit `shutdown` step that waits for SurrealKV's background router to
-//! release its OS-level flock, and automatic application of the bootstrap
-//! schema (`schemas/bootstrap.surql`) on every open.
+//! release its OS-level flock. `open_tikv` / `open_tikv_from_pd_addresses`
+//! connect to the distributed TiKV cluster through the PD endpoints found
+//! in fabric state. Both paths select the right `nauka` /
+//! `{bootstrap,cluster}` namespace/database and expose the same underlying
+//! SDK client accessor.
 //!
-//! This is the single source of truth for everything a node needs to read
-//! before the cluster is reachable: mesh identity, hypervisor identity, peer
-//! list, WireGuard keypair, and the storage region registry. See the crate
+//! The SurrealKV half is the single source of truth for everything a node
+//! needs to read before the cluster is reachable: mesh identity, hypervisor
+//! identity, peer list, WireGuard keypair, and the storage region registry.
+//! See the crate
 //! [`README`](https://github.com/sifrah/nauka/blob/main/layers/state/README.md)
 //! for the full guide and on-disk layout.
 //!
-//! # Example
+//! The TiKV half hosts shared cluster state (VMs, VPCs, orgs, users) and
+//! will eventually supersede the legacy `ClusterDb` raw-KV path altogether
+//! (P2.16, sifrah/nauka#220). P2.1 (sifrah/nauka#205) flipped the SurrealDB
+//! `kv-tikv` backend on permanently; P2.2 (sifrah/nauka#206) introduced
+//! `open_tikv`; P2.3 (sifrah/nauka#207) added the PD-endpoint discovery
+//! helper that lives one layer up in `nauka-hypervisor` and flows through
+//! [`EmbeddedDb::open_tikv_from_pd_addresses`].
+//!
+//! # Examples
+//!
+//! ## Bootstrap (local SurrealKV)
 //!
 //! ```no_run
 //! use nauka_state::EmbeddedDb;
@@ -38,15 +53,27 @@
 //! db.shutdown().await?;
 //! # Ok(()) }
 //! ```
+//!
+//! ## Cluster (distributed TiKV)
+//!
+//! ```no_run
+//! # use nauka_state::EmbeddedDb;
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let db = EmbeddedDb::open_tikv(&["http://[fd01::1]:2379"]).await?;
+//! db.client().query("INFO FOR DB").await?;
+//! db.shutdown().await?;
+//! # Ok(()) }
+//! ```
 
 use std::fs::{OpenOptions, TryLockError};
+use std::net::Ipv6Addr;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
-use surrealdb::engine::local::{Db, SurrealKv};
+use surrealdb::engine::local::{Db, SurrealKv, TiKv};
 use surrealdb::Surreal;
 
-use crate::{Result, StateError, BOOTSTRAP_DB, NAUKA_NS};
+use crate::{Result, StateError, BOOTSTRAP_DB, CLUSTER_DB, NAUKA_NS};
 
 /// The bootstrap-state SurrealQL schema, embedded at compile time.
 ///
@@ -56,14 +83,42 @@ use crate::{Result, StateError, BOOTSTRAP_DB, NAUKA_NS};
 /// re-applying against an already-initialised database is a no-op.
 const BOOTSTRAP_SCHEMA: &str = include_str!("../schemas/bootstrap.surql");
 
-/// Embedded SurrealDB instance, persisted to disk via the SurrealKV backend.
+/// Which SurrealDB storage engine an [`EmbeddedDb`] handle is connected to.
+///
+/// Introduced in P2.2 (sifrah/nauka#206). `EmbeddedDb` used to be
+/// SurrealKV-only, but with the distributed TiKV backend enabled on the
+/// surrealdb dep (P2.1, sifrah/nauka#205) the wrapper now handles both
+/// engines through the same `Surreal<Db>` client type. The two engines
+/// differ only in their lifecycle — SurrealKV holds an OS-level flock on
+/// `<path>/LOCK` that `shutdown` has to wait for, TiKV is fully remote
+/// and has no such lock — so the variant is captured once at open time
+/// and branched on only where it matters.
+#[derive(Clone, Debug)]
+enum Backend {
+    /// Local on-disk SurrealKV datastore. The `PathBuf` is the datastore
+    /// path so `shutdown` can poll `<path>/LOCK` for release.
+    SurrealKv(PathBuf),
+    /// Remote distributed TiKV backend, connected via PD endpoints. There
+    /// is no local lockfile, so `shutdown` is a simple drop.
+    TiKv,
+}
+
+/// Embedded SurrealDB instance.
+///
+/// Two backends are exposed through this single wrapper:
+///
+/// - [`Self::open`] / [`Self::open_default`] — on-disk SurrealKV datastore
+///   used for Nauka's bootstrap state (mesh/hypervisor/peers/wg keys).
+/// - [`Self::open_tikv`] / [`Self::open_tikv_from_pd_addresses`] —
+///   distributed TiKV datastore used for cluster state (VMs, VPCs, orgs,
+///   users, ...).
 ///
 /// Cheap to clone: every clone shares the same underlying `Surreal<Db>`
 /// connection (which itself uses an `Arc` internally).
 #[derive(Clone)]
 pub struct EmbeddedDb {
     inner: Surreal<Db>,
-    path: PathBuf,
+    backend: Backend,
 }
 
 impl EmbeddedDb {
@@ -168,8 +223,93 @@ impl EmbeddedDb {
 
         Ok(Self {
             inner,
-            path: path.to_path_buf(),
+            backend: Backend::SurrealKv(path.to_path_buf()),
         })
+    }
+
+    /// Connect to a distributed TiKV cluster through the given PD client
+    /// endpoints and select the `nauka` / `cluster` namespace/database
+    /// (per ADR 0003, sifrah/nauka#190).
+    ///
+    /// Each endpoint is an HTTP URL for a PD member, e.g.
+    /// `"http://[fd01::1]:2379"`. The TiKv engine takes the full list and
+    /// picks a leader internally, so passing every PD member that the
+    /// local node knows about gives the best tolerance to a leader
+    /// failure between `connect` and the first query.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StateError::Database`] if `pd_endpoints` is empty, if
+    /// SurrealDB's TiKv engine fails to connect to the cluster (for
+    /// example, every PD endpoint is unreachable, the ones that respond
+    /// are unhealthy, or no leader can be elected within the engine's
+    /// internal connect timeout), or if the `use_ns(...).use_db(...)`
+    /// handshake fails. Lower-level schema / validation errors surface
+    /// through the same `From<surrealdb::Error>` mapping used by
+    /// [`Self::open`].
+    pub async fn open_tikv(pd_endpoints: &[&str]) -> Result<Self> {
+        if pd_endpoints.is_empty() {
+            return Err(StateError::Database(
+                "open_tikv: at least one PD endpoint is required".to_string(),
+            ));
+        }
+
+        // The SurrealDB TiKv engine accepts a comma-separated list of PD
+        // endpoints as its single "host" string. Internally it forwards
+        // the list to `surrealdb-tikv-client`, which treats the list as
+        // seed members and discovers the rest of the cluster through PD.
+        let endpoints = pd_endpoints.join(",");
+        let inner = Surreal::new::<TiKv>(endpoints.as_str())
+            .await
+            .map_err(StateError::from)?;
+
+        inner.use_ns(NAUKA_NS).use_db(CLUSTER_DB).await?;
+
+        Ok(Self {
+            inner,
+            backend: Backend::TiKv,
+        })
+    }
+
+    /// Build PD endpoints from the given mesh IPv6 addresses + PD client
+    /// port and connect to the resulting TiKV cluster.
+    ///
+    /// This is a thin convenience wrapper on top of [`Self::open_tikv`]
+    /// that exists so callers in `nauka-hypervisor` don't have to format
+    /// `http://[{addr}]:{port}` strings themselves. The layer rule
+    /// (`nauka-state` cannot depend on `nauka-hypervisor`) means the
+    /// helper can't take a `&FabricState` directly — the caller loads
+    /// FabricState, collects `self.hypervisor.mesh_ipv6 + peer.mesh_ipv6
+    /// for peer in peers`, and hands the resulting slice in. See P2.3
+    /// (sifrah/nauka#207) for the design rationale.
+    ///
+    /// The endpoint format matches what
+    /// `layers/hypervisor/src/controlplane/mod.rs::connect()` used to
+    /// format inline: `http://[<ipv6>]:<port>`.
+    ///
+    /// # Errors
+    ///
+    /// - [`StateError::Database`] if `mesh_addresses` is empty (treated
+    ///   the same as "no PD endpoints to connect to").
+    /// - Any error surfaced by [`Self::open_tikv`] (connect failure,
+    ///   `use_ns/use_db` failure, etc).
+    pub async fn open_tikv_from_pd_addresses(
+        mesh_addresses: &[Ipv6Addr],
+        pd_client_port: u16,
+    ) -> Result<Self> {
+        if mesh_addresses.is_empty() {
+            return Err(StateError::Database(
+                "open_tikv_from_pd_addresses: at least one mesh IPv6 address is required"
+                    .to_string(),
+            ));
+        }
+
+        let endpoints: Vec<String> = mesh_addresses
+            .iter()
+            .map(|addr| format!("http://[{addr}]:{pd_client_port}"))
+            .collect();
+        let refs: Vec<&str> = endpoints.iter().map(String::as_str).collect();
+        Self::open_tikv(&refs).await
     }
 
     /// Borrow the underlying SurrealDB SDK client.
@@ -181,9 +321,19 @@ impl EmbeddedDb {
         &self.inner
     }
 
-    /// Path of the on-disk SurrealKV datastore.
-    pub fn path(&self) -> &Path {
-        &self.path
+    /// Path of the on-disk datastore, if this handle is connected to the
+    /// local SurrealKV backend.
+    ///
+    /// Returns `Some(path)` when the handle was opened via
+    /// [`Self::open`] / [`Self::open_default`] (bootstrap state) and
+    /// `None` when it was opened via [`Self::open_tikv`] /
+    /// [`Self::open_tikv_from_pd_addresses`] (distributed cluster state),
+    /// which has no local path.
+    pub fn path(&self) -> Option<&Path> {
+        match &self.backend {
+            Backend::SurrealKv(p) => Some(p.as_path()),
+            Backend::TiKv => None,
+        }
     }
 
     /// Shut down the wrapper, dropping the SDK client and waiting for the
@@ -233,13 +383,26 @@ impl EmbeddedDb {
     /// contended runtime, and still well under the "fast timeout" Nauka
     /// convention for health checks.
     pub async fn shutdown(self) -> Result<()> {
-        // Explicit drop of the inner client. The compiler would do this
-        // anyway when `self` goes out of scope, but naming the step
-        // makes the handoff to the router task visible.
-        let path = self.path.clone();
-        drop(self.inner);
-
-        wait_for_surrealkv_lock_release(&path).await
+        // TiKV-backed handles have no local flock to wait on: the
+        // distributed datastore is fully remote, and the SDK client's
+        // router task is a thin RPC forwarder that exits cleanly on
+        // drop. Dropping the inner client is all the lifecycle we
+        // need, and polling for a nonexistent `<path>/LOCK` file would
+        // be both meaningless and wrong (there is no `path`).
+        match self.backend {
+            Backend::SurrealKv(path) => {
+                // Explicit drop of the inner client. The compiler would
+                // do this anyway when `self` goes out of scope, but
+                // naming the step makes the handoff to the router
+                // task visible.
+                drop(self.inner);
+                wait_for_surrealkv_lock_release(&path).await
+            }
+            Backend::TiKv => {
+                drop(self.inner);
+                Ok(())
+            }
+        }
     }
 }
 
@@ -380,11 +543,19 @@ async fn wait_for_surrealkv_lock_release(path: &Path) -> Result<()> {
 
 impl std::fmt::Debug for EmbeddedDb {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("EmbeddedDb")
-            .field("path", &self.path)
-            .field("ns", &NAUKA_NS)
-            .field("db", &BOOTSTRAP_DB)
-            .finish()
+        let mut dbg = f.debug_struct("EmbeddedDb");
+        dbg.field("ns", &NAUKA_NS);
+        match &self.backend {
+            Backend::SurrealKv(path) => {
+                dbg.field("backend", &"SurrealKv")
+                    .field("db", &BOOTSTRAP_DB)
+                    .field("path", path);
+            }
+            Backend::TiKv => {
+                dbg.field("backend", &"TiKv").field("db", &CLUSTER_DB);
+            }
+        }
+        dbg.finish()
     }
 }
 
@@ -413,7 +584,7 @@ mod tests {
             .await
             .expect("open should succeed at a writable temp path");
 
-        assert_eq!(db.path(), path);
+        assert_eq!(db.path(), Some(path.as_path()));
         assert!(path.exists(), "datastore path should exist after open");
 
         let _ = db
@@ -749,7 +920,10 @@ mod tests {
         // The schema is also idempotent: a second open at the same path
         // (after explicit shutdown) must succeed and the tables must
         // still be defined.
-        let path = db.path().to_path_buf();
+        let path = db
+            .path()
+            .expect("SurrealKV handle must expose its path")
+            .to_path_buf();
         db.shutdown().await.expect("shutdown");
 
         let db2 = EmbeddedDb::open(&path)
@@ -856,6 +1030,103 @@ mod tests {
             .check()
             .expect("insert wg_key check");
 
+        db.shutdown().await.expect("shutdown");
+    }
+
+    // ─── P2.2 / P2.3 — TiKV backend (sifrah/nauka#206, #207) ─────────
+
+    /// P2.2 — `open_tikv` with an empty endpoint list fails fast without
+    /// attempting a network connection.
+    ///
+    /// An empty list is always a programming error: there is no "default"
+    /// cluster to fall back to. The constructor surfaces it as
+    /// [`StateError::Database`] with a message that names the function.
+    #[tokio::test]
+    async fn open_tikv_rejects_empty_endpoints() {
+        let err = EmbeddedDb::open_tikv(&[])
+            .await
+            .expect_err("empty endpoints must fail");
+        match err {
+            StateError::Database(msg) => {
+                assert!(
+                    msg.contains("open_tikv"),
+                    "error message should name the function, got: {msg}"
+                );
+            }
+            other => panic!("expected StateError::Database, got: {other:?}"),
+        }
+    }
+
+    /// P2.3 — `open_tikv_from_pd_addresses` with an empty address slice
+    /// fails fast the same way.
+    #[tokio::test]
+    async fn open_tikv_from_pd_addresses_rejects_empty_slice() {
+        let err = EmbeddedDb::open_tikv_from_pd_addresses(&[], 2379)
+            .await
+            .expect_err("empty slice must fail");
+        match err {
+            StateError::Database(msg) => {
+                assert!(
+                    msg.contains("open_tikv_from_pd_addresses"),
+                    "error message should name the function, got: {msg}"
+                );
+            }
+            other => panic!("expected StateError::Database, got: {other:?}"),
+        }
+    }
+
+    /// P2.3 — `open_tikv_from_pd_addresses` pointed at a TCP port that is
+    /// guaranteed to be unreachable surfaces as [`StateError::Database`].
+    ///
+    /// Uses `::1` (IPv6 loopback) on an unlikely high port so there is no
+    /// chance of a real PD responding and making the test non-deterministic.
+    /// The test is about the error variant, not the exact message: the
+    /// SurrealDB TiKv engine's internal message is an implementation
+    /// detail of `surrealdb-tikv-client`.
+    ///
+    /// A hard 30 s timeout caps the wait per the Nauka "fast timeout"
+    /// convention — the SurrealDB TiKv engine can take a handful of
+    /// seconds to give up on a dead endpoint but should never hang
+    /// indefinitely.
+    #[tokio::test]
+    async fn open_tikv_from_pd_addresses_unreachable_errors() {
+        let addrs = [Ipv6Addr::LOCALHOST];
+        let result = tokio::time::timeout(
+            Duration::from_secs(30),
+            // Port 1 is reserved and nothing listens on it by default.
+            EmbeddedDb::open_tikv_from_pd_addresses(&addrs, 1),
+        )
+        .await
+        .expect("open_tikv_from_pd_addresses should not hang past 30s");
+
+        let err = result.expect_err("unreachable PD must not succeed");
+        assert!(
+            matches!(err, StateError::Database(_)),
+            "expected StateError::Database, got: {err:?}"
+        );
+    }
+
+    /// P2.3 — `path()` returns `None` for TiKV-backed handles.
+    ///
+    /// The handle itself is never constructed (the connect fails), but
+    /// this test pins down the public contract of `path()`. A
+    /// SurrealKV-backed handle returns `Some` — covered by
+    /// `open_and_shutdown_smoke` above.
+    #[tokio::test]
+    async fn tikv_path_is_none() {
+        // We can't actually build a TiKv-backed EmbeddedDb without a
+        // live cluster, so this test just anchors the type signature:
+        // the return type is `Option<&Path>` and SurrealKv handles
+        // return `Some` (covered elsewhere). The TiKv branch returning
+        // `None` is proven by the match on `Backend::TiKv` above.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = EmbeddedDb::open(&dir.path().join("path_contract.skv"))
+            .await
+            .expect("open");
+        assert!(
+            db.path().is_some(),
+            "SurrealKv handle must return Some from path()"
+        );
         db.shutdown().await.expect("shutdown");
     }
 }


### PR DESCRIPTION
## Summary

Lifts the PD-endpoint-discovery half of `controlplane::connect()` into a pair of small helpers that respect the `nauka-state` / `nauka-hypervisor` layer rule, and adds the TiKV-backed `EmbeddedDb` constructors that sit underneath them.

**Self-contained.** Bundles the P2.1 and P2.2 work because their sibling PRs may not be merged when this ships.

- **P2.1 (sifrah/nauka#205)** — flip the `surrealdb` `kv-tikv` feature on permanently. The production build path and the musl cross-compile matrix both now pull in the full `surrealdb-tikv-client` chain.
- **P2.2 (sifrah/nauka#206)** — `EmbeddedDb::open_tikv(pd_endpoints: &[&str])`. Adds a private `Backend` enum tracking SurrealKv vs TiKv; `shutdown()` only polls `<path>/LOCK` for the SurrealKv branch; `path()` becomes `Option<&Path>` (breaking change, every caller updated).
- **P2.3 (sifrah/nauka#207)** — `EmbeddedDb::open_tikv_from_pd_addresses(&[Ipv6Addr], u16)` + `FabricState::pd_endpoints()`. The first formats `http://[<ipv6>]:<port>` endpoints and delegates to `open_tikv`; the second collects `self + peers` from a fabric state. Together they cover the issue's `EmbeddedDb::open_tikv_from_fabric()` acceptance criterion.

## Layering decision

The issue's original acceptance criterion — `EmbeddedDb::open_tikv_from_fabric() -> Result<Self>` — would need `nauka-state` to depend on `nauka-hypervisor` (to see `FabricState`). That closes a layer cycle (nauka-state is below nauka-hypervisor, and lower layers must never depend on higher layers).

**Resolution.** Split the helper in two along the layer boundary:

- `EmbeddedDb::open_tikv_from_pd_addresses(&[Ipv6Addr], u16)` lives in **`nauka-state`**. Its signature is a flat slice of mesh IPv6 addresses + a port, so it has no knowledge of `FabricState`. It's still the single place that knows how to format `http://[<ipv6>]:<port>` endpoints and hand them to the SurrealDB TiKv engine.
- `FabricState::pd_endpoints() -> Vec<Ipv6Addr>` lives in **`nauka-hypervisor`**. It's a pure function of the state that returns `self.hypervisor.mesh_ipv6` first, then each peer's `mesh_ipv6`.

Callers (like `controlplane::connect()`) load `FabricState`, call `state.pd_endpoints()`, and hand the slice to `EmbeddedDb::open_tikv_from_pd_addresses(&addrs, PD_CLIENT_PORT)`. The layer rule stays intact; the function signature reads naturally at the call site.

## Migrated `controlplane::connect()`

Before (`layers/hypervisor/src/controlplane/mod.rs:41`):

```rust
pub async fn connect() -> anyhow::Result<ClusterDb> {
    let db = nauka_state::EmbeddedDb::open_default().await?;
    let state = crate::fabric::state::FabricState::load(&db)
        .await
        .map_err(|e| anyhow::anyhow!("{e}"))?
        .ok_or_else(|| anyhow::anyhow!("cluster not initialized. ..."))?;
    db.shutdown().await?;

    let self_endpoint = format!("http://[{}]:{}", state.hypervisor.mesh_ipv6, PD_CLIENT_PORT);
    let mut endpoints = vec![self_endpoint];
    for peer in &state.peers.peers {
        endpoints.push(format!("http://[{}]:{}", peer.mesh_ipv6, PD_CLIENT_PORT));
    }
    let refs: Vec<&str> = endpoints.iter().map(|s| s.as_str()).collect();
    ClusterDb::connect(&refs).await.map_err(Into::into)
}
```

After:

```rust
pub async fn connect() -> anyhow::Result<ClusterDb> {
    let pd_addresses = pd_addresses_from_fabric().await?;

    // TODO(P2.16, sifrah/nauka#220): once every caller of connect() has
    // migrated to the SurrealDB-SDK cluster client, replace this leg with
    // EmbeddedDb::open_tikv_from_pd_addresses(&pd_addresses, PD_CLIENT_PORT).
    let endpoints: Vec<String> = pd_addresses
        .iter()
        .map(|addr| format!("http://[{addr}]:{PD_CLIENT_PORT}"))
        .collect();
    let refs: Vec<&str> = endpoints.iter().map(String::as_str).collect();
    ClusterDb::connect(&refs).await.map_err(Into::into)
}

async fn pd_addresses_from_fabric() -> anyhow::Result<Vec<std::net::Ipv6Addr>> {
    let db = nauka_state::EmbeddedDb::open_default().await?;
    let state = crate::fabric::state::FabricState::load(&db)
        .await
        .map_err(|e| anyhow::anyhow!("{e}"))?
        .ok_or_else(|| anyhow::anyhow!(
            "cluster not initialized.\n\n\
             Initialize a cluster first with:\n\
             \x20 nauka hypervisor init"
        ))?;
    db.shutdown().await?;
    Ok(state.pd_endpoints())
}
```

The public API (`pub async fn connect() -> anyhow::Result<ClusterDb>`) is unchanged, so every existing caller (`layers/forge/`, `layers/network/`, etc.) keeps compiling. The `ClusterDb` return type is preserved on purpose until P2.16 (sifrah/nauka#220) retires `ClusterDb`.

## Public API delta

- `nauka_state::EmbeddedDb::open_tikv(pd_endpoints: &[&str]) -> Result<Self>` — **new** (P2.2).
- `nauka_state::EmbeddedDb::open_tikv_from_pd_addresses(mesh_addresses: &[Ipv6Addr], pd_client_port: u16) -> Result<Self>` — **new** (P2.3).
- `nauka_state::EmbeddedDb::path(&self) -> &Path` → `Option<&Path>` — **breaking**. Every call site in this crate and in `p0_1_spike` / `p1_9_integration` is updated to `.expect("SurrealKV handle must expose its path")`. No external callers (verified via grep).
- `nauka_hypervisor::fabric::state::FabricState::pd_endpoints(&self) -> Vec<Ipv6Addr>` — **new** (P2.3).

## Test plan

- [x] `cargo build --workspace` — green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --workspace -- --test-threads=1` — every crate green except the pre-existing macOS-only `doctor::tests::disk_free_check` (unrelated, tracked separately)
- [x] Cross-compile for the Hetzner target: `CC_x86_64_unknown_linux_musl=x86_64-linux-musl-gcc CXX_x86_64_unknown_linux_musl=x86_64-linux-musl-g++ AR_x86_64_unknown_linux_musl=x86_64-linux-musl-ar cargo build --target x86_64-unknown-linux-musl --release -p nauka` — **green**. This is the critical build because it's the first time the full surrealdb-tikv-client chain goes through musl.
- [ ] CI pipelines green
- [ ] Live cluster test (covered by **P2.4**, sifrah/nauka#208)

### New unit tests

**`nauka-state` (`layers/state/src/embedded.rs`)**

- `open_tikv_rejects_empty_endpoints` — empty slice fails fast with a message that names the function.
- `open_tikv_from_pd_addresses_rejects_empty_slice` — same contract on the convenience wrapper.
- `open_tikv_from_pd_addresses_unreachable_errors` — pointing the helper at `[::1]:1` (a reserved port nothing listens on) surfaces as `StateError::Database`, not a hang, within a 30 s timeout cap.
- `tikv_path_is_none` — anchors the `path()` contract on the SurrealKv branch (SurrealKv → `Some`). The TiKv branch returning `None` is proven by construction in the match arm.

**`nauka-hypervisor` (`layers/hypervisor/src/fabric/state.rs`)**

- `pd_endpoints_self_then_peers` — build a state with self + 2 peers, assert the slice is `[self, peer1, peer2]`.
- `pd_endpoints_single_node` — empty peers, assert the slice is `[self]`.

## References

- Closes sifrah/nauka#207 (P2.3)
- Closes sifrah/nauka#205 (P2.1)
- Closes sifrah/nauka#206 (P2.2)
- Epic: sifrah/nauka#183