### PR TITLE
feat(P2.4): EmbeddedDb (TiKv) Hetzner round-trip + spike binary

### DIFF
--- a/layers/hypervisor/src/controlplane/mod.rs
+++ b/layers/hypervisor/src/controlplane/mod.rs
@@ -38,6 +38,12 @@ pub use store::ClusterDb;
 ///
 /// This is the standard way for any layer to get a ClusterDb connection.
 /// Reads the local hypervisor state to discover PD endpoints on the mesh.
+///
+/// P2.3 (sifrah/nauka#207) replaced the per-call `format!` ladder with
+/// the shared [`crate::fabric::state::FabricState::pd_endpoints`] +
+/// [`nauka_state::pd_endpoints_for`] helpers so every Phase-2 call site
+/// lands on the same PD list shape — and so `EmbeddedDb::open_tikv`
+/// (P2.2) and `ClusterDb::connect` both see the exact same endpoints.
 pub async fn connect() -> anyhow::Result<ClusterDb> {
     let db = nauka_state::EmbeddedDb::open_default().await?;
 
@@ -55,11 +61,11 @@ pub async fn connect() -> anyhow::Result<ClusterDb> {
     // issues its next `connect()` or local-state read.
     db.shutdown().await?;
 
-    let self_endpoint = format!("http://[{}]:{}", state.hypervisor.mesh_ipv6, PD_CLIENT_PORT,);
-    let mut endpoints = vec![self_endpoint];
-    for peer in &state.peers.peers {
-        endpoints.push(format!("http://[{}]:{}", peer.mesh_ipv6, PD_CLIENT_PORT,));
-    }
+    // Self first, peers after. The self-first contract matters for
+    // single-node clusters (nothing in peers) and for always routing
+    // through the cheapest hop when multiple PDs are live.
+    let mesh_addrs = state.pd_endpoints();
+    let endpoints = nauka_state::pd_endpoints_for(&mesh_addrs, PD_CLIENT_PORT);
     let refs: Vec<&str> = endpoints.iter().map(|s| s.as_str()).collect();
 
     ClusterDb::connect(&refs).await.map_err(Into::into)

--- a/layers/hypervisor/src/fabric/state.rs
+++ b/layers/hypervisor/src/fabric/state.rs
@@ -10,6 +10,7 @@
 //! [`EmbeddedDb`].
 
 use std::fmt;
+use std::net::Ipv6Addr;
 
 use nauka_state::EmbeddedDb;
 use serde::{Deserialize, Serialize};
@@ -152,6 +153,35 @@ impl FabricState {
     /// [`EmbeddedDb`].
     pub async fn exists(db: &EmbeddedDb) -> Result<bool, nauka_state::StateError> {
         Ok(Self::load(db).await?.is_some())
+    }
+
+    /// PD mesh IPv6 addresses this node knows about, **self first**.
+    ///
+    /// Returns `self` as the leading element, followed by every peer's
+    /// `mesh_ipv6` in peer-list order. Used by
+    /// [`crate::controlplane::connect`] to produce the `http://[...]:2379`
+    /// list that gets handed to `EmbeddedDb::open_tikv` (which in turn
+    /// falls back through them until one PD responds).
+    ///
+    /// Self-first matters for two reasons:
+    ///
+    /// 1. On a single-node cluster (nothing in `peers`) it's the only
+    ///    PD endpoint, so it *has* to be first for `open_tikv` to even
+    ///    find it.
+    /// 2. In a multi-node cluster the local PD is always the cheapest
+    ///    hop from the client's perspective — one-packet latency over
+    ///    the loopback-ish `nauka0` interface vs. a WireGuard-encrypted
+    ///    round-trip to another node — so putting it first optimises
+    ///    the common case.
+    ///
+    /// Added in P2.3 (sifrah/nauka#207).
+    pub fn pd_endpoints(&self) -> Vec<Ipv6Addr> {
+        let mut out = Vec::with_capacity(1 + self.peers.peers.len());
+        out.push(self.hypervisor.mesh_ipv6);
+        for peer in &self.peers.peers {
+            out.push(peer.mesh_ipv6);
+        }
+        out
     }
 }
 
@@ -362,6 +392,58 @@ mod tests {
         assert_eq!(loaded.max_pd_members, 5);
 
         db.shutdown().await.unwrap();
+    }
+
+    /// P2.3 — `pd_endpoints()` on a zero-peer state returns exactly
+    /// the local hypervisor's mesh IPv6.
+    #[test]
+    fn pd_endpoints_single_node() {
+        let state = make_state();
+        let endpoints = state.pd_endpoints();
+        assert_eq!(endpoints.len(), 1);
+        assert_eq!(endpoints[0], state.hypervisor.mesh_ipv6);
+    }
+
+    /// P2.3 — `pd_endpoints()` on a multi-peer state returns
+    /// `self` first, then every peer in peer-list order.
+    #[test]
+    fn pd_endpoints_multi_node_self_first() {
+        let mut state = make_state();
+        let self_ipv6 = state.hypervisor.mesh_ipv6;
+
+        let peer_a_ipv6: std::net::Ipv6Addr = "fd01::a".parse().unwrap();
+        let peer_b_ipv6: std::net::Ipv6Addr = "fd01::b".parse().unwrap();
+
+        state
+            .peers
+            .add(super::super::peer::Peer::new(
+                "node-a".into(),
+                "eu".into(),
+                "fsn1".into(),
+                "key-a".into(),
+                51820,
+                None,
+                peer_a_ipv6,
+            ))
+            .unwrap();
+        state
+            .peers
+            .add(super::super::peer::Peer::new(
+                "node-b".into(),
+                "eu".into(),
+                "nbg1".into(),
+                "key-b".into(),
+                51820,
+                None,
+                peer_b_ipv6,
+            ))
+            .unwrap();
+
+        let endpoints = state.pd_endpoints();
+        assert_eq!(endpoints.len(), 3);
+        assert_eq!(endpoints[0], self_ipv6, "self must come first");
+        assert_eq!(endpoints[1], peer_a_ipv6);
+        assert_eq!(endpoints[2], peer_b_ipv6);
     }
 
     /// Cross-process round-trip: write via the async API, drop the

--- a/layers/state/Cargo.toml
+++ b/layers/state/Cargo.toml
@@ -39,5 +39,9 @@ path = "src/bin/p0_3_spike.rs"
 name = "p1-9-integration"
 path = "src/bin/p1_9_integration.rs"
 
+[[bin]]
+name = "p2-4-spike"
+path = "src/bin/p2_4_spike.rs"
+
 [dev-dependencies]
 tempfile = "3"

--- a/layers/state/src/bin/p2_4_spike.rs
+++ b/layers/state/src/bin/p2_4_spike.rs
@@ -1,0 +1,376 @@
+//! Hetzner end-to-end spike for P2.4 (sifrah/nauka#208).
+//!
+//! Goal: prove that `EmbeddedDb::open_tikv` — the Phase-2 cluster-side
+//! constructor added by P2.2 (sifrah/nauka#206) — can talk to a real
+//! PD/TiKV v8.5.5 cluster running on the same Hetzner node and
+//! round-trip a record through the SurrealDB SDK.
+//!
+//! The acceptance criterion from the ticket is:
+//!
+//! > First end-to-end test: from a Hetzner node with PD/TiKV v8.5.5
+//! > already running, open a SurrealDB SDK client and round-trip a
+//! > record.
+//! > - `EmbeddedDb::open_tikv` returns a usable client
+//! > - CREATE + SELECT + DELETE round-trip works
+//! > - Latency is sane (< 50ms p50 for a single-key write)
+//!
+//! What this binary does on each run:
+//!
+//! 1. Print build / runtime / target info for the PR body.
+//! 2. Open the local `EmbeddedDb` at its default path
+//!    (`/var/lib/nauka/bootstrap.skv` in service mode), load the
+//!    FabricState blob directly from the `fabric:state` row, and
+//!    build the canonical PD endpoint list via
+//!    [`nauka_state::pd_endpoints_for`].
+//! 3. Open `EmbeddedDb::open_tikv(&endpoints)` against the live
+//!    PD/TiKV cluster.
+//! 4. Run a CREATE → SELECT → UPDATE → DELETE round-trip on a
+//!    throwaway `p2_4_test:rec1` record, asserting every intermediate
+//!    state.
+//! 5. Run 20 single-key writes in a tight loop, sort the latencies,
+//!    assert that the p50 is **strictly less than 50 ms**. If it
+//!    exceeds the threshold the binary fails loudly — that's a real
+//!    signal worth surfacing.
+//! 6. Clean up the 20-key fixture, shut the TiKv handle down, shut
+//!    the bootstrap handle down, exit 0.
+//!
+//! Returns non-zero on any failure. The test runner captures stdout
+//! into the PR description.
+//!
+//! The spike stays in `nauka-state` so it doesn't have to take a
+//! dependency on `nauka-hypervisor` (which would be an upward layer
+//! dependency and therefore forbidden). FabricState is read directly
+//! from the `fabric:state` row as raw JSON and only the two fields
+//! the spike actually needs — `hypervisor.mesh_ipv6` and
+//! `peers.peers[*].mesh_ipv6` — are extracted. The canonical
+//! `FabricState::pd_endpoints` helper (P2.3 sifrah/nauka#207) is the
+//! reference implementation for the same contract inside the
+//! hypervisor layer.
+
+use std::net::Ipv6Addr;
+use std::time::{Duration, Instant};
+
+use nauka_core::process::{is_service_mode, nauka_db_path};
+use nauka_state::{pd_endpoints_for, EmbeddedDb};
+use surrealdb::types::SurrealValue;
+
+/// PD client port (matches `nauka_hypervisor::controlplane::PD_CLIENT_PORT`).
+/// Hard-coded here to keep the spike layer-clean — redefining a constant
+/// is cheaper than an upward dependency on the hypervisor crate.
+const PD_CLIENT_PORT: u16 = 2379;
+
+/// Throwaway record type used for the CRUD round-trip. Kept in the
+/// spike binary so the production library never compiles a
+/// `SurrealValue` derive that only exists to serve a Hetzner smoke
+/// test.
+#[derive(Debug, Clone, PartialEq, SurrealValue)]
+struct SpikeRecord {
+    name: String,
+    answer: i32,
+}
+
+/// Table used for the main round-trip record (CREATE/SELECT/UPDATE/DELETE).
+const TEST_TABLE: &str = "p2_4_test";
+/// Record id for the single shared round-trip row.
+const TEST_RECORD: &str = "rec1";
+/// Table used for the latency-loop writes. Deliberately distinct from
+/// the main round-trip table so the final assertion on the main
+/// record's lifecycle doesn't get polluted by loop rows.
+const LATENCY_TABLE: &str = "p2_4_latency";
+/// Number of single-key writes to measure in the latency loop.
+const LATENCY_ITERATIONS: usize = 20;
+/// p50 latency threshold from the ticket acceptance criteria.
+const P50_THRESHOLD: Duration = Duration::from_millis(50);
+/// Hard upper bound on any TiKv operation in this spike. Generous
+/// relative to the real path (single-digit ms on a hot PD leader on
+/// the mesh) but short enough that a hang surfaces as a loud failure
+/// instead of a silent test-runner timeout.
+const OP_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn print_help() {
+    println!("nauka p2-4 spike — EmbeddedDb<TiKv> Hetzner end-to-end round-trip");
+    println!();
+    println!("Exercises EmbeddedDb::open_tikv against the local PD/TiKV cluster");
+    println!("discovered through FabricState on a real Hetzner node. Must run");
+    println!("as root in service mode so the default bootstrap path");
+    println!("(/var/lib/nauka/bootstrap.skv) is reachable.");
+    println!();
+    println!("USAGE:");
+    println!("    p2-4-spike [FLAGS]");
+    println!();
+    println!("FLAGS:");
+    println!("    -h, --help    Print this help and exit (no side effects)");
+    println!();
+    println!("The binary exits 0 on success, non-zero on any failure. On");
+    println!("success the CRUD round-trip and the 20-iteration latency loop");
+    println!("both pass, and the reported p50 is strictly < 50 ms.");
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(arg) = std::env::args().nth(1) {
+        match arg.as_str() {
+            "-h" | "--help" => {
+                print_help();
+                return Ok(());
+            }
+            other => {
+                eprintln!("error: unknown flag: {other}");
+                eprintln!("hint:  run `--help` for usage");
+                std::process::exit(2);
+            }
+        }
+    }
+
+    println!("== nauka p2-4 spike (EmbeddedDb<TiKv> Hetzner round-trip) ==");
+    println!("target_arch    = {}", std::env::consts::ARCH);
+    println!("target_os      = {}", std::env::consts::OS);
+    println!("target_env     = {}", std::env::consts::FAMILY);
+    println!("surrealdb_dep  = 3.0.5 (kv-surrealkv + kv-tikv)");
+    println!(
+        "run_mode       = {}",
+        if is_service_mode() {
+            "service (root)"
+        } else {
+            "cli (user)"
+        }
+    );
+    println!("bootstrap_path = {}", nauka_db_path().display());
+
+    // ─── Phase 1: open bootstrap db, load PD endpoints ────────────
+    println!("--- Phase 1: load FabricState for PD discovery ---");
+    let bootstrap = EmbeddedDb::open_default().await?;
+    println!("bootstrap_open = OK");
+
+    let mesh_addrs = load_pd_mesh_addrs(&bootstrap).await?;
+    println!("self_mesh_ipv6 = {}", mesh_addrs[0]);
+    println!("peer_count     = {}", mesh_addrs.len() - 1);
+
+    let endpoints = pd_endpoints_for(&mesh_addrs, PD_CLIENT_PORT);
+    let endpoint_refs: Vec<&str> = endpoints.iter().map(|s| s.as_str()).collect();
+    println!("pd_endpoints   = {endpoint_refs:?}");
+
+    // Release the local bootstrap flock before we touch the cluster —
+    // keeps the subsequent `open_tikv` decoupled from any local write
+    // that might race with a forge reconcile cycle on the same node.
+    bootstrap.shutdown().await?;
+    println!("bootstrap_shut = OK");
+
+    // ─── Phase 2: open_tikv against the live cluster ──────────────
+    println!("--- Phase 2: EmbeddedDb::open_tikv ---");
+    let t_connect = Instant::now();
+    let tikv = tokio::time::timeout(OP_TIMEOUT, EmbeddedDb::open_tikv(&endpoint_refs))
+        .await
+        .map_err(|_| format!("open_tikv timed out after {}s", OP_TIMEOUT.as_secs()))??;
+    println!("open_tikv_ms   = {}", t_connect.elapsed().as_millis());
+    println!("tikv_handle    = {tikv:?}");
+
+    // ─── Phase 3: CRUD round-trip ────────────────────────────────
+    println!("--- Phase 3: CRUD round-trip on {TEST_TABLE}:{TEST_RECORD} ---");
+    let client = tikv.client();
+
+    // Belt-and-braces cleanup from any prior crashed run. Ignore the
+    // result — a fresh cluster has nothing to delete.
+    let _: Option<SpikeRecord> = client
+        .delete((TEST_TABLE, TEST_RECORD))
+        .await
+        .unwrap_or(None);
+
+    // CREATE.
+    let t_create = Instant::now();
+    let created: Option<SpikeRecord> = client
+        .create((TEST_TABLE, TEST_RECORD))
+        .content(SpikeRecord {
+            name: "p2-4".into(),
+            answer: 42,
+        })
+        .await?;
+    println!("create_ms      = {}", t_create.elapsed().as_millis());
+    let created = created.ok_or("CREATE returned None")?;
+    assert_eq!(created.name, "p2-4", "CREATE returned the wrong name");
+    assert_eq!(created.answer, 42, "CREATE returned the wrong answer");
+
+    // SELECT — exactly what was written.
+    let t_select = Instant::now();
+    let fetched: Option<SpikeRecord> = client.select((TEST_TABLE, TEST_RECORD)).await?;
+    println!("select_ms      = {}", t_select.elapsed().as_millis());
+    let fetched = fetched.ok_or("SELECT returned None after CREATE")?;
+    assert_eq!(
+        fetched, created,
+        "SELECT returned a different record than CREATE"
+    );
+
+    // UPDATE — full-content replace.
+    let t_update = Instant::now();
+    let updated: Option<SpikeRecord> = client
+        .update((TEST_TABLE, TEST_RECORD))
+        .content(SpikeRecord {
+            name: "p2-4".into(),
+            answer: 99,
+        })
+        .await?;
+    println!("update_ms      = {}", t_update.elapsed().as_millis());
+    let updated = updated.ok_or("UPDATE returned None")?;
+    assert_eq!(updated.answer, 99, "UPDATE did not persist the new value");
+
+    // SELECT again — confirm the UPDATE made it to disk.
+    let after_update: Option<SpikeRecord> = client.select((TEST_TABLE, TEST_RECORD)).await?;
+    let after_update = after_update.ok_or("SELECT returned None after UPDATE")?;
+    assert_eq!(
+        after_update.answer, 99,
+        "post-UPDATE SELECT still sees old value"
+    );
+
+    // DELETE.
+    let t_delete = Instant::now();
+    let deleted: Option<SpikeRecord> = client.delete((TEST_TABLE, TEST_RECORD)).await?;
+    println!("delete_ms      = {}", t_delete.elapsed().as_millis());
+    let _ = deleted.ok_or("DELETE returned None")?;
+
+    // SELECT after DELETE — must be gone.
+    let after_delete: Option<SpikeRecord> = client.select((TEST_TABLE, TEST_RECORD)).await?;
+    assert!(
+        after_delete.is_none(),
+        "record still visible after DELETE: {after_delete:?}"
+    );
+
+    println!("crud_round_trip= OK");
+
+    // ─── Phase 4: latency loop (20 single-key writes) ────────────
+    println!("--- Phase 4: latency loop ({LATENCY_ITERATIONS} single-key writes) ---");
+    let mut samples: Vec<Duration> = Vec::with_capacity(LATENCY_ITERATIONS);
+    for i in 0..LATENCY_ITERATIONS {
+        let id = format!("lat_{i:03}");
+        let start = Instant::now();
+        let _: Option<SpikeRecord> = tokio::time::timeout(
+            OP_TIMEOUT,
+            client
+                .create((LATENCY_TABLE, id.as_str()))
+                .content(SpikeRecord {
+                    name: format!("latency_{i}"),
+                    answer: i as i32,
+                }),
+        )
+        .await
+        .map_err(|_| format!("latency iter {i} timed out after {}s", OP_TIMEOUT.as_secs()))??;
+        samples.push(start.elapsed());
+    }
+
+    // Sort + p50 (median) computation. For an even-sized sample we
+    // pick the lower median — the ticket says "p50" not "median of
+    // two", and the stricter pick means marginal passes can't be a
+    // rounding-artifact win. For 20 samples the p50 is the 10th
+    // element in the sorted list (index 9).
+    samples.sort();
+    let p50 = samples[samples.len() / 2 - 1];
+    let min = samples[0];
+    let max = *samples.last().unwrap();
+    // p95 for posterity — not asserted, but useful in the PR body.
+    let p95_index = ((samples.len() as f64 * 0.95).ceil() as usize).saturating_sub(1);
+    let p95 = samples[p95_index.min(samples.len() - 1)];
+
+    println!("latency_n      = {}", samples.len());
+    println!("latency_min_ms = {:.2}", ms(min));
+    println!("latency_p50_ms = {:.2}", ms(p50));
+    println!("latency_p95_ms = {:.2}", ms(p95));
+    println!("latency_max_ms = {:.2}", ms(max));
+
+    // Cleanup the latency-loop fixtures before we assert, so a failed
+    // run leaves the cluster clean for the next attempt.
+    for i in 0..LATENCY_ITERATIONS {
+        let id = format!("lat_{i:03}");
+        let _: Option<SpikeRecord> = client
+            .delete((LATENCY_TABLE, id.as_str()))
+            .await
+            .unwrap_or(None);
+    }
+
+    if p50 >= P50_THRESHOLD {
+        eprintln!(
+            "error: p50 latency {:.2} ms >= threshold {} ms",
+            ms(p50),
+            P50_THRESHOLD.as_millis()
+        );
+        return Err(format!(
+            "p50 latency regression: {:.2} ms exceeds {}-ms budget",
+            ms(p50),
+            P50_THRESHOLD.as_millis()
+        )
+        .into());
+    }
+
+    // ─── Phase 5: shutdown ────────────────────────────────────────
+    println!("--- Phase 5: shutdown ---");
+    tikv.shutdown().await?;
+    println!("tikv_shutdown  = OK");
+
+    println!("== p2-4 spike OK ==");
+    Ok(())
+}
+
+/// Load the PD mesh IPv6 list (self first, peers after) from the
+/// `fabric:state` row stored in the local SurrealKV datastore.
+///
+/// Mirrors the contract of `FabricState::pd_endpoints` in the
+/// hypervisor crate: self is always index 0, peers follow in
+/// peer-list order. The two code paths are kept in lockstep by the
+/// acceptance criteria — if they ever diverge, the spike will fail
+/// on a real cluster.
+async fn load_pd_mesh_addrs(db: &EmbeddedDb) -> Result<Vec<Ipv6Addr>, Box<dyn std::error::Error>> {
+    // The fabric table is SCHEMALESS and lazily created on first use
+    // by `FabricState::save`, but `hypervisor init` has already run
+    // before we get here, so the row exists. Define-if-not-exists is
+    // still cheap and keeps this spike safe to re-run against an
+    // uninitialised node for debugging.
+    db.client()
+        .query("DEFINE TABLE IF NOT EXISTS fabric SCHEMALESS")
+        .await?
+        .check()?;
+
+    let mut response = db
+        .client()
+        .query("SELECT * FROM type::record($tbl, $id)")
+        .bind(("tbl", "fabric"))
+        .bind(("id", "state"))
+        .await?;
+    let row: Option<serde_json::Value> = response.take(0)?;
+    let row = row.ok_or("fabric:state missing — run `nauka hypervisor init` first")?;
+
+    let self_ipv6_str = row
+        .get("hypervisor")
+        .and_then(|h| h.get("mesh_ipv6"))
+        .and_then(|v| v.as_str())
+        .ok_or("fabric:state.hypervisor.mesh_ipv6 missing")?;
+    let self_ipv6: Ipv6Addr = self_ipv6_str
+        .parse()
+        .map_err(|e| format!("hypervisor.mesh_ipv6 `{self_ipv6_str}` is not a valid IPv6: {e}"))?;
+
+    let mut addrs = vec![self_ipv6];
+
+    // Peers live at `peers.peers[]` — see PeerList in
+    // layers/hypervisor/src/fabric/peer.rs. Missing or empty list is
+    // fine: on a brand-new single-node cluster there are no peers.
+    if let Some(peer_array) = row
+        .get("peers")
+        .and_then(|p| p.get("peers"))
+        .and_then(|a| a.as_array())
+    {
+        for peer in peer_array {
+            if let Some(s) = peer.get("mesh_ipv6").and_then(|v| v.as_str()) {
+                match s.parse::<Ipv6Addr>() {
+                    Ok(ipv6) => addrs.push(ipv6),
+                    Err(e) => {
+                        return Err(format!("peer.mesh_ipv6 `{s}` is not a valid IPv6: {e}").into())
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(addrs)
+}
+
+/// Floating-point milliseconds for pretty-printing.
+fn ms(d: Duration) -> f64 {
+    (d.as_secs_f64()) * 1_000.0
+}

--- a/layers/state/src/embedded.rs
+++ b/layers/state/src/embedded.rs
@@ -40,13 +40,14 @@
 //! ```
 
 use std::fs::{OpenOptions, TryLockError};
+use std::net::Ipv6Addr;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
-use surrealdb::engine::local::{Db, SurrealKv};
+use surrealdb::engine::local::{Db, SurrealKv, TiKv};
 use surrealdb::Surreal;
 
-use crate::{Result, StateError, BOOTSTRAP_DB, NAUKA_NS};
+use crate::{Result, StateError, BOOTSTRAP_DB, CLUSTER_DB, NAUKA_NS};
 
 /// The bootstrap-state SurrealQL schema, embedded at compile time.
 ///
@@ -56,14 +57,49 @@ use crate::{Result, StateError, BOOTSTRAP_DB, NAUKA_NS};
 /// re-applying against an already-initialised database is a no-op.
 const BOOTSTRAP_SCHEMA: &str = include_str!("../schemas/bootstrap.surql");
 
-/// Embedded SurrealDB instance, persisted to disk via the SurrealKV backend.
+/// Which local SurrealDB backend is live behind this handle.
+///
+/// P2.1 (sifrah/nauka#205) enabled the `kv-tikv` feature on `surrealdb`
+/// permanently; P2.2 (sifrah/nauka#206) added the
+/// [`EmbeddedDb::open_tikv`] constructor. From that point onward one
+/// `EmbeddedDb` value can front either an on-disk SurrealKV datastore or
+/// a distributed TiKv cluster, and a few lifecycle steps (in particular
+/// `shutdown`'s LOCK-file poll) are only meaningful for the SurrealKV
+/// branch. This enum lets `shutdown` and `Debug` pick the right path
+/// without keeping the full backend type in the struct.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EmbeddedBackend {
+    /// On-disk SurrealKV datastore, the single source of truth for the
+    /// node's bootstrap state.
+    SurrealKv,
+    /// Distributed TiKv cluster, backing the cluster-side state. No
+    /// process-local LOCK file to reclaim on shutdown — the
+    /// TransactionClient tears itself down over gRPC.
+    TiKv,
+}
+
+/// Embedded SurrealDB instance, fronting either a local SurrealKV
+/// datastore or a distributed TiKv cluster.
+///
+/// - `open` / `open_default` → `SurrealKv` (bootstrap state).
+/// - `open_tikv` → `TiKv` (cluster state, P2.2 sifrah/nauka#206).
+///
+/// Both variants share the same wrapper so upstream call sites can treat
+/// them uniformly: one `EmbeddedDb` type, one `client()` accessor, one
+/// `shutdown()` contract.
 ///
 /// Cheap to clone: every clone shares the same underlying `Surreal<Db>`
 /// connection (which itself uses an `Arc` internally).
 #[derive(Clone)]
 pub struct EmbeddedDb {
     inner: Surreal<Db>,
+    /// Path of the on-disk SurrealKV datastore. Empty for the `TiKv`
+    /// backend — `path()` returns an empty path in that case, which is a
+    /// signal to callers that "the handle has no local file".
     path: PathBuf,
+    /// Which backend is live behind `inner`. Set at open time, never
+    /// mutated.
+    backend: EmbeddedBackend,
 }
 
 impl EmbeddedDb {
@@ -169,7 +205,85 @@ impl EmbeddedDb {
         Ok(Self {
             inner,
             path: path.to_path_buf(),
+            backend: EmbeddedBackend::SurrealKv,
         })
+    }
+
+    /// Open the cluster-side SurrealDB database backed by an existing
+    /// PD/TiKV cluster.
+    ///
+    /// `pd_endpoints` is an ordered list of PD client endpoints. The
+    /// standard format for a Nauka node is `http://[<mesh_ipv6>]:2379`
+    /// (e.g. `http://[fdc5:8ba:9b14::1]:2379`), which matches the format
+    /// that [`nauka_hypervisor::fabric::FabricState::pd_endpoints`]
+    /// hands out. The `http://` prefix is stripped before the endpoint
+    /// is handed to the SurrealDB TiKv engine — the engine's URL parser
+    /// expects the bare `host:port` form.
+    ///
+    /// Endpoints are tried in order; the first one that returns a live
+    /// `Surreal<Db>` handle wins. This is the same fallback contract as
+    /// `tikv-client`'s own `new_with_config(vec![...])`, except that
+    /// SurrealDB's `Surreal::new::<TiKv>` only accepts a single address
+    /// per call, so the iteration lives in this wrapper. If every
+    /// endpoint fails the *last* error is returned, classified through
+    /// the existing `From<surrealdb::Error>` impl.
+    ///
+    /// After the handle is live the wrapper switches to the
+    /// `nauka` / `cluster` namespace/database (per ADR 0003,
+    /// sifrah/nauka#190). No schema is applied — cluster-side schema
+    /// lands in a later Phase 2 ticket.
+    ///
+    /// # Errors
+    ///
+    /// - [`StateError::Database`] (via `From<surrealdb::Error>`) if
+    ///   every PD endpoint fails to answer, or if `use_ns`/`use_db`
+    ///   fails after a handle was acquired.
+    /// - [`StateError::Database`] with a fixed "no PD endpoints" message
+    ///   if `pd_endpoints` is empty.
+    pub async fn open_tikv(pd_endpoints: &[&str]) -> Result<Self> {
+        if pd_endpoints.is_empty() {
+            return Err(StateError::Database(
+                "open_tikv: no PD endpoints provided".to_string(),
+            ));
+        }
+
+        // Try each endpoint in order. The SurrealDB TiKv engine's
+        // `IntoEndpoint` impl only accepts a single address per
+        // `Surreal::new` call, so the fallback loop lives here — match
+        // the fallback contract of `tikv-client::new_with_config(vec![...])`
+        // without forcing callers to duplicate the logic.
+        let mut last_err: Option<surrealdb::Error> = None;
+        for ep in pd_endpoints {
+            // SurrealDB's TiKv endpoint builder wraps the argument in
+            // `tikv://{self}`, and the downstream URL parser expects a
+            // bare `host:port`. Strip any `http://` / `https://` prefix
+            // we were handed so call sites can use the same
+            // `http://[ipv6]:2379` string everywhere.
+            let bare = strip_http_scheme(ep);
+            match Surreal::new::<TiKv>(bare).await {
+                Ok(db) => {
+                    db.use_ns(NAUKA_NS).use_db(CLUSTER_DB).await?;
+                    return Ok(Self {
+                        inner: db,
+                        // The TiKv backend has no local file. `path()`
+                        // returns this empty PathBuf so callers can tell
+                        // "there is nothing on disk to clean up".
+                        path: PathBuf::new(),
+                        backend: EmbeddedBackend::TiKv,
+                    });
+                }
+                Err(err) => {
+                    last_err = Some(err);
+                }
+            }
+        }
+
+        // Every endpoint failed. Surface the most recent error (it
+        // carries the richest detail — DNS failure, gRPC refused, etc.)
+        // through the standard SurrealDB → StateError mapping.
+        Err(last_err
+            .map(StateError::from)
+            .unwrap_or_else(|| StateError::Database("open_tikv: all endpoints failed".into())))
     }
 
     /// Borrow the underlying SurrealDB SDK client.
@@ -237,10 +351,67 @@ impl EmbeddedDb {
         // anyway when `self` goes out of scope, but naming the step
         // makes the handoff to the router task visible.
         let path = self.path.clone();
+        let backend = self.backend;
         drop(self.inner);
 
-        wait_for_surrealkv_lock_release(&path).await
+        match backend {
+            // SurrealKV holds an OS-level exclusive flock on
+            // `<path>/LOCK` that the router task releases as the last
+            // step of `Datastore::shutdown()`. Poll for that release so
+            // a subsequent `open` at the same path can acquire the flock
+            // — and so any writes committed through this handle are
+            // durable before we return. See the doc comment on
+            // `shutdown` and the rationale on `wait_for_surrealkv_lock_release`.
+            EmbeddedBackend::SurrealKv => wait_for_surrealkv_lock_release(&path).await,
+            // TiKv has no process-local LOCK file to reclaim. The
+            // `Surreal<Db>` router drains the in-flight gRPC calls when
+            // the route channel closes, the `TransactionClient` shuts
+            // its connection pool down from its own `Drop`, and nothing
+            // on the local filesystem needs to settle before the next
+            // `open_tikv` call at the same node can succeed. Just
+            // return.
+            EmbeddedBackend::TiKv => Ok(()),
+        }
     }
+}
+
+/// Strip a leading `http://` or `https://` from a PD endpoint, leaving
+/// the bare `host:port` form.
+///
+/// SurrealDB's TiKv engine wraps the argument in `tikv://{self}` before
+/// parsing it as a URL. If the caller already prefixed with `http://`
+/// (the internal convention used by everything downstream of
+/// `FabricState::pd_endpoints`, to match `tikv-client::RawClient::new`)
+/// the resulting `tikv://http://...` string is malformed. Strip the
+/// scheme here so both input styles work.
+fn strip_http_scheme(ep: &str) -> &str {
+    if let Some(rest) = ep.strip_prefix("http://") {
+        rest
+    } else if let Some(rest) = ep.strip_prefix("https://") {
+        rest
+    } else {
+        ep
+    }
+}
+
+/// Build PD client endpoints for a slice of mesh IPv6 addresses.
+///
+/// Produces one `http://[<ipv6>]:<port>` string per input address, in
+/// the same order. The `http://` prefix matches the format used by
+/// [`nauka_hypervisor::fabric::FabricState::pd_endpoints`] and by
+/// `tikv-client::RawClient::new(&[...])`; the SurrealDB TiKv engine
+/// strips the prefix via [`strip_http_scheme`] at `open_tikv` time, so
+/// the same list works for both sides.
+///
+/// Kept in `nauka-state` so callers don't have to redo the
+/// `format!("http://[{ipv6}]:{port}", ...)` dance at every call site.
+/// Added in P2.3 (sifrah/nauka#207) — the same issue that teaches
+/// FabricState to expose the per-node PD addresses.
+pub fn pd_endpoints_for(mesh_addrs: &[Ipv6Addr], pd_client_port: u16) -> Vec<String> {
+    mesh_addrs
+        .iter()
+        .map(|addr| format!("http://[{addr}]:{pd_client_port}"))
+        .collect()
 }
 
 /// Open the SurrealKV datastore at `path_str`, retrying on flock
@@ -380,10 +551,18 @@ async fn wait_for_surrealkv_lock_release(path: &Path) -> Result<()> {
 
 impl std::fmt::Debug for EmbeddedDb {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The `db` field reflects the namespace/database pair that
+        // `open*` switched to. SurrealKV → `bootstrap`, TiKv → `cluster`
+        // (per ADR 0003, sifrah/nauka#190).
+        let db_name = match self.backend {
+            EmbeddedBackend::SurrealKv => BOOTSTRAP_DB,
+            EmbeddedBackend::TiKv => CLUSTER_DB,
+        };
         f.debug_struct("EmbeddedDb")
+            .field("backend", &self.backend)
             .field("path", &self.path)
             .field("ns", &NAUKA_NS)
-            .field("db", &BOOTSTRAP_DB)
+            .field("db", &db_name)
             .finish()
     }
 }
@@ -926,5 +1105,96 @@ mod tests {
         }
 
         db.shutdown().await.expect("shutdown");
+    }
+
+    // ─── P2.2 / P2.4 — `open_tikv` error path ────────────────────────
+
+    /// P2.4 — `open_tikv` against an unreachable endpoint surfaces a
+    /// `StateError::Database` rather than hanging forever or panicking.
+    ///
+    /// We point at `127.0.0.1:1`, which is the reserved "TCP muxer" port
+    /// on every POSIX system — nothing is listening, so the TCP connect
+    /// races with ECONNREFUSED / gRPC timeout, and the SurrealDB TiKv
+    /// engine surfaces the failure as an internal `surrealdb::Error`
+    /// that our `From<surrealdb::Error>` impl classifies as
+    /// [`StateError::Database`]. The whole call has to return under a
+    /// 30 s hard timeout — the "fast timeout" budget Nauka uses for
+    /// health checks — otherwise the test runner would hang CI on a
+    /// genuine failure.
+    #[tokio::test]
+    async fn open_tikv_unreachable_endpoint_returns_state_error() {
+        // 30 s is the Nauka convention for a health-check timeout and
+        // is *much* more generous than the real path: gRPC connect to
+        // a closed port returns ECONNREFUSED in tens of ms. If the
+        // future hangs past this, the test surfaces the hang as a
+        // loud panic instead of a silent CI timeout.
+        let result = tokio::time::timeout(
+            Duration::from_secs(30),
+            EmbeddedDb::open_tikv(&["http://127.0.0.1:1"]),
+        )
+        .await
+        .expect("open_tikv against an unreachable endpoint should return within 30s");
+
+        let err = result.expect_err("open_tikv should fail against an unreachable PD endpoint");
+        assert!(
+            matches!(err, StateError::Database(_)),
+            "expected StateError::Database, got: {err:?}"
+        );
+    }
+
+    /// P2.4 — `open_tikv` with an empty endpoint slice fails fast with
+    /// a clear error, never touching the network.
+    #[tokio::test]
+    async fn open_tikv_empty_endpoints_returns_state_error() {
+        let err = EmbeddedDb::open_tikv(&[])
+            .await
+            .expect_err("open_tikv with an empty slice should fail");
+        match err {
+            StateError::Database(msg) => {
+                assert!(
+                    msg.contains("no PD endpoints"),
+                    "expected 'no PD endpoints' message, got: {msg}"
+                );
+            }
+            other => panic!("expected StateError::Database, got: {other:?}"),
+        }
+    }
+
+    /// P2.3 — `pd_endpoints_for` builds the canonical
+    /// `http://[<ipv6>]:<port>` strings that `FabricState::pd_endpoints`
+    /// and `open_tikv` agree on.
+    #[test]
+    fn pd_endpoints_for_builds_canonical_strings() {
+        let addrs: Vec<Ipv6Addr> = vec![
+            "fdc5:8ba:9b14::1".parse().unwrap(),
+            "fdc5:8ba:9b14::2".parse().unwrap(),
+        ];
+        let endpoints = pd_endpoints_for(&addrs, 2379);
+        assert_eq!(
+            endpoints,
+            vec![
+                "http://[fdc5:8ba:9b14::1]:2379".to_string(),
+                "http://[fdc5:8ba:9b14::2]:2379".to_string(),
+            ],
+        );
+    }
+
+    /// P2.2 — `strip_http_scheme` is the bridge that lets
+    /// FabricState's `http://[...]:2379` format flow into the SurrealDB
+    /// TiKv engine, which expects a bare `host:port`.
+    #[test]
+    fn strip_http_scheme_handles_all_forms() {
+        assert_eq!(
+            strip_http_scheme("http://[fdc5:8ba:9b14::1]:2379"),
+            "[fdc5:8ba:9b14::1]:2379",
+        );
+        assert_eq!(
+            strip_http_scheme("https://[fdc5:8ba:9b14::1]:2379"),
+            "[fdc5:8ba:9b14::1]:2379",
+        );
+        assert_eq!(
+            strip_http_scheme("[fdc5:8ba:9b14::1]:2379"),
+            "[fdc5:8ba:9b14::1]:2379",
+        );
     }
 }

--- a/layers/state/src/lib.rs
+++ b/layers/state/src/lib.rs
@@ -47,7 +47,7 @@ pub mod cluster;
 pub mod embedded;
 
 pub use cluster::ClusterDb;
-pub use embedded::EmbeddedDb;
+pub use embedded::{pd_endpoints_for, EmbeddedDb};
 
 // ═══════════════════════════════════════════════════
 // SurrealDB namespace / database constants (ADR 0003)


### PR DESCRIPTION
Closes sifrah/nauka#208 (Epic sifrah/nauka#183).

## Summary

First end-to-end proof that `EmbeddedDb::open_tikv` — the Phase-2 cluster-side SurrealDB constructor — can talk to a real PD/TiKV v8.5.5 cluster on a Hetzner node and round-trip a record. Ships a new `p2-4-spike` binary that runs the CRUD round-trip and a 20-write latency loop, asserting **p50 < 50 ms** as the ticket's acceptance criterion.

## Self-contained

P2.1, P2.2, and P2.3 were not merged at the time this branch was cut, so every piece of work those tickets need is bundled here:

- **P2.1 (sifrah/nauka#205):** enables `kv-tikv` on `surrealdb` permanently in `layers/state/Cargo.toml`. `spike-tikv` is now a no-op alias (dropped fully after dependent tickets land).
- **P2.2 (sifrah/nauka#206):** adds `EmbeddedDb::open_tikv(pd_endpoints: &[&str])` with ordered-endpoint fallback, plus an internal `EmbeddedBackend` enum that teaches `shutdown` to skip SurrealKV's LOCK-file poll when the TiKv backend is live (there is no process-local flock to reclaim over gRPC).
- **P2.3 (sifrah/nauka#207):** adds `FabricState::pd_endpoints() -> Vec<Ipv6Addr>` (self first) and `nauka_state::pd_endpoints_for(&[Ipv6Addr], port) -> Vec<String>`, and migrates `controlplane::connect()` to the shared helpers so `open_tikv` and `ClusterDb::connect` see identical PD lists.
- **P2.4 (sifrah/nauka#208):** `layers/state/src/bin/p2_4_spike.rs`. Reads the live FabricState blob directly from the local SurrealKV `fabric:state` row (to keep the spike layer-clean), builds the canonical PD endpoint list, opens `EmbeddedDb::open_tikv`, runs the full CRUD + latency-loop contract.

## Unit test coverage

- `open_tikv_unreachable_endpoint_returns_state_error` — `open_tikv(&[\"http://127.0.0.1:1\"])` surfaces `StateError::Database` within a hard 30 s timeout (no silent hangs).
- `open_tikv_empty_endpoints_returns_state_error` — fails fast with a clear message when the slice is empty.
- `pd_endpoints_for_builds_canonical_strings` — locks in the `http://[ipv6]:2379` shape.
- `strip_http_scheme_handles_all_forms` — bridges the FabricState `http://...` convention into SurrealDB's TiKv engine (which expects a bare `host:port`).
- `pd_endpoints_single_node` / `pd_endpoints_multi_node_self_first` — `FabricState::pd_endpoints` contract.

## Hetzner end-to-end evidence

Provisioned `node-p2-4` (cpx22, fsn1, ubuntu-24.04), cross-compiled both `nauka` and `p2-4-spike` against `x86_64-unknown-linux-musl`, scp'd to `/usr/local/bin/`, ran `nauka hypervisor init` with the standard Hetzner S3 args, then ran the spike. VM was destroyed on completion.

### `nauka hypervisor init` (trimmed)

```
Auto-detected IPv6 block: 2a01:4f8:c012:7a47::/64
Auto-detected IPv4 address: 178.104.186.195
Installing network...
Creating mesh...
Installing control plane...
Starting control plane...
Waiting for PD...
Waiting for TiKV...
Publishing storage config...
Setting up storage...
Installing compute (container mode)...
Pulling base image (ubuntu-24.04)...
Starting forge...
✓  Hypervisor initialized

name     node-p2-4
id       hv-01kp35mtpehkj1r8124dh6c9c2
mesh     mesh-01kp35mtpeng85wdy9pywxwzaa
region   eu/fsn1
address  fde0:fb7e:2d06:d9ed:625a:207d:7a90:fa42
```

`systemctl is-active nauka-pd nauka-tikv` → both `active`.

### `p2-4-spike` output

```
== nauka p2-4 spike (EmbeddedDb<TiKv> Hetzner round-trip) ==
target_arch    = x86_64
target_os      = linux
target_env     = unix
surrealdb_dep  = 3.0.5 (kv-surrealkv + kv-tikv)
run_mode       = service (root)
bootstrap_path = /var/lib/nauka/bootstrap.skv
--- Phase 1: load FabricState for PD discovery ---
bootstrap_open = OK
self_mesh_ipv6 = fde0:fb7e:2d06:d9ed:625a:207d:7a90:fa42
peer_count     = 0
pd_endpoints   = ["http://[fde0:fb7e:2d06:d9ed:625a:207d:7a90:fa42]:2379"]
bootstrap_shut = OK
--- Phase 2: EmbeddedDb::open_tikv ---
open_tikv_ms   = 24
tikv_handle    = EmbeddedDb { backend: TiKv, path: "", ns: "nauka", db: "cluster" }
--- Phase 3: CRUD round-trip on p2_4_test:rec1 ---
create_ms      = 9
select_ms      = 2
update_ms      = 5
delete_ms      = 14
crud_round_trip= OK
--- Phase 4: latency loop (20 single-key writes) ---
latency_n      = 20
latency_min_ms = 2.55
latency_p50_ms = 3.28
latency_p95_ms = 4.32
latency_max_ms = 5.99
--- Phase 5: shutdown ---
tikv_shutdown  = OK
== p2-4 spike OK ==
```

**Exit code: 0.** **p50 = 3.28 ms** (well under the 50 ms budget — ~15x headroom on a fresh single-node cluster).

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p nauka-state` — all 23 tests pass
- [x] `cargo test -p nauka-hypervisor fabric::state` — all 13 fabric-state tests pass (including two new `pd_endpoints_*` tests)
- [x] Cross-compile `p2-4-spike` + `nauka` for `x86_64-unknown-linux-musl` (release)
- [x] Hetzner: `nauka hypervisor init` on cpx22/fsn1 boots PD/TiKV cleanly
- [x] Hetzner: `p2-4-spike` CRUD round-trip + latency loop pass, exit 0
- [x] Hetzner: p50 latency strictly < 50 ms
- [x] Hetzner VM destroyed