### PR TITLE
feat(P2.7): apply cluster schemas in controlplane::bootstrap

### DIFF
--- a/layers/hypervisor/src/controlplane/ops.rs
+++ b/layers/hypervisor/src/controlplane/ops.rs
@@ -17,8 +17,15 @@ use super::service::{self, PdConfig, TikvConfig};
 
 /// Bootstrap a new single-node TiKV cluster.
 ///
-/// Uses `steps` to report progress (consumes 4 steps).
-pub fn bootstrap(
+/// Uses `steps` to report progress (consumes 5 steps).
+///
+/// The fifth step — "Applying cluster schemas" — was added in P2.7
+/// (sifrah/nauka#211) per ADR 0004 (sifrah/nauka#210): the bootstrap
+/// node applies the cluster `.surql` schemas to TiKV exactly once,
+/// after PD/TiKV are healthy and before the storage region config is
+/// published. Joining nodes do NOT apply the schemas — they assume
+/// the cluster already has them.
+pub async fn bootstrap(
     node_name: &str,
     mesh_ipv6: &Ipv6Addr,
     steps: &ui::Steps,
@@ -61,12 +68,55 @@ pub fn bootstrap(
 
     steps.inc();
 
+    // ── Step 5: Apply cluster schemas (P2.7, sifrah/nauka#211) ──────
+    //
+    // Per ADR 0004 (sifrah/nauka#210), the bootstrap node applies the
+    // cluster `.surql` schemas exactly once, after PD/TiKV are up and
+    // before the storage region config is published. Idempotent thanks
+    // to `IF NOT EXISTS` on every `DEFINE`, so a re-run during a retry
+    // is safe. The schemas live in nauka-state via `include_str!`, so
+    // there is no runtime filesystem dependency on the source tree.
+    //
+    // The PD endpoint list is built the same way `controlplane::connect`
+    // builds it — `pd_endpoints_for` produces the canonical
+    // `http://[<ipv6>]:<port>` strings that `EmbeddedDb::open_tikv`
+    // expects. On a single-node bootstrap there is exactly one address
+    // (the local mesh IPv6), so the slice is a one-element window onto
+    // `mesh_ipv6`.
+    steps.set("Applying cluster schemas");
+    let pd_addresses = std::slice::from_ref(mesh_ipv6);
+    let pd_endpoints = nauka_state::pd_endpoints_for(pd_addresses, super::PD_CLIENT_PORT);
+    let pd_refs: Vec<&str> = pd_endpoints.iter().map(String::as_str).collect();
+    let cluster_db = nauka_state::EmbeddedDb::open_tikv(&pd_refs)
+        .await
+        .map_err(|e| NaukaError::internal(format!("connect TiKV for schema apply: {e}")))?;
+    nauka_state::apply_cluster_schemas(&cluster_db)
+        .await
+        .map_err(|e| NaukaError::internal(format!("apply cluster schemas: {e}")))?;
+    // Drop the EmbeddedDb so the SDK client gets cleaned up before
+    // bootstrap returns; the next caller will reconnect via
+    // `controlplane::connect()`. The TiKV branch of `shutdown` is a
+    // no-op on the local filesystem — the router drains its in-flight
+    // gRPC calls as the `Surreal<Db>` is dropped — so any failure here
+    // is not actionable for the bootstrap flow and we swallow it.
+    let _ = cluster_db.shutdown().await;
+    steps.inc();
+
     Ok(())
 }
 
 /// Join an existing TiKV cluster.
 ///
 /// Uses `steps` to report progress (consumes 4 steps).
+///
+/// Schema handling — per ADR 0004 (sifrah/nauka#210) joining nodes do
+/// **not** apply the cluster `.surql` schemas. They assume the
+/// bootstrap node (the one that ran `nauka hypervisor init`) already
+/// applied them as part of its own bootstrap, and they read/write
+/// the existing tables on the shared TiKV cluster through the
+/// already-deployed schema. Running DDL from every joining node would
+/// be wasteful, racey under partial partitions, and hostile to future
+/// data-backfill migrations — see the ADR for the full rationale.
 ///
 /// PD scaling strategy — **never run an even number of PD members**
 /// (even counts have no fault-tolerance advantage and risk split-brain):

--- a/layers/hypervisor/src/handlers.rs
+++ b/layers/hypervisor/src/handlers.rs
@@ -446,9 +446,13 @@ async fn handle_init(req: OperationRequest) -> anyhow::Result<OperationResponse>
         is_default: true,
     };
 
-    // Init: 2 (fabric) + 4 (control plane) + 2 (storage) + 3 (compute+forge) = 11
+    // Init: 2 (fabric) + 5 (control plane) + 2 (storage) + 3 (compute+forge) = 12
+    //
+    // The control plane consumed 4 steps through P2.6 and gained a fifth
+    // step — "Applying cluster schemas" — in P2.7 (sifrah/nauka#211) per
+    // ADR 0004 (sifrah/nauka#210).
     let step_count = if network_mode == fabric::NetworkMode::WireGuard {
-        11
+        12
     } else {
         5 // fabric + compute + forge
     };
@@ -491,7 +495,7 @@ async fn handle_init(req: OperationRequest) -> anyhow::Result<OperationResponse>
     // Bootstrap control plane (TiKV) on the mesh — only in WireGuard mode
     if network_mode == fabric::NetworkMode::WireGuard {
         if let Err(e) =
-            controlplane::ops::bootstrap(&node_name, &result.hypervisor.mesh_ipv6, &steps)
+            controlplane::ops::bootstrap(&node_name, &result.hypervisor.mesh_ipv6, &steps).await
         {
             steps.finish_err(&format!("Control plane failed: {e}"));
             rollback(&db, network_mode, fabric_initialized, false, false).await;

--- a/layers/state/src/lib.rs
+++ b/layers/state/src/lib.rs
@@ -45,9 +45,11 @@
 
 pub mod cluster;
 pub mod embedded;
+pub mod schema;
 
 pub use cluster::ClusterDb;
 pub use embedded::{pd_endpoints_for, EmbeddedDb};
+pub use schema::apply_cluster_schemas;
 
 // ═══════════════════════════════════════════════════
 // SurrealDB namespace / database constants (ADR 0003)

--- a/layers/state/src/schema.rs
+++ b/layers/state/src/schema.rs
@@ -1,0 +1,103 @@
+//! Cluster-state SurrealQL schema application.
+//!
+//! ADR 0004 (sifrah/nauka#210) chose Option A: the bootstrap node applies
+//! the cluster `.surql` schemas to TiKV exactly once, after PD/TiKV come
+//! up and before the storage region is written. Joining nodes do NOT
+//! call this function — they assume the schemas are already in place.
+//!
+//! P2.5 (sifrah/nauka#209) shipped the schema files; this module
+//! consumes them at compile time via `include_str!` so the binary has
+//! no runtime filesystem dependency on the source tree.
+//!
+//! Idempotency: every `DEFINE` in every schema file uses `IF NOT EXISTS`,
+//! so re-running this function against an already-initialised cluster
+//! is a no-op. The test
+//! [`tests::apply_cluster_schemas_is_idempotent`] pins that contract.
+
+use crate::{EmbeddedDb, Result, StateError};
+
+/// Compile-time-embedded copies of every P2.5 cluster schema, keyed by
+/// short name for diagnostics. The order is deliberate: parent tables
+/// come before children, so even a SCHEMAFULL backend that doesn't
+/// support forward references would still apply cleanly.
+///
+/// `include_str!` resolves relative to *this* source file
+/// (`layers/state/src/schema.rs`), so the paths climb out of
+/// `state/src` and back down into each sibling layer's `schemas/`
+/// directory.
+const CLUSTER_SCHEMAS: &[(&str, &str)] = &[
+    ("user", include_str!("../../org/schemas/user.surql")),
+    ("org", include_str!("../../org/schemas/org.surql")),
+    ("project", include_str!("../../org/schemas/project.surql")),
+    ("env", include_str!("../../org/schemas/env.surql")),
+    ("vpc", include_str!("../../network/schemas/vpc.surql")),
+    ("subnet", include_str!("../../network/schemas/subnet.surql")),
+    ("vm", include_str!("../../compute/schemas/vm.surql")),
+];
+
+/// Apply every cluster schema to the given [`EmbeddedDb`] in order.
+///
+/// Idempotent — every `DEFINE` uses `IF NOT EXISTS`, so callers can
+/// invoke this against either a freshly-bootstrapped TiKV cluster or
+/// one that already has the schemas applied. Returns an error on the
+/// first schema that fails to apply, with a message that names the
+/// offending schema for fast triage.
+///
+/// # Errors
+///
+/// Returns [`StateError::Database`] if any schema fails to apply or
+/// if the SurrealDB response's `.check()` surfaces a per-statement
+/// error (e.g. a parse error, an `ASSERT` failure, a SCHEMAFULL
+/// violation). The error message is prefixed with the name of the
+/// offending schema (`"apply vm schema: ..."` or
+/// `"check vm schema: ..."`) so the operator can immediately tell
+/// which file is at fault.
+pub async fn apply_cluster_schemas(db: &EmbeddedDb) -> Result<()> {
+    for (name, schema) in CLUSTER_SCHEMAS {
+        db.client()
+            .query(*schema)
+            .await
+            .map_err(|e| StateError::Database(format!("apply {name} schema: {e}")))?
+            .check()
+            .map_err(|e| StateError::Database(format!("check {name} schema: {e}")))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::EmbeddedDb;
+
+    /// P2.7 — `apply_cluster_schemas` runs cleanly against a fresh
+    /// `EmbeddedDb` (using the SurrealKV backend for the test, since
+    /// we don't have a TiKV cluster in unit tests). Re-running against
+    /// the same handle must also succeed — that's the idempotency
+    /// contract the acceptance criteria calls out as "re-running on an
+    /// existing cluster does not fail".
+    ///
+    /// The schemas define `cluster`-scoped tables that don't collide
+    /// with the bootstrap tables already applied by `EmbeddedDb::open`,
+    /// so we can safely share the same SurrealDB instance here.
+    #[tokio::test]
+    async fn apply_cluster_schemas_is_idempotent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = EmbeddedDb::open(&dir.path().join("p2_7.skv"))
+            .await
+            .expect("open");
+
+        // First apply — must succeed against an empty db.
+        apply_cluster_schemas(&db)
+            .await
+            .expect("first apply should succeed");
+
+        // Second apply — must be a no-op thanks to `IF NOT EXISTS` on
+        // every DEFINE. Any regression that drops the guard surfaces
+        // here as an "already exists" error.
+        apply_cluster_schemas(&db)
+            .await
+            .expect("second apply (idempotency) should succeed");
+
+        db.shutdown().await.expect("shutdown");
+    }
+}


### PR DESCRIPTION
## Summary

- Wires `nauka_state::schema::apply_cluster_schemas` into `controlplane::ops::bootstrap` per ADR 0004 (sifrah/nauka#210 / #260): the bootstrap node applies every P2.5 cluster schema to TiKV exactly once, after PD/TiKV come up and before the storage region is published. Joining nodes stay out of the DDL path.
- New helper `nauka_state::apply_cluster_schemas(&EmbeddedDb)` walks the seven schemas (user, org, project, env, vpc, subnet, vm) in parent-first order via `include_str!`, so the binary has no runtime filesystem dependency on the source tree.
- `bootstrap()` grew from 4 to 5 steps; `handle_init` bumps its total from 11 to 12 and awaits the now-async call.

Closes sifrah/nauka#211
Epic sifrah/nauka#183
ADR sifrah/nauka#210 (merged via #260)

## Public API delta

```rust
// layers/state/src/schema.rs — NEW
pub async fn apply_cluster_schemas(db: &EmbeddedDb) -> Result<()>;

// layers/state/src/lib.rs
+ pub mod schema;
+ pub use schema::apply_cluster_schemas;

// layers/hypervisor/src/controlplane/ops.rs
- pub fn bootstrap(node_name, mesh_ipv6, steps) -> Result<(), NaukaError>
+ pub async fn bootstrap(node_name, mesh_ipv6, steps) -> Result<(), NaukaError>
```

## Step count

`handle_init` in WireGuard mode:
- Before: `2 (fabric) + 4 (control plane) + 2 (storage) + 3 (compute+forge) = 11`
- After:  `2 (fabric) + 5 (control plane) + 2 (storage) + 3 (compute+forge) = 12`

The new step is `"Applying cluster schemas"` between `"Waiting for TiKV"` / max-replicas adjust and the function return.

## Idempotency

Every `DEFINE` in every P2.5 schema uses `IF NOT EXISTS`, so re-running `apply_cluster_schemas` on an already-initialised cluster is a no-op. The new unit test opens an `EmbeddedDb` against a tempdir, calls `apply_cluster_schemas` twice in sequence, and asserts both invocations succeed — the AC's "re-running on an existing cluster does not fail" contract.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p nauka-state --lib` — 25/25 pass, including new `schema::tests::apply_cluster_schemas_is_idempotent`
- [x] `cargo test --workspace --all-targets -- --test-threads=1 --skip disk_free_check` — 731 passed, 0 failed
  - Pre-existing macOS-only failure `doctor::tests::disk_free_check` is unrelated to this PR and skipped, matching prior phase-2 PRs
- [x] Cross-compile musl: `cargo build --target x86_64-unknown-linux-musl --release -p nauka` — clean
- [ ] CI green on Linux runner

No Hetzner end-to-end validation: P2.4 already covers the `open_tikv` live-cluster path, and the new helper is a thin wrapper over `client().query().check()`. The AC's "re-running does not fail" requirement is the unit test pinned above.