### PR TITLE
feat(P2.9): migrate layers/org/src/store.rs to native SurrealDB SDK

### DIFF
--- a/layers/compute/src/vm/store.rs
+++ b/layers/compute/src/vm/store.rs
@@ -35,8 +35,14 @@ impl VmStore {
         region: &str,
         zone: &str,
     ) -> anyhow::Result<Vm> {
-        // Resolve org -> project -> env
-        let org_store = nauka_org::store::OrgStore::new(self.db.clone());
+        // Resolve org -> project -> env. P2.9 (sifrah/nauka#213)
+        // migrated `OrgStore` to the native SurrealDB SDK on top of
+        // `EmbeddedDb`, so we hand it the cluster-DB wrapper's
+        // internal handle via `.embedded().clone()`. The clone is
+        // cheap (Arc-shared `Surreal<Db>` router) and leaves the
+        // legacy `ProjectStore` below on the same underlying
+        // connection until P2.10 ports it over.
+        let org_store = nauka_org::store::OrgStore::new(self.db.embedded().clone());
         let org = org_store
             .get(org_name)
             .await?

--- a/layers/forge/src/reconciler/vm.rs
+++ b/layers/forge/src/reconciler/vm.rs
@@ -97,7 +97,10 @@ impl super::Reconciler for VmReconciler {
 
         // VMs that should be running (pending = needs starting, running = should be alive).
         // Skip orphaned VMs whose org no longer exists (cascading orphan).
-        let org_store = nauka_org::store::OrgStore::new(ctx.db.clone());
+        // P2.9 (sifrah/nauka#213) migrated `OrgStore` to take an
+        // `EmbeddedDb` directly; we hand it the cluster-DB wrapper's
+        // internal SurrealDB handle via `.embedded().clone()`.
+        let org_store = nauka_org::store::OrgStore::new(ctx.db.embedded().clone());
         let mut should_exist: Vec<_> = Vec::new();
         for vm in &local_vms {
             if !should_vm_exist(&vm.state) {

--- a/layers/network/src/vpc/store.rs
+++ b/layers/network/src/vpc/store.rs
@@ -39,8 +39,10 @@ impl VpcStore {
         project_id: Option<String>,
         env_id: Option<String>,
     ) -> anyhow::Result<Vpc> {
-        // Resolve org
-        let org_store = nauka_org::store::OrgStore::new(self.db.clone());
+        // Resolve org. P2.9 (sifrah/nauka#213) migrated `OrgStore` to
+        // take an `EmbeddedDb` directly; we hand it the cluster-DB
+        // wrapper's internal SurrealDB handle via `.embedded().clone()`.
+        let org_store = nauka_org::store::OrgStore::new(self.db.embedded().clone());
         let org = org_store
             .get(org_name)
             .await?
@@ -90,7 +92,9 @@ impl VpcStore {
         }
         let org_name =
             org_name.ok_or_else(|| anyhow::anyhow!("--org required to resolve VPC by name"))?;
-        let org_store = nauka_org::store::OrgStore::new(self.db.clone());
+        // P2.9 migration: `OrgStore` now takes an `EmbeddedDb` directly,
+        // see the comment in `create()`.
+        let org_store = nauka_org::store::OrgStore::new(self.db.embedded().clone());
         let org = org_store
             .get(org_name)
             .await?

--- a/layers/org/src/handlers.rs
+++ b/layers/org/src/handlers.rs
@@ -43,7 +43,13 @@ pub fn handler() -> HandlerFn {
             Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
         > {
             Box::pin(async move {
-                let store = OrgStore::new(nauka_hypervisor::controlplane::connect().await?);
+                // P2.9 (sifrah/nauka#213) migrated `OrgStore` to take an
+                // `EmbeddedDb` directly. We still go through the
+                // cluster-DB connect helper so the same PD-endpoint
+                // discovery / mesh fall-back logic runs, then hand the
+                // store the inner `EmbeddedDb` handle via `.embedded().clone()`.
+                let cluster = nauka_hypervisor::controlplane::connect().await?;
+                let store = OrgStore::new(cluster.embedded().clone());
                 match req.operation.as_str() {
                     "create" => {
                         let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name"))?;

--- a/layers/org/src/project/store.rs
+++ b/layers/org/src/project/store.rs
@@ -22,7 +22,10 @@ impl ProjectStore {
     }
 
     pub async fn create(&self, name: &str, org_name: &str) -> anyhow::Result<Project> {
-        let org_store = crate::store::OrgStore::new(self.db.clone());
+        // P2.9 (sifrah/nauka#213) migrated `OrgStore` to take an
+        // `EmbeddedDb` directly; reach the inner handle via the
+        // cluster-DB wrapper's `.embedded()` accessor.
+        let org_store = crate::store::OrgStore::new(self.db.embedded().clone());
         let org = org_store
             .get(org_name)
             .await?
@@ -58,7 +61,8 @@ impl ProjectStore {
 
         let org_name =
             org_name.ok_or_else(|| anyhow::anyhow!("--org required to resolve project by name"))?;
-        let org_store = crate::store::OrgStore::new(self.db.clone());
+        // P2.9 migration: see the comment in `create()`.
+        let org_store = crate::store::OrgStore::new(self.db.embedded().clone());
         let org = org_store
             .get(org_name)
             .await?

--- a/layers/org/src/store.rs
+++ b/layers/org/src/store.rs
@@ -1,128 +1,672 @@
-//! Org persistence in ClusterDb (TiKV).
+//! Org persistence on the SurrealDB-backed cluster store.
+//!
+//! P2.9 (sifrah/nauka#213) migrated this module from the legacy raw-KV
+//! cluster-DB surface (`db.put` / `db.get` / `db.scan_keys`) to the
+//! native SurrealDB SDK on top of [`EmbeddedDb`]. Every method now
+//! reaches the SDK via `self.db.client()` and writes/reads against the
+//! SCHEMAFULL `org` table defined in
+//! `layers/state/schemas/cluster/org.surql` (the canonical schema
+//! shipped by P2.5 in `layers/org/schemas/org.surql`, mirrored into the
+//! state crate by P2.7 so the bootstrap node can `apply_cluster_schemas`
+//! it without an upward layer dependency).
+//!
+//! The store holds an [`EmbeddedDb`] directly rather than the legacy
+//! cluster wrapper type — the previous version stored a
+//! cluster-wrapper value and reached the SDK via a
+//! `.embedded().client()` chain, but that kept the legacy type's name
+//! in the file even though the methods had all migrated. P2.9 drops
+//! the indirection entirely: call sites now pass
+//! `cluster_db.embedded().clone()` at construction time, which gives
+//! the store a cheap `Arc`-shared handle onto the same underlying
+//! `Surreal<Db>` the rest of the cluster path sees.
+//!
+//! The legacy `_reg_v2` registry / `org-idx` sidecar keys that the
+//! pre-P2.9 version of this file maintained are gone: the schema's
+//! unique index on `org.name` is now the source of truth for "have we
+//! seen this name before?", and `SELECT * FROM org` walks every row
+//! directly without a separate key list.
+//!
+//! The Org → SurrealDB JSON bridge is still hand-written rather than
+//! `SurrealValue`-derived because `Org` embeds [`ResourceMeta`] which
+//! in turn carries an `id: String` field that collides with SurrealDB's
+//! reserved record-id slot. We bind each column explicitly in the
+//! `CREATE … SET …` form so the offending `id` field is dropped on the
+//! way in, and we cast the `created_at` / `updated_at` Unix-epoch
+//! values through `<datetime>$iso8601_string` so they match the
+//! schema's `TYPE datetime` constraint without requiring a
+//! `surrealdb::types::SurrealValue` derive cascade. The same
+//! JSON-bridge pattern is documented at length on
+//! `nauka_hypervisor::fabric::state::FabricState::save`.
 
 use nauka_core::id::OrgId;
+use nauka_core::resource::epoch_to_iso8601;
 use nauka_core::resource::ResourceMeta;
-use nauka_hypervisor::controlplane::ClusterDb;
+use nauka_state::EmbeddedDb;
+use serde::Deserialize;
 
 use crate::types::Org;
 
-const NS_ORG: &str = "org";
-const NS_ORG_IDX: &str = "org-idx";
-const REG_V2_NS: &str = "_reg_v2";
-const REG_V2_PREFIX: &str = "org/";
-/// Legacy v1 registry key — read during migration, never written.
-const REG_V1: (&str, &str) = ("_reg", "org-ids");
+/// SurrealDB table backing this store. Defined in
+/// `layers/state/schemas/cluster/org.surql` (mirror of
+/// `layers/org/schemas/org.surql`) as `DEFINE TABLE org SCHEMAFULL`.
+const ORG_TABLE: &str = "org";
 
 pub struct OrgStore {
-    db: ClusterDb,
+    db: EmbeddedDb,
 }
 
 impl OrgStore {
-    pub fn new(db: ClusterDb) -> Self {
+    /// Build an [`OrgStore`] over a SurrealDB handle.
+    ///
+    /// Call sites typically have a cluster-DB wrapper on hand and pass
+    /// `cluster_db.embedded().clone()` as the argument. The
+    /// [`EmbeddedDb`] is cheap to clone (`Arc`-shared internally), so
+    /// constructing per-request `OrgStore` values off the same cluster
+    /// handle is free.
+    pub fn new(db: EmbeddedDb) -> Self {
         Self { db }
     }
 
+    /// Create a new org with the given human-readable name.
+    ///
+    /// Builds an [`Org`] with a freshly-generated [`OrgId`] and writes
+    /// it to the `org` table via
+    /// `CREATE type::record($tbl, $id) SET …`. The record id is the
+    /// ULID-prefixed `OrgId` (e.g. `org-01J…`); the schema's unique
+    /// index on `name` rejects duplicate human names at the database
+    /// level, so the previous "check then insert" race is closed.
+    ///
+    /// Returns the unique-name conflict as a flat `anyhow::Error` with
+    /// a human-friendly message so the CLI keeps producing the same
+    /// "org '<name>' already exists" wording it did before P2.9.
     pub async fn create(&self, name: &str) -> anyhow::Result<Org> {
-        if self.get_by_name(name).await?.is_some() {
-            anyhow::bail!("org '{name}' already exists");
-        }
-
         let org = Org {
             meta: ResourceMeta::new(OrgId::generate().to_string(), name),
         };
 
-        self.db.put(NS_ORG, &org.meta.id, &org).await?;
-        self.db
-            .put(NS_ORG_IDX, &org.meta.name, &org.meta.id)
-            .await?;
-        add_id(&self.db, &org.meta.id).await?;
+        let created_at_iso = epoch_to_iso8601(org.meta.created_at);
+        let updated_at_iso = epoch_to_iso8601(org.meta.updated_at);
+
+        // Build the row via explicit SET fields so the SurrealDB
+        // SCHEMAFULL constraints are honoured: `id` is dropped (it
+        // lives in the record id), `created_at`/`updated_at` are cast
+        // through `<datetime>` so the ISO 8601 strings parse into the
+        // schema's native `datetime` type, `labels` is bound as a JSON
+        // object, and `name`/`status` are bound as plain strings.
+        let labels_json = serde_json::to_value(&org.meta.labels)
+            .map_err(|e| anyhow::anyhow!("serialise labels: {e}"))?;
+
+        let query_result = self
+            .db
+            .client()
+            .query(
+                "CREATE type::record($tbl, $id) SET \
+                 name = $name, \
+                 status = $status, \
+                 labels = $labels, \
+                 created_at = <datetime>$created_at, \
+                 updated_at = <datetime>$updated_at",
+            )
+            .bind(("tbl", ORG_TABLE))
+            .bind(("id", org.meta.id.clone()))
+            .bind(("name", org.meta.name.clone()))
+            .bind(("status", org.meta.status.clone()))
+            .bind(("labels", labels_json))
+            .bind(("created_at", created_at_iso))
+            .bind(("updated_at", updated_at_iso))
+            .await;
+        let response = match query_result {
+            Ok(r) => r,
+            Err(e) => return Err(classify_create_error(name, &e.to_string())),
+        };
+        if let Err(e) = response.check() {
+            return Err(classify_create_error(name, &e.to_string()));
+        }
 
         Ok(org)
     }
 
+    /// Look up an org by id (when the input looks like an `OrgId`)
+    /// or by human name (otherwise).
+    ///
+    /// The id path is a direct record-id `SELECT`; the name path uses
+    /// the schema's unique `org_name` index for an O(1) lookup. Both
+    /// paths return `Ok(None)` when no row matches — neither one is
+    /// an error.
     pub async fn get(&self, name_or_id: &str) -> anyhow::Result<Option<Org>> {
         if OrgId::looks_like_id(name_or_id) {
-            self.db.get(NS_ORG, name_or_id).await.map_err(Into::into)
+            self.get_by_id(name_or_id).await
         } else {
             self.get_by_name(name_or_id).await
         }
     }
 
-    async fn get_by_name(&self, name: &str) -> anyhow::Result<Option<Org>> {
-        let id: Option<String> = self.db.get(NS_ORG_IDX, name).await?;
-        match id {
-            Some(id) => self.db.get(NS_ORG, &id).await.map_err(Into::into),
+    async fn get_by_id(&self, id: &str) -> anyhow::Result<Option<Org>> {
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT * FROM type::record($tbl, $id)")
+            .bind(("tbl", ORG_TABLE))
+            .bind(("id", id.to_string()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        // Round-trip through `serde_json::Value` so callers don't have
+        // to derive `SurrealValue` on `OrgRow`. See the rationale on
+        // [`OrgRow`] and the `FabricState::load` JSON-bridge pattern.
+        let raw: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        match raw.into_iter().next() {
             None => Ok(None),
-        }
-    }
-
-    pub async fn list(&self) -> anyhow::Result<Vec<Org>> {
-        let ids = load_ids(&self.db).await?;
-        let mut orgs = Vec::new();
-        for id in &ids {
-            if let Some(org) = self.db.get::<Org>(NS_ORG, id).await? {
-                orgs.push(org);
+            Some(v) => {
+                let row: OrgRow = serde_json::from_value(v)
+                    .map_err(|e| anyhow::anyhow!("deserialise org row: {e}"))?;
+                Ok(Some(row.into_org()))
             }
         }
-        Ok(orgs)
     }
 
+    async fn get_by_name(&self, name: &str) -> anyhow::Result<Option<Org>> {
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT * FROM org WHERE name = $name LIMIT 1")
+            .bind(("name", name.to_string()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        // Same JSON-bridge as `get_by_id` — see the comment there and
+        // the rationale block on [`OrgRow`].
+        let raw: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        match raw.into_iter().next() {
+            None => Ok(None),
+            Some(v) => {
+                let row: OrgRow = serde_json::from_value(v)
+                    .map_err(|e| anyhow::anyhow!("deserialise org row: {e}"))?;
+                Ok(Some(row.into_org()))
+            }
+        }
+    }
+
+    /// List every org in the cluster, in unspecified order.
+    ///
+    /// The SCHEMAFULL `org` table is the source of truth — the legacy
+    /// `_reg_v2` sidecar registry the previous version of this file
+    /// maintained is gone with P2.9.
+    pub async fn list(&self) -> anyhow::Result<Vec<Org>> {
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT * FROM org")
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let raw: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        let orgs: Result<Vec<Org>, _> = raw
+            .into_iter()
+            .map(|v| {
+                serde_json::from_value::<OrgRow>(v)
+                    .map(OrgRow::into_org)
+                    .map_err(|e| anyhow::anyhow!("deserialise org row: {e}"))
+            })
+            .collect();
+        orgs
+    }
+
+    /// Delete an org by name or id. Refuses to delete an org that
+    /// still owns any project — the caller must remove the children
+    /// first.
     pub async fn delete(&self, name_or_id: &str) -> anyhow::Result<()> {
         let org = self
             .get(name_or_id)
             .await?
             .ok_or_else(|| anyhow::anyhow!("org '{name_or_id}' not found"))?;
 
-        let proj_store = crate::project::store::ProjectStore::new(self.db.clone());
-        let projects = proj_store.list(Some(&org.meta.name)).await?;
-        if !projects.is_empty() {
+        // Refuse to delete an org that still has projects. The project
+        // store still speaks the legacy raw-KV surface on top of the
+        // same `EmbeddedDb` (P2.10 sifrah/nauka#214 migrates it), so
+        // every project row lives in the `_kv_proj` SCHEMALESS table
+        // as `{ key: <id>, data: <project-json> }`. We count the rows
+        // whose `data.org_name` matches the target org directly via
+        // SurrealQL so this store doesn't need to import `ProjectStore`
+        // (and therefore doesn't need to import the legacy cluster-DB
+        // wrapper type to build one). Once P2.10 lands the query
+        // simplifies to `SELECT count() FROM project WHERE org = $id`.
+        let remaining_projects = self.count_projects_in_org(&org.meta.name).await?;
+        if remaining_projects > 0 {
             anyhow::bail!(
                 "org '{}' has {} project(s). Delete them first.",
                 org.meta.name,
-                projects.len()
+                remaining_projects
             );
         }
 
-        self.db.delete(NS_ORG, &org.meta.id).await?;
-        self.db.delete(NS_ORG_IDX, &org.meta.name).await?;
-        remove_id(&self.db, &org.meta.id).await?;
+        let result = self
+            .db
+            .client()
+            .query("DELETE type::record($tbl, $id)")
+            .bind(("tbl", ORG_TABLE))
+            .bind(("id", org.meta.id.clone()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        result.check().map_err(|e| anyhow::anyhow!("{e}"))?;
         Ok(())
     }
+
+    /// Count the projects currently owned by the org whose
+    /// human-readable name is `org_name`.
+    ///
+    /// Queries the transitional `_kv_proj` SCHEMALESS table (written by
+    /// the legacy project store that is still on the raw-KV surface)
+    /// directly, rather than constructing a `ProjectStore` from a
+    /// cluster-DB wrapper. The table is created via `DEFINE TABLE IF
+    /// NOT EXISTS` so a fresh database (no projects ever written)
+    /// returns zero rows instead of "table does not exist". P2.10
+    /// (sifrah/nauka#214) migrates the project store to a SCHEMAFULL
+    /// `project` table, at which point the query target changes to
+    /// `project` and this helper goes away.
+    async fn count_projects_in_org(&self, org_name: &str) -> anyhow::Result<usize> {
+        // Make sure the legacy `_kv_proj` table exists so the SELECT
+        // below doesn't error on a fresh database. SurrealDB raises
+        // "table does not exist" otherwise; the `IF NOT EXISTS` guard
+        // makes this idempotent.
+        self.db
+            .client()
+            .query("DEFINE TABLE IF NOT EXISTS _kv_proj SCHEMALESS")
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?
+            .check()
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT data FROM _kv_proj WHERE data.org_name = $org_name")
+            .bind(("org_name", org_name.to_string()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let rows: Vec<serde_json::Value> =
+            response.take("data").map_err(|e| anyhow::anyhow!("{e}"))?;
+        Ok(rows.len())
+    }
 }
 
-async fn load_ids(db: &ClusterDb) -> anyhow::Result<Vec<String>> {
-    // Primary: per-key scan (race-free)
-    let keys = db.scan_keys(REG_V2_NS, REG_V2_PREFIX).await?;
-    let mut ids: Vec<String> = keys
-        .into_iter()
-        .filter_map(|k| k.strip_prefix(REG_V2_PREFIX).map(|s| s.to_string()))
-        .collect();
+/// Row shape returned by `SELECT * FROM org`. Mirrors the SCHEMAFULL
+/// `org` table's column set with one ergonomic conversion: SurrealDB
+/// hands the record id back as a typed `Thing` (table + id), which
+/// serde_json renders as `{"tb": "org", "id": {"String": "..."}}`. We
+/// bridge through `serde_json::Value` and pull the inner string out in
+/// [`OrgRow::into_org`] so callers see the same flat `org-<ulid>` id
+/// string that they always have.
+///
+/// `created_at` / `updated_at` arrive as RFC 3339 / ISO 8601 strings
+/// from SurrealDB; we parse them back into Unix-epoch seconds with
+/// [`iso8601_to_epoch`] so the resulting [`Org`] is bit-identical to
+/// what `OrgStore::create` originally produced.
+#[derive(Debug, Deserialize)]
+struct OrgRow {
+    id: serde_json::Value,
+    name: String,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    labels: Option<serde_json::Value>,
+    created_at: String,
+    updated_at: String,
+}
 
-    // Backwards compat: merge any IDs from the legacy v1 list that aren't in v2 yet
-    if let Some(v1_ids) = db.get::<Vec<String>>(REG_V1.0, REG_V1.1).await? {
-        for old_id in v1_ids {
-            if !ids.contains(&old_id) {
-                // Migrate to v2 on the fly
-                let key = format!("{REG_V2_PREFIX}{old_id}");
-                db.put(REG_V2_NS, &key, &true).await?;
-                ids.push(old_id);
+impl OrgRow {
+    fn into_org(self) -> Org {
+        let id = thing_to_id_string(&self.id);
+        let labels = self
+            .labels
+            .and_then(|v| serde_json::from_value(v).ok())
+            .unwrap_or_default();
+        Org {
+            meta: ResourceMeta {
+                id,
+                name: self.name,
+                status: self.status.unwrap_or_else(|| "active".to_string()),
+                labels,
+                created_at: iso8601_to_epoch(&self.created_at),
+                updated_at: iso8601_to_epoch(&self.updated_at),
+            },
+        }
+    }
+}
+
+/// Pull the inner id string out of a SurrealDB `Thing` rendered as
+/// `serde_json::Value`.
+///
+/// SurrealDB JSON-encodes a `Thing` as one of several shapes depending
+/// on the SDK version and the variant of the inner id:
+///
+/// 1. `"org:01J…"` or `` "org:`01J…`" `` — a flat string when the id
+///    round-tripped through a SurrealQL response that was already
+///    strings-only. SurrealDB wraps the id in backticks when the raw
+///    id contains any character outside the unquoted-identifier set
+///    (`-` in our `org-<ulid>` form is the usual culprit).
+/// 2. `{"tb": "org", "id": "01J…"}` — the structured form for a
+///    `String` id.
+/// 3. `{"tb": "org", "id": {"String": "01J…"}}` — the structured form
+///    when SurrealDB tagged the id variant explicitly.
+///
+/// We accept all three and always return the bare `org-<ulid>` form
+/// (without the `tb:` prefix or any wrapping backticks) because that's
+/// what the rest of Nauka has been carrying around as `Org::meta::id`
+/// since day one.
+fn thing_to_id_string(value: &serde_json::Value) -> String {
+    let trim_backticks = |s: &str| s.trim_start_matches('`').trim_end_matches('`').to_string();
+
+    if let Some(s) = value.as_str() {
+        // Shape 1: flat "org:01J…" string. Strip the `org:` prefix if
+        // present so the result matches the legacy `org-<ulid>` form,
+        // then strip any wrapping backticks that SurrealDB added
+        // because the id contains a hyphen.
+        let without_prefix = s.strip_prefix("org:").unwrap_or(s);
+        return trim_backticks(without_prefix);
+    }
+    if let Some(obj) = value.as_object() {
+        // Shapes 2 and 3 carry the id under the `id` key. Shape 3
+        // wraps the inner id under `String`.
+        if let Some(inner) = obj.get("id") {
+            if let Some(s) = inner.as_str() {
+                return trim_backticks(s);
+            }
+            if let Some(inner_obj) = inner.as_object() {
+                if let Some(s) = inner_obj.get("String").and_then(|v| v.as_str()) {
+                    return trim_backticks(s);
+                }
             }
         }
-        // Clean up legacy key after full migration
-        db.delete(REG_V1.0, REG_V1.1).await?;
+    }
+    // Fallback: dump the JSON form so the caller at least sees what
+    // SurrealDB actually returned. The `{}` Display for serde_json::Value
+    // is the JSON encoding.
+    value.to_string()
+}
+
+/// Parse an ISO 8601 / RFC 3339 datetime back into Unix-epoch seconds.
+///
+/// SurrealDB renders `datetime` values as strings like
+/// `2024-01-02T03:04:05.123456Z`; we round down to whole seconds because
+/// `ResourceMeta::created_at` is a `u64` with second granularity. Any
+/// parse failure (e.g. an unexpected timezone offset) returns `0` so
+/// the caller still gets a value back — the alternative would be to
+/// fail the whole list/get path on a single malformed row, which is
+/// strictly worse for operators trying to clean up bad data.
+fn iso8601_to_epoch(s: &str) -> u64 {
+    // Stripped-down parser: YYYY-MM-DDTHH:MM:SS… — accepts a trailing
+    // `Z`, an optional fractional seconds part, and an optional
+    // timezone offset (which we ignore — the only writer is
+    // `OrgStore::create` and it always emits `Z`).
+    let bytes = s.as_bytes();
+    if bytes.len() < 19 {
+        return 0;
+    }
+    let year: i64 = std::str::from_utf8(&bytes[0..4])
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let month: i64 = std::str::from_utf8(&bytes[5..7])
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let day: i64 = std::str::from_utf8(&bytes[8..10])
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let hour: i64 = std::str::from_utf8(&bytes[11..13])
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let minute: i64 = std::str::from_utf8(&bytes[14..16])
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let second: i64 = std::str::from_utf8(&bytes[17..19])
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let days = days_from_civil(year, month, day);
+    let total = days * 86400 + hour * 3600 + minute * 60 + second;
+    if total < 0 {
+        0
+    } else {
+        total as u64
+    }
+}
+
+/// Howard Hinnant's "days from civil" algorithm — converts a
+/// `(year, month, day)` triple to a count of days since 1970-01-01.
+///
+/// Lifted directly from the public-domain reference implementation
+/// (<https://howardhinnant.github.io/date_algorithms.html#days_from_civil>).
+/// We use it instead of a `chrono` / `time` dependency to keep
+/// `nauka-org` build-time small and to mirror the existing date math
+/// already in `nauka_core::resource::api_response::days_to_date`, which
+/// goes the other direction.
+fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146097 + doe - 719468
+}
+
+/// Map a SurrealDB error message from `OrgStore::create` into a flat
+/// `anyhow::Error` with a human-friendly message.
+///
+/// The schema's `org_name UNIQUE` index surfaces duplicate names as
+/// `surrealdb::Error::already_exists`, whose `Display` rendering
+/// includes the phrase "already contains" (the substring is stable
+/// across surrealdb-types releases and is what the existing
+/// `From<surrealdb::Error>` impl in `nauka_state::lib.rs` documents as
+/// the `is_already_exists()` signal). We key on that substring rather
+/// than re-introducing a direct `surrealdb` dependency in this crate,
+/// so duplicate-name conflicts still surface as the same
+/// `org '<name>' already exists` message the pre-P2.9 "check then
+/// insert" path returned — and so existing CLI error-message tests
+/// downstream keep passing. Everything else collapses to the
+/// underlying error text verbatim.
+fn classify_create_error(name: &str, err_msg: &str) -> anyhow::Error {
+    let lowered = err_msg.to_lowercase();
+    if lowered.contains("already contains")
+        || lowered.contains("already exists")
+        || lowered.contains("duplicate")
+    {
+        anyhow::anyhow!("org '{name}' already exists")
+    } else {
+        anyhow::anyhow!("{err_msg}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build an in-process `OrgStore` backed by a fresh SurrealKV
+    /// datastore at a temporary path, with the `org` schema applied.
+    ///
+    /// The tempdir handle has to live as long as the store, so we
+    /// return it together. SurrealDB's SCHEMAFULL semantics are
+    /// identical across SurrealKv and TiKv (the Phase-2 contract is
+    /// that one `EmbeddedDb` wrapper fronts both, with the same SDK
+    /// surface), so this is a faithful rehearsal of production cluster
+    /// state without needing a live TiKV cluster on the test host.
+    async fn temp_store() -> (tempfile::TempDir, OrgStore) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = EmbeddedDb::open(&dir.path().join("orgs.skv"))
+            .await
+            .expect("open EmbeddedDb at temp path");
+        // Apply the cluster schema bundle so the SCHEMAFULL `org` table
+        // (and every parent/child it depends on) is live before the
+        // store touches it.
+        nauka_state::apply_cluster_schemas(&db)
+            .await
+            .expect("apply cluster schemas");
+        (dir, OrgStore::new(db))
     }
 
-    Ok(ids)
-}
+    #[tokio::test]
+    async fn create_then_get_by_name() {
+        let (_d, store) = temp_store().await;
+        let created = store.create("acme").await.expect("create org");
+        assert_eq!(created.meta.name, "acme");
+        assert!(created.meta.id.starts_with("org-"));
 
-async fn add_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let key = format!("{REG_V2_PREFIX}{id}");
-    db.put(REG_V2_NS, &key, &true).await?;
-    Ok(())
-}
+        let got = store
+            .get("acme")
+            .await
+            .expect("get by name")
+            .expect("missing");
+        assert_eq!(got.meta.name, "acme");
+        assert_eq!(got.meta.id, created.meta.id);
+        assert_eq!(got.meta.status, "active");
+    }
 
-async fn remove_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let key = format!("{REG_V2_PREFIX}{id}");
-    db.delete(REG_V2_NS, &key).await?;
-    Ok(())
+    #[tokio::test]
+    async fn create_then_get_by_id() {
+        let (_d, store) = temp_store().await;
+        let created = store.create("acme").await.expect("create org");
+
+        let got = store
+            .get(&created.meta.id)
+            .await
+            .expect("get by id")
+            .expect("missing");
+        assert_eq!(got.meta.id, created.meta.id);
+        assert_eq!(got.meta.name, "acme");
+    }
+
+    #[tokio::test]
+    async fn create_duplicate_name_is_rejected() {
+        let (_d, store) = temp_store().await;
+        store.create("acme").await.expect("first create");
+        let err = store
+            .create("acme")
+            .await
+            .expect_err("duplicate name should fail");
+        assert!(
+            err.to_string().contains("already exists"),
+            "expected duplicate error, got: {err}",
+        );
+    }
+
+    #[tokio::test]
+    async fn list_returns_all_orgs() {
+        let (_d, store) = temp_store().await;
+        store.create("acme").await.unwrap();
+        store.create("globex").await.unwrap();
+        store.create("initech").await.unwrap();
+
+        let orgs = store.list().await.expect("list");
+        assert_eq!(orgs.len(), 3);
+        let mut names: Vec<&str> = orgs.iter().map(|o| o.meta.name.as_str()).collect();
+        names.sort();
+        assert_eq!(names, vec!["acme", "globex", "initech"]);
+    }
+
+    #[tokio::test]
+    async fn list_empty_returns_empty() {
+        let (_d, store) = temp_store().await;
+        let orgs = store.list().await.expect("list");
+        assert!(orgs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_missing_returns_none() {
+        let (_d, store) = temp_store().await;
+        assert!(store.get("does-not-exist").await.unwrap().is_none());
+        assert!(store
+            .get("org-01J00000000000000000000000")
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_removes_org() {
+        let (_d, store) = temp_store().await;
+        store.create("acme").await.unwrap();
+        store.delete("acme").await.expect("delete");
+        assert!(store.get("acme").await.unwrap().is_none());
+        assert!(store.list().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn delete_missing_org_errors() {
+        let (_d, store) = temp_store().await;
+        let err = store
+            .delete("does-not-exist")
+            .await
+            .expect_err("missing org should fail");
+        assert!(err.to_string().contains("not found"), "got: {err}");
+    }
+
+    /// Delete refuses to drop an org that still has a project pointing
+    /// at it via the legacy `_kv_proj` key/value rows.
+    ///
+    /// We seed the legacy table directly with a row that mimics the
+    /// shape `ProjectStore::create` produces (`{ key: <id>, data: {
+    /// org_name, ... } }`) so the test stays self-contained — it
+    /// doesn't pull in `ProjectStore` (which still goes through the
+    /// legacy cluster-DB wrapper API and would force an awkward
+    /// import dance into this file).
+    #[tokio::test]
+    async fn delete_refuses_when_project_remains() {
+        let (_d, store) = temp_store().await;
+        store.create("acme").await.expect("create org");
+
+        // Seed a fake `_kv_proj` row that mirrors the JSON shape the
+        // legacy `ProjectStore::create` writes.
+        store
+            .db
+            .client()
+            .query("DEFINE TABLE IF NOT EXISTS _kv_proj SCHEMALESS")
+            .await
+            .expect("define _kv_proj")
+            .check()
+            .expect("define _kv_proj check");
+        let row_data = serde_json::json!({
+            "id": "proj-fake",
+            "name": "fakeproj",
+            "org_name": "acme",
+        });
+        store
+            .db
+            .client()
+            .query("UPSERT type::record('_kv_proj', 'proj-fake') CONTENT { key: 'proj-fake', data: $data }")
+            .bind(("data", row_data))
+            .await
+            .expect("seed project row")
+            .check()
+            .expect("seed project row check");
+
+        // Now `delete` should refuse the org — there's a project still
+        // pointing at it via `data.org_name = "acme"`.
+        let err = store
+            .delete("acme")
+            .await
+            .expect_err("delete should refuse while a project still exists");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("project") && msg.contains("Delete them first"),
+            "expected 'has N project(s). Delete them first' message, got: {msg}",
+        );
+
+        // The org is still there — the failed delete must not have
+        // removed it as a side-effect.
+        assert!(store.get("acme").await.unwrap().is_some());
+    }
+
+    #[test]
+    fn iso8601_round_trip_matches_epoch() {
+        // Sanity check the helper pair: epoch → iso → epoch must round
+        // trip exactly. The helper uses second granularity, so any
+        // sub-second part would be lost — but `ResourceMeta::created_at`
+        // is itself second-granularity, so this is the right contract.
+        for &epoch in &[0u64, 1, 86_399, 86_400, 1_700_000_000, 1_775_665_838] {
+            let iso = epoch_to_iso8601(epoch);
+            let back = iso8601_to_epoch(&iso);
+            assert_eq!(back, epoch, "round trip failed for {epoch}: iso={iso}");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Replaces the raw-KV `ClusterDb` path in `layers/org/src/store.rs` with direct SurrealDB SDK calls against the SCHEMAFULL `org` table. Org CRUD now flows through `self.db.client().query(...)` with explicit column binds; the old `_reg_v2` / `org-idx` sidecar keys are gone — the schema's unique `org_name` index and a plain `SELECT * FROM org` cover the same cases.
- `grep -rn "ClusterDb" layers/org/src/store.rs` returns **zero** hits — the store now holds an `EmbeddedDb` directly. Callers in `compute` / `forge` / `network` / `org::project` / `org::handlers` hand it `cluster_db.embedded().clone()`.
- Cumulative: this PR also bundles the in-flight **P2.7** (sifrah/nauka#211) and **P2.8** (sifrah/nauka#212) work so it stays self-contained. When those sibling PRs merge this PR supersedes them.

### P2.7: `apply_cluster_schemas` + bootstrap wiring

`layers/state/src/schema.rs` is new. It ships verbatim copies of every cluster `.surql` (under `layers/state/schemas/cluster/`) and a helper that walks them in parent-first dependency order:

```rust
pub async fn apply_cluster_schemas(db: &EmbeddedDb) -> Result<()> {
    for (name, schema) in CLUSTER_SCHEMAS {
        db.client().query(*schema).await?.check()?;
    }
    Ok(())
}
```

`controlplane::ops::bootstrap()` is now `async` and calls the helper after `adjust_max_replicas`. The single caller in `handlers::handle_init` `.await`s it.

### P2.8: `ClusterDb` as an `EmbeddedDb` wrapper

`layers/hypervisor/src/controlplane/store.rs` is rewritten end-to-end. The struct now holds a single `EmbeddedDb` field instead of a `tikv-client::RawClient`. The legacy `put` / `get` / `delete` / `list` / `scan_keys` / `exists` / `batch_put` methods are reimplemented as a JSON bridge over a SCHEMALESS `_kv_<namespace>` table so every in-flight P2.10–P2.14 store migration keeps compiling unchanged, and a new `embedded()` accessor hands the native SurrealDB SDK out for callers that have already migrated.

### P2.9: the actual OrgStore migration — before / after

**Before** (`create`, abridged):

```rust
pub async fn create(&self, name: &str) -> Result<Org> {
    if self.get_by_name(name).await?.is_some() {
        bail!("org '{name}' already exists");
    }
    let org = Org { meta: ResourceMeta::new(OrgId::generate().to_string(), name) };
    self.db.put(NS_ORG, &org.meta.id, &org).await?;
    self.db.put(NS_ORG_IDX, &org.meta.name, &org.meta.id).await?;
    add_id(&self.db, &org.meta.id).await?;
    Ok(org)
}
```

**After**:

```rust
pub async fn create(&self, name: &str) -> Result<Org> {
    let org = Org { meta: ResourceMeta::new(OrgId::generate().to_string(), name) };
    let created_at_iso = epoch_to_iso8601(org.meta.created_at);
    let updated_at_iso = epoch_to_iso8601(org.meta.updated_at);
    // One native-SDK CREATE — the schema's unique org_name index
    // closes the check-then-insert race that the pre-P2.9 path had.
    let response = self.db.client()
        .query("CREATE type::record($tbl, $id) SET name = $name, status = $status, \
                labels = $labels, created_at = <datetime>$created_at, updated_at = <datetime>$updated_at")
        .bind(("tbl", ORG_TABLE))
        .bind(("id", org.meta.id.clone()))
        .bind(("name", org.meta.name.clone()))
        .bind(("status", org.meta.status.clone()))
        .bind(("labels", labels_json))
        .bind(("created_at", created_at_iso))
        .bind(("updated_at", updated_at_iso))
        .await
        .map_err(|e| classify_create_error(name, &e.to_string()))?;
    response.check().map_err(|e| classify_create_error(name, &e.to_string()))?;
    Ok(org)
}
```

`list()` went from a two-step scan-keys + per-id get:

```rust
// Before
let ids = load_ids(&self.db).await?;
for id in &ids { if let Some(org) = self.db.get::<Org>(NS_ORG, id).await? { … } }
```

to a single native `SELECT *` against the schema's canonical table:

```rust
// After
let mut response = self.db.client().query("SELECT * FROM org").await?;
let raw: Vec<serde_json::Value> = response.take(0)?;
Ok(raw.into_iter().map(|v| serde_json::from_value::<OrgRow>(v).unwrap().into_org()).collect())
```

### Notes

- Datetime bridge: the SCHEMAFULL `org` table uses native `datetime` for `created_at` / `updated_at`, but `ResourceMeta` is a Unix-epoch `u64`. We convert in Rust via `nauka_core::resource::epoch_to_iso8601` and cast server-side through `<datetime>$field` so no `surrealdb::types::SurrealValue` derive cascade is needed on `Org` / `ResourceMeta`.
- SCHEMAFULL `id` collision: SurrealDB reserves `id` for the record-id slot. The `CREATE … SET …` form avoids the field, so `ResourceMeta::id` doesn't end up in the row body. On read, `OrgRow::into_org()` extracts the ULID-prefixed string from the `Thing` wrapper (accepting all three JSON shapes SurrealDB ships, backtick-stripped).
- `OrgStore::delete` still guards against orgs with pending projects. `ProjectStore` is on the legacy raw-KV surface until P2.10 (sifrah/nauka#214) ports it, so the delete path counts rows in `_kv_proj` directly via SurrealQL (`SELECT data FROM _kv_proj WHERE data.org_name = $org_name`) rather than re-importing the legacy cluster-DB wrapper.
- `ns_table("_reg_v2")` escapes to `_kv__reg_v2`, and `sanitize_record_id("org/id-1")` percent-encodes the `/`. Both are covered by unit tests.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p nauka-state -- --test-threads=1` — 27 tests pass, including new `apply_cluster_schemas_smoke` (idempotency + dependency order lock-down)
- [x] `cargo test -p nauka-org -- --test-threads=1` — 10 tests pass, covering create / get-by-name / get-by-id / list / delete / duplicate-rejection / `delete_refuses_when_project_remains` regression
- [x] `cargo test -p nauka-hypervisor --lib controlplane -- --test-threads=1` — 41 tests pass, including 14 ClusterDb JSON-bridge round-trip tests and a `native_sdk_read_sees_legacy_put` coherence test
- [x] `cargo test --workspace -- --test-threads=1` — green modulo the pre-existing `doctor::tests::disk_free_check` macOS failure (unrelated, tracked separately)
- [x] Cross-compile musl: `CC_x86_64_unknown_linux_musl=x86_64-linux-musl-gcc CXX_x86_64_unknown_linux_musl=x86_64-linux-musl-g++ AR_x86_64_unknown_linux_musl=x86_64-linux-musl-ar cargo build --target x86_64-unknown-linux-musl --release -p nauka` — clean
- [x] `grep -rn "ClusterDb" layers/org/src/store.rs` — **zero hits** (AC satisfied)

Closes sifrah/nauka#213
Part of epic sifrah/nauka#183