### PR TITLE
feat(P2.10): migrate ProjectStore to native SurrealDB SDK

### DIFF
--- a/layers/compute/src/vm/store.rs
+++ b/layers/compute/src/vm/store.rs
@@ -48,7 +48,10 @@ impl VmStore {
             .await?
             .ok_or_else(|| anyhow::anyhow!("org '{org_name}' not found"))?;
 
-        let proj_store = nauka_org::project::store::ProjectStore::new(self.db.clone());
+        // P2.10 (sifrah/nauka#214) migrated `ProjectStore` to take an
+        // `EmbeddedDb` directly, same as `OrgStore` above. Reach the
+        // handle through the cluster wrapper's `.embedded().clone()`.
+        let proj_store = nauka_org::project::store::ProjectStore::new(self.db.embedded().clone());
         let project = proj_store
             .get(project_name, Some(org_name))
             .await?

--- a/layers/org/src/lib.rs
+++ b/layers/org/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod handlers;
 pub mod project;
+mod sdk_bridge;
 pub mod store;
 pub mod types;
 

--- a/layers/org/src/project/env/store.rs
+++ b/layers/org/src/project/env/store.rs
@@ -28,7 +28,10 @@ impl EnvStore {
         project_name: &str,
         org_name: &str,
     ) -> anyhow::Result<Environment> {
-        let proj_store = project::store::ProjectStore::new(self.db.clone());
+        // P2.10 (sifrah/nauka#214): `ProjectStore::new` takes an
+        // `EmbeddedDb` directly; reach the inner handle via
+        // `ClusterDb::embedded().clone()`.
+        let proj_store = project::store::ProjectStore::new(self.db.embedded().clone());
         let project = proj_store
             .get(project_name, Some(org_name))
             .await?
@@ -69,7 +72,10 @@ impl EnvStore {
 
         let project_name = project_name
             .ok_or_else(|| anyhow::anyhow!("--project required to resolve environment by name"))?;
-        let proj_store = project::store::ProjectStore::new(self.db.clone());
+        // P2.10 (sifrah/nauka#214): `ProjectStore::new` takes an
+        // `EmbeddedDb` directly; reach the inner handle via
+        // `ClusterDb::embedded().clone()`.
+        let proj_store = project::store::ProjectStore::new(self.db.embedded().clone());
         let project = proj_store
             .get(project_name, org_name)
             .await?

--- a/layers/org/src/project/handlers.rs
+++ b/layers/org/src/project/handlers.rs
@@ -46,7 +46,11 @@ pub fn handler() -> HandlerFn {
             Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
         > {
             Box::pin(async move {
-                let store = ProjectStore::new(nauka_hypervisor::controlplane::connect().await?);
+                // P2.10 (sifrah/nauka#214): ProjectStore now takes an
+                // EmbeddedDb directly; reach the cluster handle via
+                // the wrapper's `.embedded()` accessor.
+                let cluster_db = nauka_hypervisor::controlplane::connect().await?;
+                let store = ProjectStore::new(cluster_db.embedded().clone());
                 match req.operation.as_str() {
                     "create" => {
                         let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name"))?;

--- a/layers/org/src/project/store.rs
+++ b/layers/org/src/project/store.rs
@@ -1,41 +1,90 @@
-//! Project persistence in ClusterDb (TiKV).
+//! Project persistence on the SurrealDB-backed cluster store.
+//!
+//! P2.10 (sifrah/nauka#214) migrated this module from the legacy raw-KV
+//! cluster-DB surface (`db.put` / `db.get` / `db.scan_keys`) to the
+//! native SurrealDB SDK on top of [`EmbeddedDb`]. Every method now
+//! reaches the SDK via `self.db.client()` and writes/reads against the
+//! SCHEMAFULL `project` table defined in
+//! `layers/org/schemas/project.surql` (applied to the cluster by
+//! `nauka_state::apply_cluster_schemas` at bootstrap per ADR 0004).
+//!
+//! The store holds an [`EmbeddedDb`] directly, same as the post-P2.9
+//! `OrgStore`. Call sites pass `cluster_db.embedded().clone()` at
+//! construction time; the clone is cheap (`Arc`-shared `Surreal<Db>`
+//! router) and lets the store share the underlying connection with the
+//! rest of the cluster path.
+//!
+//! The legacy `_reg_v2` / `proj-idx` sidecar keys are gone: the
+//! schema's composite unique index on `(org, name)` is now the source
+//! of truth for "have we seen this (org, name) pair before?", and
+//! `SELECT * FROM project` walks every row directly without a separate
+//! key list.
+//!
+//! The `Project` → SurrealDB JSON bridge is hand-written rather than
+//! `SurrealValue`-derived for the same reason `OrgStore` bridges
+//! manually: `Project` embeds [`ResourceMeta`] which carries an
+//! `id: String` field that collides with SurrealDB's reserved
+//! record-id slot. We bind each column explicitly in the
+//! `CREATE … SET …` form so the offending `id` field is dropped on the
+//! way in, and we cast the `created_at` / `updated_at` Unix-epoch
+//! values through `<datetime>$iso8601_string` to match the schema's
+//! `TYPE datetime` constraint. The JSON-bridge pattern is documented
+//! at length on `nauka_hypervisor::fabric::state::FabricState::save`.
 
-use nauka_core::id::ProjectId;
+use nauka_core::id::{OrgId, ProjectId};
+use nauka_core::resource::epoch_to_iso8601;
 use nauka_core::resource::ResourceMeta;
-use nauka_hypervisor::controlplane::ClusterDb;
+use nauka_state::EmbeddedDb;
+use serde::Deserialize;
+
+use crate::sdk_bridge::{classify_create_error, iso8601_to_epoch, thing_to_id_string};
 
 use super::types::Project;
 
-const NS_PROJ: &str = "proj";
-const NS_PROJ_IDX: &str = "proj-idx";
-const REG_V2_NS: &str = "_reg_v2";
-const REG_V2_PREFIX: &str = "proj/";
-const REG_V1: (&str, &str) = ("_reg", "proj-ids");
+/// SurrealDB table backing this store. Defined by
+/// `layers/org/schemas/project.surql` as `DEFINE TABLE project
+/// SCHEMAFULL` and applied at bootstrap via
+/// `nauka_state::apply_cluster_schemas`.
+const PROJECT_TABLE: &str = "project";
 
 pub struct ProjectStore {
-    db: ClusterDb,
+    db: EmbeddedDb,
 }
 
 impl ProjectStore {
-    pub fn new(db: ClusterDb) -> Self {
+    /// Build a [`ProjectStore`] over a SurrealDB handle.
+    ///
+    /// Call sites that already hold a cluster-DB wrapper pass
+    /// `cluster_db.embedded().clone()` — the [`EmbeddedDb`] is cheap
+    /// to clone (`Arc`-shared internally), so constructing per-request
+    /// stores off the same cluster handle is free.
+    pub fn new(db: EmbeddedDb) -> Self {
         Self { db }
     }
 
+    /// Create a new project within an org.
+    ///
+    /// Resolves the owning org by its human-readable name, builds a
+    /// `Project` with a fresh [`ProjectId`], and writes it to the
+    /// `project` table via `CREATE type::record($tbl, $id) SET …`. The
+    /// record id is the ULID-prefixed `ProjectId` (e.g.
+    /// `project-01J…`); the schema's composite unique index on
+    /// `(org, name)` rejects duplicate `(org, name)` pairs at the
+    /// database level, closing the old "check then insert" race.
+    ///
+    /// Duplicate-name conflicts surface as a flat `anyhow::Error` with
+    /// a human-friendly `"project '<name>' already exists in org
+    /// '<org>'"` message so the CLI keeps producing the same wording
+    /// it did before P2.10.
     pub async fn create(&self, name: &str, org_name: &str) -> anyhow::Result<Project> {
         // P2.9 (sifrah/nauka#213) migrated `OrgStore` to take an
-        // `EmbeddedDb` directly; reach the inner handle via the
-        // cluster-DB wrapper's `.embedded()` accessor.
-        let org_store = crate::store::OrgStore::new(self.db.embedded().clone());
+        // `EmbeddedDb` directly; reach the inner handle via a cheap
+        // clone of our own.
+        let org_store = crate::store::OrgStore::new(self.db.clone());
         let org = org_store
             .get(org_name)
             .await?
             .ok_or_else(|| anyhow::anyhow!("org '{org_name}' not found"))?;
-
-        let idx_key = format!("{}/{}", org.meta.id, name);
-        let existing: Option<String> = self.db.get(NS_PROJ_IDX, &idx_key).await?;
-        if existing.is_some() {
-            anyhow::bail!("project '{name}' already exists in org '{org_name}'");
-        }
 
         let project = Project {
             meta: ResourceMeta::new(ProjectId::generate().to_string(), name),
@@ -43,47 +92,133 @@ impl ProjectStore {
             org_name: org.meta.name.clone(),
         };
 
-        self.db.put(NS_PROJ, &project.meta.id, &project).await?;
-        self.db.put(NS_PROJ_IDX, &idx_key, &project.meta.id).await?;
-        add_id(&self.db, &project.meta.id).await?;
+        let created_at_iso = epoch_to_iso8601(project.meta.created_at);
+        let updated_at_iso = epoch_to_iso8601(project.meta.updated_at);
+        let labels_json = serde_json::to_value(&project.meta.labels)
+            .map_err(|e| anyhow::anyhow!("serialise labels: {e}"))?;
+
+        let query_result = self
+            .db
+            .client()
+            .query(
+                "CREATE type::record($tbl, $id) SET \
+                 name = $name, \
+                 status = $status, \
+                 labels = $labels, \
+                 org = $org, \
+                 org_name = $org_name, \
+                 created_at = <datetime>$created_at, \
+                 updated_at = <datetime>$updated_at",
+            )
+            .bind(("tbl", PROJECT_TABLE))
+            .bind(("id", project.meta.id.clone()))
+            .bind(("name", project.meta.name.clone()))
+            .bind(("status", project.meta.status.clone()))
+            .bind(("labels", labels_json))
+            .bind(("org", project.org_id.as_str().to_string()))
+            .bind(("org_name", project.org_name.clone()))
+            .bind(("created_at", created_at_iso))
+            .bind(("updated_at", updated_at_iso))
+            .await;
+        let response = match query_result {
+            Ok(r) => r,
+            Err(e) => {
+                return Err(classify_create_error_with_org(
+                    name,
+                    org_name,
+                    &e.to_string(),
+                ))
+            }
+        };
+        if let Err(e) = response.check() {
+            return Err(classify_create_error_with_org(
+                name,
+                org_name,
+                &e.to_string(),
+            ));
+        }
 
         Ok(project)
     }
 
+    /// Look up a project by id (when the input looks like a
+    /// [`ProjectId`]) or by human name (otherwise).
+    ///
+    /// The id path is a direct record-id `SELECT`; the name path
+    /// requires `org_name` so the lookup goes through the composite
+    /// `(org, name)` index. Both paths return `Ok(None)` when no row
+    /// matches.
     pub async fn get(
         &self,
         name_or_id: &str,
         org_name: Option<&str>,
     ) -> anyhow::Result<Option<Project>> {
         if ProjectId::looks_like_id(name_or_id) {
-            return self.db.get(NS_PROJ, name_or_id).await.map_err(Into::into);
+            return self.get_by_id(name_or_id).await;
         }
 
         let org_name =
             org_name.ok_or_else(|| anyhow::anyhow!("--org required to resolve project by name"))?;
-        // P2.9 migration: see the comment in `create()`.
-        let org_store = crate::store::OrgStore::new(self.db.embedded().clone());
+
+        // Resolve the owning org so we can query by its record id via
+        // the composite `(org, name)` unique index.
+        let org_store = crate::store::OrgStore::new(self.db.clone());
         let org = org_store
             .get(org_name)
             .await?
             .ok_or_else(|| anyhow::anyhow!("org '{org_name}' not found"))?;
 
-        let idx_key = format!("{}/{}", org.meta.id, name_or_id);
-        let id: Option<String> = self.db.get(NS_PROJ_IDX, &idx_key).await?;
-        match id {
-            Some(id) => self.db.get(NS_PROJ, &id).await.map_err(Into::into),
-            None => Ok(None),
-        }
+        self.get_by_org_and_name(&org.meta.id, name_or_id).await
     }
 
+    async fn get_by_id(&self, id: &str) -> anyhow::Result<Option<Project>> {
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT * FROM type::record($tbl, $id)")
+            .bind(("tbl", PROJECT_TABLE))
+            .bind(("id", id.to_string()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let raw: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        decode_first(raw)
+    }
+
+    async fn get_by_org_and_name(
+        &self,
+        org_id: &str,
+        name: &str,
+    ) -> anyhow::Result<Option<Project>> {
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT * FROM project WHERE org = $org AND name = $name LIMIT 1")
+            .bind(("org", org_id.to_string()))
+            .bind(("name", name.to_string()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let raw: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        decode_first(raw)
+    }
+
+    /// List every project in the cluster, optionally filtered by the
+    /// owning org's human name (or id).
     pub async fn list(&self, org_name: Option<&str>) -> anyhow::Result<Vec<Project>> {
-        let ids = load_ids(&self.db).await?;
-        let mut projects = Vec::new();
-        for id in &ids {
-            if let Some(p) = self.db.get::<Project>(NS_PROJ, id).await? {
-                projects.push(p);
-            }
-        }
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT * FROM project")
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let raw: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        let projects: Vec<Project> = raw
+            .into_iter()
+            .filter_map(|v| {
+                serde_json::from_value::<ProjectRow>(v)
+                    .ok()
+                    .map(ProjectRow::into_project)
+            })
+            .collect();
 
         match org_name {
             Some(name) => Ok(projects
@@ -94,60 +229,355 @@ impl ProjectStore {
         }
     }
 
+    /// Delete a project by name or id. Refuses to delete a project
+    /// that still has any environment — the caller must remove the
+    /// children first.
     pub async fn delete(&self, name_or_id: &str, org_name: &str) -> anyhow::Result<()> {
         let project = self.get(name_or_id, Some(org_name)).await?.ok_or_else(|| {
             anyhow::anyhow!("project '{name_or_id}' not found in org '{org_name}'")
         })?;
 
-        let env_store = super::env::store::EnvStore::new(self.db.clone());
-        let envs = env_store
-            .list(Some(&project.meta.name), Some(org_name))
-            .await?;
-        if !envs.is_empty() {
+        // Refuse to delete a project that still owns environments. We
+        // query the SCHEMAFULL `env` table (from the P2.5 bundle,
+        // applied at bootstrap by `nauka_state::apply_cluster_schemas`)
+        // directly on the `project` column rather than constructing
+        // an `EnvStore` here — `EnvStore` still goes through the
+        // legacy raw-KV cluster wrapper (P2.11, sifrah/nauka#215
+        // migrates it), whose `data` wrapper column would collide
+        // with the SCHEMAFULL `env` table's declared fields once the
+        // schema bundle is in place. Querying by the owning
+        // `project` record-id keeps this path layer-clean and lets
+        // the same check work before and after P2.11 lands.
+        let remaining_envs = self.count_envs_in_project(&project.meta.id).await?;
+        if remaining_envs > 0 {
             anyhow::bail!(
                 "project '{}' has {} environment(s). Delete them first.",
                 project.meta.name,
-                envs.len()
+                remaining_envs
             );
         }
 
-        let idx_key = format!("{}/{}", project.org_id.as_str(), project.meta.name);
-        self.db.delete(NS_PROJ, &project.meta.id).await?;
-        self.db.delete(NS_PROJ_IDX, &idx_key).await?;
-        remove_id(&self.db, &project.meta.id).await?;
+        let result = self
+            .db
+            .client()
+            .query("DELETE type::record($tbl, $id)")
+            .bind(("tbl", PROJECT_TABLE))
+            .bind(("id", project.meta.id.clone()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        result.check().map_err(|e| anyhow::anyhow!("{e}"))?;
         Ok(())
     }
+
+    /// Count the environments currently owned by the project whose
+    /// record-id is `project_id`.
+    ///
+    /// Uses the SCHEMAFULL `env` table from the P2.5 bundle. The
+    /// table is created by `apply_cluster_schemas` at bootstrap, so a
+    /// freshly-bootstrapped database already has it.
+    async fn count_envs_in_project(&self, project_id: &str) -> anyhow::Result<usize> {
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT name FROM env WHERE project = $project")
+            .bind(("project", project_id.to_string()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let rows: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        Ok(rows.len())
+    }
 }
 
-async fn load_ids(db: &ClusterDb) -> anyhow::Result<Vec<String>> {
-    let keys = db.scan_keys(REG_V2_NS, REG_V2_PREFIX).await?;
-    let mut ids: Vec<String> = keys
-        .into_iter()
-        .filter_map(|k| k.strip_prefix(REG_V2_PREFIX).map(|s| s.to_string()))
-        .collect();
+/// Row shape returned by `SELECT * FROM project`. Same conversion
+/// pattern as [`crate::store::OrgStore`]'s `OrgRow`: SurrealDB hands
+/// the record id back as a typed `Thing` (table + id) which
+/// serde_json renders as one of several shapes; we bridge through
+/// `serde_json::Value` and pull the inner string out in
+/// [`ProjectRow::into_project`] via
+/// [`crate::sdk_bridge::thing_to_id_string`].
+#[derive(Debug, Deserialize)]
+struct ProjectRow {
+    id: serde_json::Value,
+    name: String,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    labels: Option<serde_json::Value>,
+    org: String,
+    org_name: String,
+    created_at: String,
+    updated_at: String,
+}
 
-    if let Some(v1_ids) = db.get::<Vec<String>>(REG_V1.0, REG_V1.1).await? {
-        for old_id in v1_ids {
-            if !ids.contains(&old_id) {
-                let key = format!("{REG_V2_PREFIX}{old_id}");
-                db.put(REG_V2_NS, &key, &true).await?;
-                ids.push(old_id);
-            }
+impl ProjectRow {
+    fn into_project(self) -> Project {
+        let id = thing_to_id_string("project:", &self.id);
+        let labels = self
+            .labels
+            .and_then(|v| serde_json::from_value(v).ok())
+            .unwrap_or_default();
+        Project {
+            meta: ResourceMeta {
+                id,
+                name: self.name,
+                status: self.status.unwrap_or_else(|| "active".to_string()),
+                labels,
+                created_at: iso8601_to_epoch(&self.created_at),
+                updated_at: iso8601_to_epoch(&self.updated_at),
+            },
+            org_id: OrgId::from(self.org),
+            org_name: self.org_name,
         }
-        db.delete(REG_V1.0, REG_V1.1).await?;
+    }
+}
+
+/// Deserialize the first row from a `SELECT` result set, returning
+/// `Ok(None)` when the set is empty.
+fn decode_first(raw: Vec<serde_json::Value>) -> anyhow::Result<Option<Project>> {
+    match raw.into_iter().next() {
+        None => Ok(None),
+        Some(v) => {
+            let row: ProjectRow = serde_json::from_value(v)
+                .map_err(|e| anyhow::anyhow!("deserialise project row: {e}"))?;
+            Ok(Some(row.into_project()))
+        }
+    }
+}
+
+/// Wrap [`crate::sdk_bridge::classify_create_error`] so the user-facing
+/// duplicate message includes the owning org. The composite unique
+/// index on `(org, name)` rejects `(org_a, "web")` + `(org_a, "web")`
+/// but allows `(org_a, "web")` + `(org_b, "web")`, so the error
+/// wording "project 'web' already exists in org 'acme'" is both
+/// accurate and matches the pre-P2.10 wording the CLI tests expect.
+fn classify_create_error_with_org(name: &str, org_name: &str, err_msg: &str) -> anyhow::Error {
+    let lowered = err_msg.to_lowercase();
+    if lowered.contains("already contains")
+        || lowered.contains("already exists")
+        || lowered.contains("duplicate")
+    {
+        anyhow::anyhow!("project '{name}' already exists in org '{org_name}'")
+    } else {
+        // Fall back to the shared helper for anything that isn't a
+        // duplicate — it preserves the raw error text.
+        classify_create_error("project", name, err_msg)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build an in-process `ProjectStore` backed by a fresh SurrealKV
+    /// datastore at a temporary path, with the cluster schema bundle
+    /// applied. Returns the tempdir guard, the store, and a ready-made
+    /// `OrgStore` over the same handle so individual tests can seed
+    /// the parent orgs they need.
+    async fn temp_store() -> (tempfile::TempDir, ProjectStore, crate::store::OrgStore) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = EmbeddedDb::open(&dir.path().join("projects.skv"))
+            .await
+            .expect("open EmbeddedDb at temp path");
+        nauka_state::apply_cluster_schemas(&db)
+            .await
+            .expect("apply cluster schemas");
+        let store = ProjectStore::new(db.clone());
+        let org_store = crate::store::OrgStore::new(db);
+        (dir, store, org_store)
     }
 
-    Ok(ids)
-}
+    #[tokio::test]
+    async fn create_then_get_by_name() {
+        let (_d, store, org_store) = temp_store().await;
+        org_store.create("acme").await.expect("create org");
 
-async fn add_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let key = format!("{REG_V2_PREFIX}{id}");
-    db.put(REG_V2_NS, &key, &true).await?;
-    Ok(())
-}
+        let project = store.create("web", "acme").await.expect("create project");
+        assert_eq!(project.meta.name, "web");
+        // `ProjectId`'s prefix is `proj`, not `project`; the SurrealDB
+        // record ends up at `project:proj-01J…` — the record-id table
+        // part is `project` (from `PROJECT_TABLE`), the record-id part
+        // is the ULID-prefixed `ProjectId`.
+        assert!(
+            project.meta.id.starts_with("proj-"),
+            "expected proj- prefix, got: {}",
+            project.meta.id
+        );
+        assert_eq!(project.org_name, "acme");
 
-async fn remove_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let key = format!("{REG_V2_PREFIX}{id}");
-    db.delete(REG_V2_NS, &key).await?;
-    Ok(())
+        let got = store
+            .get("web", Some("acme"))
+            .await
+            .expect("get by name")
+            .expect("missing");
+        assert_eq!(got.meta.id, project.meta.id);
+        assert_eq!(got.meta.name, "web");
+        assert_eq!(got.org_name, "acme");
+    }
+
+    #[tokio::test]
+    async fn create_then_get_by_id() {
+        let (_d, store, org_store) = temp_store().await;
+        org_store.create("acme").await.expect("create org");
+        let project = store.create("web", "acme").await.expect("create project");
+
+        let got = store
+            .get(&project.meta.id, None)
+            .await
+            .expect("get by id")
+            .expect("missing");
+        assert_eq!(got.meta.id, project.meta.id);
+        assert_eq!(got.meta.name, "web");
+    }
+
+    #[tokio::test]
+    async fn create_without_parent_org_errors() {
+        let (_d, store, _os) = temp_store().await;
+        let err = store
+            .create("web", "nonexistent")
+            .await
+            .expect_err("missing org should fail");
+        assert!(
+            err.to_string().contains("not found"),
+            "expected 'not found', got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn duplicate_name_in_same_org_is_rejected() {
+        let (_d, store, org_store) = temp_store().await;
+        org_store.create("acme").await.expect("create org");
+        store.create("web", "acme").await.expect("first create");
+
+        let err = store
+            .create("web", "acme")
+            .await
+            .expect_err("duplicate (org, name) should fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("already exists"),
+            "expected duplicate error, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn same_name_in_different_orgs_is_allowed() {
+        let (_d, store, org_store) = temp_store().await;
+        org_store.create("acme").await.expect("create acme");
+        org_store.create("globex").await.expect("create globex");
+
+        // Two orgs may both have a project called "web" — the unique
+        // index is on `(org, name)`, not just `name`.
+        store.create("web", "acme").await.expect("create acme/web");
+        store
+            .create("web", "globex")
+            .await
+            .expect("create globex/web");
+
+        // Fetching by (name, org) must find each one.
+        let acme_web = store
+            .get("web", Some("acme"))
+            .await
+            .expect("get acme/web")
+            .expect("missing acme/web");
+        let globex_web = store
+            .get("web", Some("globex"))
+            .await
+            .expect("get globex/web")
+            .expect("missing globex/web");
+        assert_ne!(acme_web.meta.id, globex_web.meta.id);
+        assert_eq!(acme_web.org_name, "acme");
+        assert_eq!(globex_web.org_name, "globex");
+    }
+
+    #[tokio::test]
+    async fn list_returns_all_projects() {
+        let (_d, store, org_store) = temp_store().await;
+        org_store.create("acme").await.expect("create acme");
+        org_store.create("globex").await.expect("create globex");
+        store.create("web", "acme").await.expect("create acme/web");
+        store.create("api", "acme").await.expect("create acme/api");
+        store
+            .create("web", "globex")
+            .await
+            .expect("create globex/web");
+
+        let all = store.list(None).await.expect("list all");
+        assert_eq!(all.len(), 3);
+
+        let acme_projects = store.list(Some("acme")).await.expect("list acme");
+        assert_eq!(acme_projects.len(), 2);
+        let mut names: Vec<&str> = acme_projects.iter().map(|p| p.meta.name.as_str()).collect();
+        names.sort();
+        assert_eq!(names, vec!["api", "web"]);
+    }
+
+    #[tokio::test]
+    async fn list_empty_returns_empty() {
+        let (_d, store, _os) = temp_store().await;
+        let all = store.list(None).await.expect("list");
+        assert!(all.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_missing_returns_none() {
+        let (_d, store, org_store) = temp_store().await;
+        org_store.create("acme").await.expect("create acme");
+        assert!(store
+            .get("does-not-exist", Some("acme"))
+            .await
+            .unwrap()
+            .is_none());
+        // `ProjectId::looks_like_id` checks for the `proj-` prefix.
+        assert!(store
+            .get("proj-01J00000000000000000000000", None)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_removes_project() {
+        let (_d, store, org_store) = temp_store().await;
+        org_store.create("acme").await.expect("create org");
+        store.create("web", "acme").await.expect("create project");
+
+        store.delete("web", "acme").await.expect("delete");
+        assert!(store.get("web", Some("acme")).await.unwrap().is_none());
+        assert!(store.list(None).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn delete_missing_project_errors() {
+        let (_d, store, org_store) = temp_store().await;
+        org_store.create("acme").await.expect("create org");
+        let err = store
+            .delete("does-not-exist", "acme")
+            .await
+            .expect_err("missing project should fail");
+        assert!(err.to_string().contains("not found"), "got: {err}");
+    }
+
+    /// Org delete is forbidden while a project still points at it —
+    /// mirrors the test under `OrgStore` but uses the real project
+    /// store to seed the child instead of a hand-crafted row.
+    #[tokio::test]
+    async fn org_delete_refuses_while_child_project_exists() {
+        let (_d, store, org_store) = temp_store().await;
+        org_store.create("acme").await.expect("create org");
+        store.create("web", "acme").await.expect("create project");
+
+        let err = org_store
+            .delete("acme")
+            .await
+            .expect_err("org delete should refuse while a project exists");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("project") && msg.contains("Delete them first"),
+            "expected 'has N project(s). Delete them first' message, got: {msg}",
+        );
+
+        // Removing the project unblocks the org delete.
+        store.delete("web", "acme").await.expect("delete project");
+        org_store.delete("acme").await.expect("delete org");
+    }
 }

--- a/layers/org/src/sdk_bridge.rs
+++ b/layers/org/src/sdk_bridge.rs
@@ -1,0 +1,253 @@
+//! Shared SurrealDB SDK → Rust bridge helpers used by the org-layer stores.
+//!
+//! Every store in this crate talks to the cluster database through the
+//! `EmbeddedDb::client()` SDK handle and the JSON-bridge pattern
+//! established by `nauka_hypervisor::fabric::state::FabricState::save`:
+//! write via an explicit `CREATE … SET …` statement, read via
+//! `SELECT * FROM …`, and bounce the row through `serde_json::Value` so
+//! the Rust side doesn't need a `surrealdb::types::SurrealValue` derive
+//! cascade over every resource type in the workspace.
+//!
+//! The helpers in this module are the small amount of glue every store
+//! needs for that pattern:
+//!
+//! - [`thing_to_id_string`] extracts the bare `<table>-<ulid>` id from
+//!   the `Thing` value that SurrealDB hands back on `SELECT`.
+//! - [`iso8601_to_epoch`] parses the RFC 3339 `datetime` strings that
+//!   SurrealDB emits back into the `u64` Unix-epoch seconds that
+//!   [`nauka_core::resource::ResourceMeta`] carries.
+//! - [`classify_create_error`] maps a surrealdb-side "unique index
+//!   already contains …" error into a human-friendly
+//!   `"<kind> '<name>' already exists"` flat `anyhow::Error` so every
+//!   store produces the same CLI-facing message shape.
+//!
+//! P2.9 (sifrah/nauka#213) introduced the first copies of these helpers
+//! inline in `crate::store` (the org store). P2.10 (sifrah/nauka#214)
+//! extracted them here so the newly-migrated project store can reuse
+//! them without drift.
+
+/// Pull the bare id string out of a SurrealDB `Thing` rendered as
+/// `serde_json::Value`.
+///
+/// SurrealDB JSON-encodes a `Thing` as one of several shapes depending
+/// on the SDK version and the variant of the inner id:
+///
+/// 1. `"org:01J…"` or `` "org:`01J…`" `` — a flat string when the id
+///    round-tripped through a SurrealQL response that was already
+///    strings-only. SurrealDB wraps the id in backticks when the raw
+///    id contains any character outside the unquoted-identifier set
+///    (the `-` in our `org-<ulid>` form is the usual culprit).
+/// 2. `{"tb": "org", "id": "01J…"}` — the structured form for a
+///    `String` id.
+/// 3. `{"tb": "org", "id": {"String": "01J…"}}` — the structured form
+///    when SurrealDB tagged the id variant explicitly.
+///
+/// `table_prefix` is the `"<table>:"` string used by Shape 1. For the
+/// org store pass `"org:"`, for the project store `"project:"`, and so
+/// on.
+///
+/// Always returns the bare `<table>-<ulid>` id (without the `tb:`
+/// prefix or any wrapping backticks) because that's what the rest of
+/// Nauka has been carrying around as `ResourceMeta::id` since day one.
+pub(crate) fn thing_to_id_string(table_prefix: &str, value: &serde_json::Value) -> String {
+    let trim_backticks = |s: &str| s.trim_start_matches('`').trim_end_matches('`').to_string();
+
+    if let Some(s) = value.as_str() {
+        // Shape 1: flat "org:01J…" string. Strip the "<table>:" prefix
+        // if present so the result matches the legacy `<kind>-<ulid>`
+        // form, then strip any wrapping backticks SurrealDB added
+        // because the id contains a hyphen.
+        let without_prefix = s.strip_prefix(table_prefix).unwrap_or(s);
+        return trim_backticks(without_prefix);
+    }
+    if let Some(obj) = value.as_object() {
+        // Shapes 2 and 3 carry the id under the `id` key. Shape 3
+        // wraps the inner id under `String`.
+        if let Some(inner) = obj.get("id") {
+            if let Some(s) = inner.as_str() {
+                return trim_backticks(s);
+            }
+            if let Some(inner_obj) = inner.as_object() {
+                if let Some(s) = inner_obj.get("String").and_then(|v| v.as_str()) {
+                    return trim_backticks(s);
+                }
+            }
+        }
+    }
+    // Fallback: dump the JSON form so the caller at least sees what
+    // SurrealDB actually returned. The `{}` Display for serde_json::Value
+    // is the JSON encoding.
+    value.to_string()
+}
+
+/// Parse an ISO 8601 / RFC 3339 datetime back into Unix-epoch seconds.
+///
+/// SurrealDB renders `datetime` values as strings like
+/// `2024-01-02T03:04:05.123456Z`; we round down to whole seconds
+/// because [`nauka_core::resource::ResourceMeta::created_at`] is a
+/// `u64` with second granularity. Any parse failure (e.g. an
+/// unexpected timezone offset) returns `0` so the caller still gets a
+/// value back — the alternative would be to fail a whole list/get path
+/// on a single malformed row, which is strictly worse for operators
+/// trying to clean up bad data.
+pub(crate) fn iso8601_to_epoch(s: &str) -> u64 {
+    // Stripped-down parser: YYYY-MM-DDTHH:MM:SS… — accepts a trailing
+    // `Z`, an optional fractional seconds part, and an optional
+    // timezone offset (which we ignore — the only writers are the
+    // org-layer stores, and they always emit `Z`).
+    let bytes = s.as_bytes();
+    if bytes.len() < 19 {
+        return 0;
+    }
+    let year: i64 = std::str::from_utf8(&bytes[0..4])
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let month: i64 = std::str::from_utf8(&bytes[5..7])
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let day: i64 = std::str::from_utf8(&bytes[8..10])
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let hour: i64 = std::str::from_utf8(&bytes[11..13])
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let minute: i64 = std::str::from_utf8(&bytes[14..16])
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let second: i64 = std::str::from_utf8(&bytes[17..19])
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let days = days_from_civil(year, month, day);
+    let total = days * 86400 + hour * 3600 + minute * 60 + second;
+    if total < 0 {
+        0
+    } else {
+        total as u64
+    }
+}
+
+/// Howard Hinnant's "days from civil" algorithm — converts a
+/// `(year, month, day)` triple to a count of days since 1970-01-01.
+///
+/// Lifted directly from the public-domain reference implementation
+/// (<https://howardhinnant.github.io/date_algorithms.html#days_from_civil>).
+/// We use it instead of a `chrono` / `time` dependency to keep
+/// `nauka-org` build-time small and to mirror the existing date math
+/// already in `nauka_core::resource::api_response::days_to_date`, which
+/// goes the other direction.
+fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146097 + doe - 719468
+}
+
+/// Map a SurrealDB error message from a `CREATE` into a flat
+/// `anyhow::Error` with a human-friendly message.
+///
+/// Each cluster-state store has a unique index on its natural key
+/// (e.g. `org_name`, `project_org_name`) that surfaces duplicate
+/// inserts as `surrealdb::Error::already_exists`, whose `Display`
+/// rendering includes the phrase "already contains" (the substring is
+/// stable across surrealdb-types releases and is what the
+/// `From<surrealdb::Error>` impl in `nauka_state::lib.rs` documents as
+/// the `is_already_exists()` signal). We key on that substring rather
+/// than re-introducing a direct `surrealdb` dependency in this crate,
+/// so duplicate-name conflicts still surface as the same
+/// `<kind> '<name>' already exists` wording every store returned
+/// before the SurrealDB migration — CLI error-message tests downstream
+/// keep passing without edits.
+///
+/// `kind` is the resource noun used in the message (`"org"`,
+/// `"project"`, `"environment"`, …). `name` is the human-readable name
+/// that was rejected. Everything else collapses to the underlying
+/// error text verbatim.
+pub(crate) fn classify_create_error(kind: &str, name: &str, err_msg: &str) -> anyhow::Error {
+    let lowered = err_msg.to_lowercase();
+    if lowered.contains("already contains")
+        || lowered.contains("already exists")
+        || lowered.contains("duplicate")
+    {
+        anyhow::anyhow!("{kind} '{name}' already exists")
+    } else {
+        anyhow::anyhow!("{err_msg}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nauka_core::resource::epoch_to_iso8601;
+
+    #[test]
+    fn thing_to_id_string_flat_string_with_prefix() {
+        let v = serde_json::Value::String("org:org-01J00000000000000000000000".into());
+        assert_eq!(
+            thing_to_id_string("org:", &v),
+            "org-01J00000000000000000000000"
+        );
+    }
+
+    #[test]
+    fn thing_to_id_string_flat_string_with_backticks() {
+        let v = serde_json::Value::String("org:`org-01J00000000000000000000000`".into());
+        assert_eq!(
+            thing_to_id_string("org:", &v),
+            "org-01J00000000000000000000000"
+        );
+    }
+
+    #[test]
+    fn thing_to_id_string_structured_string_variant() {
+        let v = serde_json::json!({ "tb": "project", "id": "project-01J…" });
+        assert_eq!(thing_to_id_string("project:", &v), "project-01J…");
+    }
+
+    #[test]
+    fn thing_to_id_string_structured_tagged_string() {
+        let v = serde_json::json!({
+            "tb": "project",
+            "id": { "String": "project-01J…" }
+        });
+        assert_eq!(thing_to_id_string("project:", &v), "project-01J…");
+    }
+
+    #[test]
+    fn iso8601_round_trip_matches_epoch() {
+        for &epoch in &[0u64, 1, 86_399, 86_400, 1_700_000_000, 1_775_665_838] {
+            let iso = epoch_to_iso8601(epoch);
+            let back = iso8601_to_epoch(&iso);
+            assert_eq!(back, epoch, "round trip failed for {epoch}: iso={iso}");
+        }
+    }
+
+    #[test]
+    fn iso8601_too_short_returns_zero() {
+        assert_eq!(iso8601_to_epoch("2024"), 0);
+        assert_eq!(iso8601_to_epoch(""), 0);
+    }
+
+    #[test]
+    fn classify_create_error_detects_duplicate() {
+        let err = classify_create_error(
+            "project",
+            "web",
+            "database contains already contains an entry for `web`",
+        );
+        assert_eq!(err.to_string(), "project 'web' already exists");
+    }
+
+    #[test]
+    fn classify_create_error_passes_through_unrelated() {
+        let err = classify_create_error("project", "web", "disk full");
+        assert_eq!(err.to_string(), "disk full");
+    }
+}

--- a/layers/org/src/store.rs
+++ b/layers/org/src/store.rs
@@ -44,6 +44,7 @@ use nauka_core::resource::ResourceMeta;
 use nauka_state::EmbeddedDb;
 use serde::Deserialize;
 
+use crate::sdk_bridge::{classify_create_error, iso8601_to_epoch, thing_to_id_string};
 use crate::types::Org;
 
 /// SurrealDB table backing this store. Defined in
@@ -117,10 +118,10 @@ impl OrgStore {
             .await;
         let response = match query_result {
             Ok(r) => r,
-            Err(e) => return Err(classify_create_error(name, &e.to_string())),
+            Err(e) => return Err(classify_create_error("org", name, &e.to_string())),
         };
         if let Err(e) = response.check() {
-            return Err(classify_create_error(name, &e.to_string()));
+            return Err(classify_create_error("org", name, &e.to_string()));
         }
 
         Ok(org)
@@ -218,17 +219,16 @@ impl OrgStore {
             .await?
             .ok_or_else(|| anyhow::anyhow!("org '{name_or_id}' not found"))?;
 
-        // Refuse to delete an org that still has projects. The project
-        // store still speaks the legacy raw-KV surface on top of the
-        // same `EmbeddedDb` (P2.10 sifrah/nauka#214 migrates it), so
-        // every project row lives in the `_kv_proj` SCHEMALESS table
-        // as `{ key: <id>, data: <project-json> }`. We count the rows
-        // whose `data.org_name` matches the target org directly via
-        // SurrealQL so this store doesn't need to import `ProjectStore`
-        // (and therefore doesn't need to import the legacy cluster-DB
-        // wrapper type to build one). Once P2.10 lands the query
-        // simplifies to `SELECT count() FROM project WHERE org = $id`.
-        let remaining_projects = self.count_projects_in_org(&org.meta.name).await?;
+        // Refuse to delete an org that still has projects. P2.10
+        // (sifrah/nauka#214) migrated the project store to the native
+        // SurrealDB SDK on top of the SCHEMAFULL `project` table, so
+        // we can count the surviving children with a direct query on
+        // the owning-org id. This store still doesn't import
+        // `ProjectStore` because that would force a circular module
+        // dependency (`ProjectStore::delete` reaches back into
+        // `OrgStore::get` to resolve the parent org) — the inline
+        // query is cheaper.
+        let remaining_projects = self.count_projects_in_org(&org.meta.id).await?;
         if remaining_projects > 0 {
             anyhow::bail!(
                 "org '{}' has {} project(s). Delete them first.",
@@ -249,40 +249,26 @@ impl OrgStore {
         Ok(())
     }
 
-    /// Count the projects currently owned by the org whose
-    /// human-readable name is `org_name`.
+    /// Count the projects currently owned by the org whose record-id
+    /// is `org_id`.
     ///
-    /// Queries the transitional `_kv_proj` SCHEMALESS table (written by
-    /// the legacy project store that is still on the raw-KV surface)
-    /// directly, rather than constructing a `ProjectStore` from a
-    /// cluster-DB wrapper. The table is created via `DEFINE TABLE IF
-    /// NOT EXISTS` so a fresh database (no projects ever written)
-    /// returns zero rows instead of "table does not exist". P2.10
-    /// (sifrah/nauka#214) migrates the project store to a SCHEMAFULL
-    /// `project` table, at which point the query target changes to
-    /// `project` and this helper goes away.
-    async fn count_projects_in_org(&self, org_name: &str) -> anyhow::Result<usize> {
-        // Make sure the legacy `_kv_proj` table exists so the SELECT
-        // below doesn't error on a fresh database. SurrealDB raises
-        // "table does not exist" otherwise; the `IF NOT EXISTS` guard
-        // makes this idempotent.
-        self.db
-            .client()
-            .query("DEFINE TABLE IF NOT EXISTS _kv_proj SCHEMALESS")
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?
-            .check()
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-
+    /// Uses the SCHEMAFULL `project` table that P2.10 migrated to, so
+    /// the query is a single `SELECT name FROM project WHERE org =
+    /// $org`. The `project` table is defined by
+    /// `nauka_state::apply_cluster_schemas` at bootstrap, so a fresh
+    /// database already has the table — no `DEFINE TABLE IF NOT
+    /// EXISTS` dance is needed. If the schema hasn't been applied at
+    /// all (e.g. a pre-bootstrap sanity test), the SurrealDB error
+    /// bubbles up as an `anyhow::Error` and the caller surfaces it.
+    async fn count_projects_in_org(&self, org_id: &str) -> anyhow::Result<usize> {
         let mut response = self
             .db
             .client()
-            .query("SELECT data FROM _kv_proj WHERE data.org_name = $org_name")
-            .bind(("org_name", org_name.to_string()))
+            .query("SELECT name FROM project WHERE org = $org")
+            .bind(("org", org_id.to_string()))
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;
-        let rows: Vec<serde_json::Value> =
-            response.take("data").map_err(|e| anyhow::anyhow!("{e}"))?;
+        let rows: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
         Ok(rows.len())
     }
 }
@@ -313,7 +299,7 @@ struct OrgRow {
 
 impl OrgRow {
     fn into_org(self) -> Org {
-        let id = thing_to_id_string(&self.id);
+        let id = thing_to_id_string("org:", &self.id);
         let labels = self
             .labels
             .and_then(|v| serde_json::from_value(v).ok())
@@ -328,153 +314,6 @@ impl OrgRow {
                 updated_at: iso8601_to_epoch(&self.updated_at),
             },
         }
-    }
-}
-
-/// Pull the inner id string out of a SurrealDB `Thing` rendered as
-/// `serde_json::Value`.
-///
-/// SurrealDB JSON-encodes a `Thing` as one of several shapes depending
-/// on the SDK version and the variant of the inner id:
-///
-/// 1. `"org:01J…"` or `` "org:`01J…`" `` — a flat string when the id
-///    round-tripped through a SurrealQL response that was already
-///    strings-only. SurrealDB wraps the id in backticks when the raw
-///    id contains any character outside the unquoted-identifier set
-///    (`-` in our `org-<ulid>` form is the usual culprit).
-/// 2. `{"tb": "org", "id": "01J…"}` — the structured form for a
-///    `String` id.
-/// 3. `{"tb": "org", "id": {"String": "01J…"}}` — the structured form
-///    when SurrealDB tagged the id variant explicitly.
-///
-/// We accept all three and always return the bare `org-<ulid>` form
-/// (without the `tb:` prefix or any wrapping backticks) because that's
-/// what the rest of Nauka has been carrying around as `Org::meta::id`
-/// since day one.
-fn thing_to_id_string(value: &serde_json::Value) -> String {
-    let trim_backticks = |s: &str| s.trim_start_matches('`').trim_end_matches('`').to_string();
-
-    if let Some(s) = value.as_str() {
-        // Shape 1: flat "org:01J…" string. Strip the `org:` prefix if
-        // present so the result matches the legacy `org-<ulid>` form,
-        // then strip any wrapping backticks that SurrealDB added
-        // because the id contains a hyphen.
-        let without_prefix = s.strip_prefix("org:").unwrap_or(s);
-        return trim_backticks(without_prefix);
-    }
-    if let Some(obj) = value.as_object() {
-        // Shapes 2 and 3 carry the id under the `id` key. Shape 3
-        // wraps the inner id under `String`.
-        if let Some(inner) = obj.get("id") {
-            if let Some(s) = inner.as_str() {
-                return trim_backticks(s);
-            }
-            if let Some(inner_obj) = inner.as_object() {
-                if let Some(s) = inner_obj.get("String").and_then(|v| v.as_str()) {
-                    return trim_backticks(s);
-                }
-            }
-        }
-    }
-    // Fallback: dump the JSON form so the caller at least sees what
-    // SurrealDB actually returned. The `{}` Display for serde_json::Value
-    // is the JSON encoding.
-    value.to_string()
-}
-
-/// Parse an ISO 8601 / RFC 3339 datetime back into Unix-epoch seconds.
-///
-/// SurrealDB renders `datetime` values as strings like
-/// `2024-01-02T03:04:05.123456Z`; we round down to whole seconds because
-/// `ResourceMeta::created_at` is a `u64` with second granularity. Any
-/// parse failure (e.g. an unexpected timezone offset) returns `0` so
-/// the caller still gets a value back — the alternative would be to
-/// fail the whole list/get path on a single malformed row, which is
-/// strictly worse for operators trying to clean up bad data.
-fn iso8601_to_epoch(s: &str) -> u64 {
-    // Stripped-down parser: YYYY-MM-DDTHH:MM:SS… — accepts a trailing
-    // `Z`, an optional fractional seconds part, and an optional
-    // timezone offset (which we ignore — the only writer is
-    // `OrgStore::create` and it always emits `Z`).
-    let bytes = s.as_bytes();
-    if bytes.len() < 19 {
-        return 0;
-    }
-    let year: i64 = std::str::from_utf8(&bytes[0..4])
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
-    let month: i64 = std::str::from_utf8(&bytes[5..7])
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
-    let day: i64 = std::str::from_utf8(&bytes[8..10])
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
-    let hour: i64 = std::str::from_utf8(&bytes[11..13])
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
-    let minute: i64 = std::str::from_utf8(&bytes[14..16])
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
-    let second: i64 = std::str::from_utf8(&bytes[17..19])
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
-    let days = days_from_civil(year, month, day);
-    let total = days * 86400 + hour * 3600 + minute * 60 + second;
-    if total < 0 {
-        0
-    } else {
-        total as u64
-    }
-}
-
-/// Howard Hinnant's "days from civil" algorithm — converts a
-/// `(year, month, day)` triple to a count of days since 1970-01-01.
-///
-/// Lifted directly from the public-domain reference implementation
-/// (<https://howardhinnant.github.io/date_algorithms.html#days_from_civil>).
-/// We use it instead of a `chrono` / `time` dependency to keep
-/// `nauka-org` build-time small and to mirror the existing date math
-/// already in `nauka_core::resource::api_response::days_to_date`, which
-/// goes the other direction.
-fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
-    let y = if m <= 2 { y - 1 } else { y };
-    let era = if y >= 0 { y } else { y - 399 } / 400;
-    let yoe = y - era * 400;
-    let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1;
-    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
-    era * 146097 + doe - 719468
-}
-
-/// Map a SurrealDB error message from `OrgStore::create` into a flat
-/// `anyhow::Error` with a human-friendly message.
-///
-/// The schema's `org_name UNIQUE` index surfaces duplicate names as
-/// `surrealdb::Error::already_exists`, whose `Display` rendering
-/// includes the phrase "already contains" (the substring is stable
-/// across surrealdb-types releases and is what the existing
-/// `From<surrealdb::Error>` impl in `nauka_state::lib.rs` documents as
-/// the `is_already_exists()` signal). We key on that substring rather
-/// than re-introducing a direct `surrealdb` dependency in this crate,
-/// so duplicate-name conflicts still surface as the same
-/// `org '<name>' already exists` message the pre-P2.9 "check then
-/// insert" path returned — and so existing CLI error-message tests
-/// downstream keep passing. Everything else collapses to the
-/// underlying error text verbatim.
-fn classify_create_error(name: &str, err_msg: &str) -> anyhow::Error {
-    let lowered = err_msg.to_lowercase();
-    if lowered.contains("already contains")
-        || lowered.contains("already exists")
-        || lowered.contains("duplicate")
-    {
-        anyhow::anyhow!("org '{name}' already exists")
-    } else {
-        anyhow::anyhow!("{err_msg}")
     }
 }
 
@@ -602,46 +441,43 @@ mod tests {
     }
 
     /// Delete refuses to drop an org that still has a project pointing
-    /// at it via the legacy `_kv_proj` key/value rows.
+    /// at it.
     ///
-    /// We seed the legacy table directly with a row that mimics the
-    /// shape `ProjectStore::create` produces (`{ key: <id>, data: {
-    /// org_name, ... } }`) so the test stays self-contained — it
-    /// doesn't pull in `ProjectStore` (which still goes through the
-    /// legacy cluster-DB wrapper API and would force an awkward
-    /// import dance into this file).
+    /// We seed the SCHEMAFULL `project` table directly (via a `CREATE`
+    /// bypassing `ProjectStore::create`) so this test stays
+    /// self-contained — it doesn't pull in `ProjectStore`, which
+    /// reaches back into `OrgStore::get` to resolve the parent org
+    /// and would force a circular import dance into this file.
     #[tokio::test]
     async fn delete_refuses_when_project_remains() {
         let (_d, store) = temp_store().await;
-        store.create("acme").await.expect("create org");
+        let org = store.create("acme").await.expect("create org");
 
-        // Seed a fake `_kv_proj` row that mirrors the JSON shape the
-        // legacy `ProjectStore::create` writes.
+        // Seed a `project` row directly. The SCHEMAFULL `project`
+        // table is created by `apply_cluster_schemas` in `temp_store`,
+        // so every column has to be populated to satisfy the ASSERT
+        // constraints.
         store
             .db
             .client()
-            .query("DEFINE TABLE IF NOT EXISTS _kv_proj SCHEMALESS")
-            .await
-            .expect("define _kv_proj")
-            .check()
-            .expect("define _kv_proj check");
-        let row_data = serde_json::json!({
-            "id": "proj-fake",
-            "name": "fakeproj",
-            "org_name": "acme",
-        });
-        store
-            .db
-            .client()
-            .query("UPSERT type::record('_kv_proj', 'proj-fake') CONTENT { key: 'proj-fake', data: $data }")
-            .bind(("data", row_data))
+            .query(
+                "CREATE type::record('project', 'project-fake') SET \
+                 name = 'fakeproj', \
+                 status = 'active', \
+                 labels = {}, \
+                 org = $org, \
+                 org_name = 'acme', \
+                 created_at = time::now(), \
+                 updated_at = time::now()",
+            )
+            .bind(("org", org.meta.id.clone()))
             .await
             .expect("seed project row")
             .check()
             .expect("seed project row check");
 
         // Now `delete` should refuse the org — there's a project still
-        // pointing at it via `data.org_name = "acme"`.
+        // pointing at it via `org = <org.meta.id>`.
         let err = store
             .delete("acme")
             .await
@@ -655,18 +491,5 @@ mod tests {
         // The org is still there — the failed delete must not have
         // removed it as a side-effect.
         assert!(store.get("acme").await.unwrap().is_some());
-    }
-
-    #[test]
-    fn iso8601_round_trip_matches_epoch() {
-        // Sanity check the helper pair: epoch → iso → epoch must round
-        // trip exactly. The helper uses second granularity, so any
-        // sub-second part would be lost — but `ResourceMeta::created_at`
-        // is itself second-granularity, so this is the right contract.
-        for &epoch in &[0u64, 1, 86_399, 86_400, 1_700_000_000, 1_775_665_838] {
-            let iso = epoch_to_iso8601(epoch);
-            let back = iso8601_to_epoch(&iso);
-            assert_eq!(back, epoch, "round trip failed for {epoch}: iso={iso}");
-        }
     }
 }


### PR DESCRIPTION
## Summary

Closes sifrah/nauka#214. Epic: sifrah/nauka#183.

Replaces the raw-KV cluster path in `layers/org/src/project/store.rs` with direct SurrealDB SDK calls against the SCHEMAFULL `project` table shipped by P2.5. Project CRUD now flows through `self.db.client().query(...)` with explicit column binds; the previous `proj` / `proj-idx` / `_reg_v2` sidecar namespaces are retired now that the schema's composite unique index on `(org, name)` enforces "no duplicate project name within a single org" at the database level.

## Shared bridge helpers

A new `layers/org/src/sdk_bridge.rs` module extracts the JSON-bridge helpers that P2.9 originally inlined in `OrgStore`:

- `thing_to_id_string(table_prefix: &str, value: &Value)` — now takes the table prefix (`"org:"`, `"project:"`, ...) as a parameter so both stores reuse the same record-id extraction code.
- `iso8601_to_epoch` + private `days_from_civil` — SurrealDB `datetime` → Unix epoch, unchanged.
- `classify_create_error(kind, name, err_msg)` — now takes the resource noun as a parameter so the duplicate-name wording matches whichever store threw it.

Both `OrgStore` (P2.9) and `ProjectStore` now share exactly this one set of helpers. No drift between the two.

## Store shape

`ProjectStore::new` takes an `EmbeddedDb` directly, same as the post-P2.9 `OrgStore::new`. The three in-tree call sites thread through `cluster_db.embedded().clone()`:

- `layers/org/src/project/handlers.rs` — the CLI handler for `nauka org project <op>`
- `layers/org/src/project/env/store.rs` — `EnvStore::create` / `EnvStore::get` resolve the parent project
- `layers/compute/src/vm/store.rs` — `VmStore::create` resolves `org → project → env`

The clone is cheap (`Arc`-shared `Surreal<Db>` router).

## `ProjectStore::delete` → inline env count

The previous path built an `EnvStore` and called `list` on it. That worked against a raw-KV backend, but once the P2.5 schema bundle is applied at bootstrap the SCHEMAFULL `env` table's declared columns collide with the legacy wrapper's catch-all `data` column. The inline query `SELECT name FROM env WHERE project = $project` works both before and after P2.11 (sifrah/nauka#215) migrates the env store — no environment-store dependency needed, and the check stays correct through the migration window.

## Drive-by fix: `OrgStore::count_projects_in_org`

P2.9's version queried a fictional `_kv_proj` SCHEMALESS table (created only by the test fixture, never written to in production), so in real use it always returned zero. P2.10 switches it to query the SCHEMAFULL `project` table directly on the owning-org id. The `delete_refuses_when_project_remains` test now seeds a real `project` row via `CREATE type::record('project', 'project-fake') SET ...` instead of the old `_kv_proj` fake — the check exercises the production path.

## Acceptance criteria (sifrah/nauka#214) — all met

- [x] All project store methods use the SurrealDB SDK
- [x] Existing project tests pass: **11 new project tests** + 10 org tests + 7 `sdk_bridge` tests = **28 nauka-org tests green** (up from 10 in main)
- [x] `grep "ClusterDb" layers/org/src/project/store.rs` → **zero hits**

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p nauka-org` → 28 pass
- [x] `cargo test --workspace -- --test-threads=1` → every crate green (pre-existing macOS `doctor::tests::disk_free_check` failure unrelated; tracked separately)
- [x] Cross-compile `x86_64-unknown-linux-musl --release` — clean

## Files touched

| File | Change |
|------|--------|
| `layers/org/src/sdk_bridge.rs` | **new** — shared SurrealDB JSON-bridge helpers |
| `layers/org/src/lib.rs` | declare `mod sdk_bridge` |
| `layers/org/src/project/store.rs` | full rewrite (153 → ~560 lines including tests) |
| `layers/org/src/store.rs` | drop duplicated helpers, fix `count_projects_in_org` query, update `classify_create_error` call sites |
| `layers/org/src/project/handlers.rs` | CLI handler call-site update |
| `layers/org/src/project/env/store.rs` | call-site updates (2×) |
| `layers/compute/src/vm/store.rs` | call-site update |

**7 files changed, +824 / -304**.