### PR TITLE
feat(P2.12): migrate layers/network to native SurrealDB SDK

### DIFF
--- a/layers/compute/src/vm/store.rs
+++ b/layers/compute/src/vm/store.rs
@@ -70,14 +70,17 @@ impl VmStore {
                 anyhow::anyhow!("environment '{env_name}' not found in project '{project_name}'")
             })?;
 
-        // Resolve vpc -> subnet
-        let vpc_store = nauka_network::vpc::store::VpcStore::new(self.db.clone());
+        // Resolve vpc -> subnet. P2.12 (sifrah/nauka#216) migrated
+        // both stores to take an `EmbeddedDb` directly; reach the
+        // inner handle via `ClusterDb::embedded().clone()`.
+        let vpc_store = nauka_network::vpc::store::VpcStore::new(self.db.embedded().clone());
         let vpc = vpc_store
             .get(vpc_name, Some(org_name))
             .await?
             .ok_or_else(|| anyhow::anyhow!("vpc '{vpc_name}' not found"))?;
 
-        let sub_store = nauka_network::vpc::subnet::store::SubnetStore::new(self.db.clone());
+        let sub_store =
+            nauka_network::vpc::subnet::store::SubnetStore::new(self.db.embedded().clone());
         let subnet = sub_store
             .get(subnet_name, Some(vpc_name), Some(org_name))
             .await?
@@ -95,9 +98,11 @@ impl VmStore {
         // Generate VM ID first — needed for IPAM allocation
         let vm_id = VmId::generate().to_string();
 
-        // Allocate private IP from subnet IPAM
+        // Allocate private IP from subnet IPAM. P2.12 (sifrah/nauka#216)
+        // migrated the IPAM helper to take an `EmbeddedDb`; reach it
+        // via `ClusterDb::embedded()`.
         let private_ip = nauka_network::vpc::subnet::ipam::allocate(
-            &self.db,
+            self.db.embedded(),
             &subnet.meta.id,
             &subnet.cidr,
             &subnet.gateway,
@@ -251,9 +256,14 @@ impl VmStore {
             );
         }
 
-        // Release IPAM allocation
-        nauka_network::vpc::subnet::ipam::release(&self.db, vm.subnet_id.as_str(), &vm.meta.id)
-            .await?;
+        // Release IPAM allocation. P2.12 migrated the helper to take
+        // an `EmbeddedDb` directly.
+        nauka_network::vpc::subnet::ipam::release(
+            self.db.embedded(),
+            vm.subnet_id.as_str(),
+            &vm.meta.id,
+        )
+        .await?;
 
         let idx_key = format!("{}/{}", vm.env_id.as_str(), vm.meta.name);
         self.db.delete(NS_VM, &vm.meta.id).await?;

--- a/layers/forge/src/reconciler/natgw.rs
+++ b/layers/forge/src/reconciler/natgw.rs
@@ -18,7 +18,7 @@ impl super::Reconciler for NatGwReconciler {
     async fn reconcile(&self, ctx: &ReconcileContext) -> anyhow::Result<ReconcileResult> {
         let mut result = ReconcileResult::new("natgw");
 
-        let store = NatGwStore::new(ctx.db.clone());
+        let store = NatGwStore::new(ctx.db.embedded().clone());
         let all_natgws = store.list(None).await?;
 
         // Filter NAT gateways assigned to this node
@@ -39,7 +39,7 @@ impl super::Reconciler for NatGwReconciler {
         // Ensure each NAT GW is provisioned
         for natgw in &local_natgws {
             // Resolve VPC VNI
-            let vpc_store = nauka_network::vpc::store::VpcStore::new(ctx.db.clone());
+            let vpc_store = nauka_network::vpc::store::VpcStore::new(ctx.db.embedded().clone());
             let vpc = match vpc_store.get(natgw.vpc_id.as_str(), None).await? {
                 Some(v) => v,
                 None => {

--- a/layers/forge/src/reconciler/vm.rs
+++ b/layers/forge/src/reconciler/vm.rs
@@ -147,15 +147,20 @@ impl super::Reconciler for VmReconciler {
                             let ip = vm.private_ip.as_deref().unwrap_or("0.0.0.0");
                             let mac =
                                 nauka_network::vpc::provision::mac_from_ip(ip).unwrap_or_default();
-                            let subnet_store =
-                                nauka_network::vpc::subnet::store::SubnetStore::new(ctx.db.clone());
+                            // P2.12 (sifrah/nauka#216): the VPC and
+                            // subnet stores take an `EmbeddedDb`
+                            // directly now; reach the inner handle
+                            // via `ClusterDb::embedded().clone()`.
+                            let subnet_store = nauka_network::vpc::subnet::store::SubnetStore::new(
+                                ctx.db.embedded().clone(),
+                            );
                             let gateway = subnet_store
                                 .get(vm.subnet_id.as_str(), None, None)
                                 .await?
                                 .map(|s| s.gateway.clone())
                                 .unwrap_or_else(|| "0.0.0.0".to_string());
                             let vpc_store =
-                                nauka_network::vpc::store::VpcStore::new(ctx.db.clone());
+                                nauka_network::vpc::store::VpcStore::new(ctx.db.embedded().clone());
                             let vpc_cidr = vpc_store
                                 .get(vm.vpc_id.as_str(), None)
                                 .await?
@@ -235,14 +240,16 @@ impl super::Reconciler for VmReconciler {
                         let has_tini = std::path::Path::new(&rootfs_dir)
                             .join("usr/bin/tini")
                             .exists();
-                        let subnet_store =
-                            nauka_network::vpc::subnet::store::SubnetStore::new(ctx.db.clone());
+                        let subnet_store = nauka_network::vpc::subnet::store::SubnetStore::new(
+                            ctx.db.embedded().clone(),
+                        );
                         let subnet = subnet_store.get(vm.subnet_id.as_str(), None, None).await?;
                         let (gateway, cidr) = match &subnet {
                             Some(s) => (s.gateway.clone(), s.cidr.clone()),
                             None => ("0.0.0.0".to_string(), "0.0.0.0/0".to_string()),
                         };
-                        let vpc_store = nauka_network::vpc::store::VpcStore::new(ctx.db.clone());
+                        let vpc_store =
+                            nauka_network::vpc::store::VpcStore::new(ctx.db.embedded().clone());
                         let vpc_cidr = vpc_store
                             .get(vm.vpc_id.as_str(), None)
                             .await?
@@ -338,7 +345,7 @@ impl super::Reconciler for VmReconciler {
                 }
 
                 let subnet_store =
-                    nauka_network::vpc::subnet::store::SubnetStore::new(ctx.db.clone());
+                    nauka_network::vpc::subnet::store::SubnetStore::new(ctx.db.embedded().clone());
                 let subnet = subnet_store.get(vm.subnet_id.as_str(), None, None).await?;
 
                 let (gateway, cidr) = match &subnet {
@@ -347,7 +354,7 @@ impl super::Reconciler for VmReconciler {
                 };
 
                 // Resolve VPC CIDR for DNS64/NAT64 setup
-                let vpc_store = nauka_network::vpc::store::VpcStore::new(ctx.db.clone());
+                let vpc_store = nauka_network::vpc::store::VpcStore::new(ctx.db.embedded().clone());
                 let vpc_cidr = vpc_store
                     .get(vm.vpc_id.as_str(), None)
                     .await?

--- a/layers/forge/src/reconciler/vpc.rs
+++ b/layers/forge/src/reconciler/vpc.rs
@@ -96,7 +96,7 @@ impl super::Reconciler for VpcReconciler {
             .collect();
 
         // 2. Collect unique VPC IDs needed on this node + resolve their VNIs
-        let vpc_store = nauka_network::vpc::store::VpcStore::new(ctx.db.clone());
+        let vpc_store = nauka_network::vpc::store::VpcStore::new(ctx.db.embedded().clone());
         let mut needed_vpcs: Vec<(String, u32)> = Vec::new();
         for vm in &local_vms {
             let vpc_id = vm.vpc_id.as_str().to_string();
@@ -231,7 +231,7 @@ impl super::Reconciler for VpcReconciler {
             // Look up the subnet gateway from any local VM in this VPC
             if let Some(local_vm) = local_vms.iter().find(|vm| vm.vpc_id.as_str() == *vpc_id) {
                 let subnet_store =
-                    nauka_network::vpc::subnet::store::SubnetStore::new(ctx.db.clone());
+                    nauka_network::vpc::subnet::store::SubnetStore::new(ctx.db.embedded().clone());
                 if let Ok(Some(subnet)) = subnet_store
                     .get(local_vm.subnet_id.as_str(), None, None)
                     .await
@@ -275,7 +275,8 @@ impl super::Reconciler for VpcReconciler {
         }
 
         // 8. VPC Peering — route leak between VRFs
-        let peering_store = nauka_network::vpc::peering::store::PeeringStore::new(ctx.db.clone());
+        let peering_store =
+            nauka_network::vpc::peering::store::PeeringStore::new(ctx.db.embedded().clone());
         let mut peered_bridge_pairs: Vec<(String, String)> = Vec::new();
         for (vpc_id, _) in &needed_vpcs {
             let peerings = peering_store.list(Some(vpc_id)).await.unwrap_or_default();

--- a/layers/network/schemas/natgw.surql
+++ b/layers/network/schemas/natgw.surql
@@ -1,0 +1,114 @@
+-- ============================================================================
+-- Nauka — cluster state schema: natgw
+-- ============================================================================
+-- Target: nauka / cluster (SurrealDB on top of kv-tikv)
+--
+-- Distributed cluster-state representation of a `NatGw` — a NAT
+-- gateway that provides outbound IPv4 → IPv6 translation for VMs in a
+-- single VPC. Today NAT gateways are written through
+-- `nauka_network::vpc::natgw::store::NatGwStore` via the SurrealDB
+-- SDK after P2.12 (sifrah/nauka#216); this schema file ships the
+-- SCHEMAFULL definition that pair of writes target.
+--
+-- Source of truth: `layers/network/src/vpc/natgw/types.rs`
+-- (`struct NatGw`), which embeds `ResourceMeta` via
+-- `#[serde(flatten)]` and carries an owning `vpc_id` / `vpc_name`
+-- pair, a public IPv6 address allocated from the hosting hypervisor's
+-- `/64` block, the hypervisor's id, and a lifecycle `state`
+-- (provisioning → active → error).
+--
+-- Idempotency: every DEFINE statement uses `IF NOT EXISTS` so this
+-- file can be re-applied against an initialised cluster database as a
+-- no-op. `nauka_state::apply_cluster_schemas` runs this at bootstrap.
+--
+-- Multi-tenancy: NAT gateways inherit their tenant from the owning
+-- VPC. The `(vpc, name)` tuple is the natural key, same as subnets.
+-- There is additionally an "at most one NAT gateway per VPC"
+-- invariant enforced by the store layer at create time — the schema
+-- does not express that single-row-per-parent constraint because
+-- SurrealDB has no "partial unique" index type; the store's "check
+-- before create" closes the gap.
+--
+-- Foreign keys: `vpc` is a plain `string` record id for now. See
+-- `org.surql` for the rationale — P3 codegen may upgrade to
+-- `record<vpc>`.
+-- ============================================================================
+
+
+-- ── natgw ────────────────────────────────────────────────────────────────
+-- A NAT gateway. Exactly one per VPC. Provisioned on a specific
+-- hypervisor with an IPv6 address drawn from that hypervisor's /64
+-- public block.
+
+DEFINE TABLE IF NOT EXISTS natgw SCHEMAFULL;
+
+-- Human-readable name. Unique within the owning VPC.
+DEFINE FIELD IF NOT EXISTS name ON natgw TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Resource lifecycle status. Same free-form semantics as every other
+-- cluster-state table — NOT the business-logic `state` column below.
+DEFINE FIELD IF NOT EXISTS status ON natgw TYPE string
+    ASSERT string::len($value) > 0;
+
+-- User-defined labels. Defaults to `{}` so the column is never null.
+DEFINE FIELD IF NOT EXISTS labels ON natgw TYPE object DEFAULT {};
+
+-- Owning VPC — SurrealDB record id of the `vpc` row. Tenant scoping
+-- and the `(vpc, name)` composite index both read this column.
+DEFINE FIELD IF NOT EXISTS vpc ON natgw TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Denormalised VPC name copied from `NatGw.vpc_name`.
+DEFINE FIELD IF NOT EXISTS vpc_name ON natgw TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Dedicated public IPv6 address for this NAT gateway's outbound
+-- traffic, as a string like "2a01:4f8:c012:abcd::a1b2:c3d4:e5f6:…".
+-- Allocated from the hosting hypervisor's `/64` block by the
+-- `ipv6_alloc` helper. SurrealDB has no native IPv6 type, so we
+-- store the canonical string form — the application layer parses it
+-- back into `std::net::Ipv6Addr` on read.
+DEFINE FIELD IF NOT EXISTS public_ipv6 ON natgw TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Id of the hypervisor where this NAT gateway is provisioned.
+-- Plain `string` today because `NatGw.hypervisor_id` is a `String`,
+-- not a typed `HypervisorId`. A future pass may tighten this to
+-- `record<hypervisor>` once cluster-side hypervisor rows exist.
+DEFINE FIELD IF NOT EXISTS hypervisor ON natgw TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Business-logic state, mirrors
+-- `nauka_network::vpc::natgw::types::NatGwState`. The enum is
+-- rendered as a lowercase string by serde
+-- (`#[serde(rename = "provisioning" | "active" | "error")]`); the
+-- `ASSERT` limits incoming values to that exact set so a bad client
+-- can't write a nonsense state.
+DEFINE FIELD IF NOT EXISTS state ON natgw TYPE string
+    ASSERT $value INSIDE ["provisioning", "active", "error"];
+
+-- Creation timestamp.
+DEFINE FIELD IF NOT EXISTS created_at ON natgw TYPE datetime;
+
+-- Last-update timestamp.
+DEFINE FIELD IF NOT EXISTS updated_at ON natgw TYPE datetime;
+
+-- Composite unique index on `(vpc, name)`. Two NAT gateways in
+-- different VPCs may share a name; within a single VPC the name is
+-- unique.
+DEFINE INDEX IF NOT EXISTS natgw_vpc_name ON natgw
+    FIELDS vpc, name UNIQUE;
+
+-- Secondary (non-unique) index on `vpc` for "is there a NAT gateway
+-- for this VPC yet?" scans, which the store layer uses to enforce
+-- the "at most one NAT gateway per VPC" invariant at create time.
+DEFINE INDEX IF NOT EXISTS natgw_vpc ON natgw FIELDS vpc;
+
+-- Secondary index on `public_ipv6` to catch address collisions early
+-- — the `ipv6_alloc` helper hashes the NAT gateway id into a
+-- deterministic /128, so collisions are extremely unlikely but the
+-- schema should still guard against a bad migration writing two
+-- rows with the same address.
+DEFINE INDEX IF NOT EXISTS natgw_public_ipv6 ON natgw
+    FIELDS public_ipv6 UNIQUE;

--- a/layers/network/schemas/peering.surql
+++ b/layers/network/schemas/peering.surql
@@ -1,0 +1,113 @@
+-- ============================================================================
+-- Nauka — cluster state schema: vpc_peering
+-- ============================================================================
+-- Target: nauka / cluster (SurrealDB on top of kv-tikv)
+--
+-- Distributed cluster-state representation of a `VpcPeering` — a
+-- bidirectional peering relationship between two VPCs in the same
+-- cluster. Today peerings are written through
+-- `nauka_network::vpc::peering::store::PeeringStore` via the SurrealDB
+-- SDK after P2.12 (sifrah/nauka#216); this schema file ships the
+-- SCHEMAFULL definition that pair of writes target.
+--
+-- Source of truth: `layers/network/src/vpc/peering/types.rs`
+-- (`struct VpcPeering`), which embeds `ResourceMeta` via
+-- `#[serde(flatten)]` and carries an owning `vpc_id` / `vpc_name` pair
+-- for the "local" VPC plus a matching `peer_vpc_id` / `peer_vpc_name`
+-- pair for the partner. A `state` enum (`active` | `pending`) tracks
+-- whether both sides have acknowledged the peering.
+--
+-- Idempotency: every DEFINE statement uses `IF NOT EXISTS` so this
+-- file can be re-applied against an initialised cluster database as a
+-- no-op. `nauka_state::apply_cluster_schemas` runs this at bootstrap.
+--
+-- Multi-tenancy: peerings inherit their tenant from the local VPC —
+-- there is no `org` column on this row because a peering is
+-- identified cluster-wide and tenant filtering walks through
+-- `vpc.org`. A future row-level authz rule may project the owning
+-- org down here; for now we keep the schema minimal.
+--
+-- Uniqueness: the `(vpc, peer_vpc)` pair is enforced unique, and the
+-- store side additionally rejects a pair whose reverse `(peer_vpc,
+-- vpc)` already exists — a peering is bidirectional, so only one row
+-- may exist for each unordered pair of VPCs. The schema index
+-- enforces only the ordered-pair case because SurrealDB can't express
+-- a "set of 2 values" unique index directly; the store layer closes
+-- the reverse-pair gap.
+--
+-- Foreign keys: `vpc` and `peer_vpc` are both plain `string` record
+-- ids for now. See `org.surql` for the rationale — P3 codegen may
+-- upgrade them to typed `record<vpc>` links.
+-- ============================================================================
+
+
+-- ── vpc_peering ──────────────────────────────────────────────────────────
+-- A bidirectional VPC-to-VPC peering. The two VPCs must be in the
+-- same cluster; cross-cluster peerings (Phase 4+) will live in a
+-- separate table.
+
+DEFINE TABLE IF NOT EXISTS vpc_peering SCHEMAFULL;
+
+-- Human-readable auto-generated name, e.g. "web-to-db". Present in
+-- `ResourceMeta.name`. Non-empty.
+DEFINE FIELD IF NOT EXISTS name ON vpc_peering TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Resource lifecycle status, same free-form semantics as every other
+-- cluster-state table.
+DEFINE FIELD IF NOT EXISTS status ON vpc_peering TYPE string
+    ASSERT string::len($value) > 0;
+
+-- User-defined labels. Defaults to `{}` so the column is never null.
+DEFINE FIELD IF NOT EXISTS labels ON vpc_peering TYPE object DEFAULT {};
+
+-- Local VPC — SurrealDB record id of the `vpc` row that hosts this
+-- peering. The "local" side is the one that submitted the create
+-- request; the naming is arbitrary because peerings are
+-- bidirectional.
+DEFINE FIELD IF NOT EXISTS vpc ON vpc_peering TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Denormalised local-VPC name copied from `VpcPeering.vpc_name`.
+DEFINE FIELD IF NOT EXISTS vpc_name ON vpc_peering TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Peer VPC — SurrealDB record id of the other `vpc` row.
+DEFINE FIELD IF NOT EXISTS peer_vpc ON vpc_peering TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Denormalised peer-VPC name copied from `VpcPeering.peer_vpc_name`.
+DEFINE FIELD IF NOT EXISTS peer_vpc_name ON vpc_peering TYPE string
+    ASSERT string::len($value) > 0;
+
+-- Peering state, mirrors `nauka_network::vpc::peering::types::PeeringState`.
+-- The enum is rendered as a lowercase string by serde
+-- (`#[serde(rename = "active" | "pending")]`); the `ASSERT` limits
+-- incoming values to that exact set so a bad client can't write a
+-- nonsense state.
+DEFINE FIELD IF NOT EXISTS state ON vpc_peering TYPE string
+    ASSERT $value INSIDE ["active", "pending"];
+
+-- Creation timestamp.
+DEFINE FIELD IF NOT EXISTS created_at ON vpc_peering TYPE datetime;
+
+-- Last-update timestamp.
+DEFINE FIELD IF NOT EXISTS updated_at ON vpc_peering TYPE datetime;
+
+-- Composite unique index on `(vpc, peer_vpc)`. Same pair cannot be
+-- peered twice in the same direction. The reverse-direction check
+-- (`(peer_vpc, vpc)`) is enforced by the store layer because
+-- SurrealDB can't express "an unordered pair is unique" as a single
+-- index.
+DEFINE INDEX IF NOT EXISTS vpc_peering_pair ON vpc_peering
+    FIELDS vpc, peer_vpc UNIQUE;
+
+-- Secondary (non-unique) index on `vpc` for "list peerings touching
+-- this VPC" scans. The list side also walks `peer_vpc` — SurrealQL
+-- can `UNION` the two, or the application layer can filter a
+-- `SELECT *`; either is fine at the row counts Phase 2 targets.
+DEFINE INDEX IF NOT EXISTS vpc_peering_vpc ON vpc_peering FIELDS vpc;
+
+-- Matching secondary index on the other side of the pair.
+DEFINE INDEX IF NOT EXISTS vpc_peering_peer_vpc ON vpc_peering
+    FIELDS peer_vpc;

--- a/layers/network/src/vpc/handlers.rs
+++ b/layers/network/src/vpc/handlers.rs
@@ -60,7 +60,11 @@ pub fn handler() -> HandlerFn {
             Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
         > {
             Box::pin(async move {
-                let store = VpcStore::new(nauka_hypervisor::controlplane::connect().await?);
+                // P2.12 (sifrah/nauka#216): VpcStore now takes an
+                // EmbeddedDb directly; reach the cluster handle via
+                // the wrapper's `.embedded()` accessor.
+                let cluster_db = nauka_hypervisor::controlplane::connect().await?;
+                let store = VpcStore::new(cluster_db.embedded().clone());
                 match req.operation.as_str() {
                     "create" => {
                         let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name"))?;

--- a/layers/network/src/vpc/natgw/handlers.rs
+++ b/layers/network/src/vpc/natgw/handlers.rs
@@ -60,7 +60,11 @@ pub fn handler() -> HandlerFn {
             Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
         > {
             Box::pin(async move {
-                let store = NatGwStore::new(nauka_hypervisor::controlplane::connect().await?);
+                // P2.12 (sifrah/nauka#216): NatGwStore now takes an
+                // EmbeddedDb directly; reach the cluster handle via
+                // the wrapper's `.embedded()` accessor.
+                let cluster_db = nauka_hypervisor::controlplane::connect().await?;
+                let store = NatGwStore::new(cluster_db.embedded().clone());
                 match req.operation.as_str() {
                     "create" => {
                         let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name"))?;

--- a/layers/network/src/vpc/natgw/ipv6_alloc.rs
+++ b/layers/network/src/vpc/natgw/ipv6_alloc.rs
@@ -1,17 +1,32 @@
 //! IPv6 address allocator for NAT gateways.
 //!
-//! Allocates /128 addresses from a hypervisor's public /64 block.
-//! Each NAT gateway gets a deterministic, unique IPv6 derived from
-//! the /64 prefix + a hash of the NAT gateway ID.
+//! Allocates deterministic `/128` addresses from a hypervisor's
+//! public `/64` block. Each NAT gateway gets a unique IPv6 derived
+//! from the prefix + a SHA-256 hash of the NAT gateway id, so the
+//! allocation is stable across restarts and identical across nodes
+//! without coordination.
+//!
+//! P2.12 (sifrah/nauka#216) migrated this helper from the legacy
+//! raw-KV cluster surface to the native SurrealDB SDK. The
+//! allocation ledger lives in a transitional SCHEMALESS
+//! `natgw_ipv6_alloc` table, keyed by the hypervisor id, with a
+//! `data` column holding the JSON blob of `{ipv6, nat_gw_id}`
+//! entries. The table is intentionally NOT in the
+//! `apply_cluster_schemas` bundle because it's a transitional
+//! single-blob-per-hypervisor shape — Phase 3 or a dedicated IPAM
+//! rewrite can normalise it into one row per address.
 
 use std::net::Ipv6Addr;
 
-use nauka_hypervisor::controlplane::ClusterDb;
+use nauka_state::EmbeddedDb;
 use serde::{Deserialize, Serialize};
 
-const NS_NATGW_IPV6: &str = "natgw-ipv6";
+/// Transitional SCHEMALESS table that holds the IPv6 allocation
+/// ledger. One row per hypervisor, keyed by the hypervisor's record
+/// id, with a `data` column holding the JSON blob.
+const IPV6_ALLOC_TABLE: &str = "natgw_ipv6_alloc";
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct Ipv6Allocations {
     entries: Vec<Ipv6Allocation>,
 }
@@ -22,10 +37,11 @@ struct Ipv6Allocation {
     nat_gw_id: String,
 }
 
-/// Derive a deterministic IPv6 /128 from a /64 prefix and a NAT gateway ID.
+/// Derive a deterministic IPv6 /128 from a /64 prefix and a NAT
+/// gateway id.
 ///
-/// Uses SHA-256 of the NAT GW ID to fill the lower 64 bits (interface ID).
-/// Skips ::1 which is conventionally reserved for the host.
+/// Uses SHA-256 of the NAT GW id to fill the lower 64 bits (interface
+/// id). Skips `::1` which is conventionally reserved for the host.
 fn derive_ipv6(prefix_str: &str, nat_gw_id: &str) -> anyhow::Result<Ipv6Addr> {
     let net: ipnet::Ipv6Net = prefix_str
         .parse()
@@ -40,7 +56,6 @@ fn derive_ipv6(prefix_str: &str, nat_gw_id: &str) -> anyhow::Result<Ipv6Addr> {
     use sha2::{Digest, Sha256};
     let hash = Sha256::digest(nat_gw_id.as_bytes());
 
-    // Take 8 bytes from hash to form the interface ID (lower 64 bits)
     let iid = [
         u16::from_be_bytes([hash[0], hash[1]]),
         u16::from_be_bytes([hash[2], hash[3]]),
@@ -52,9 +67,8 @@ fn derive_ipv6(prefix_str: &str, nat_gw_id: &str) -> anyhow::Result<Ipv6Addr> {
         segs[0], segs[1], segs[2], segs[3], iid[0], iid[1], iid[2], iid[3],
     );
 
-    // Avoid ::1 (host) and :: (network)
+    // Avoid `::` (network) and `::1` (host).
     if addr == prefix || addr.segments()[4..] == [0, 0, 0, 1] {
-        // Extremely unlikely with SHA-256, but handle it
         let addr2 = Ipv6Addr::new(
             segs[0],
             segs[1],
@@ -71,23 +85,79 @@ fn derive_ipv6(prefix_str: &str, nat_gw_id: &str) -> anyhow::Result<Ipv6Addr> {
     Ok(addr)
 }
 
-/// Allocate a public IPv6 address for a NAT gateway from the hypervisor's /64 block.
+/// Ensure the transitional SCHEMALESS `natgw_ipv6_alloc` table
+/// exists. Idempotent thanks to `IF NOT EXISTS`.
+async fn ensure_table(db: &EmbeddedDb) -> anyhow::Result<()> {
+    db.client()
+        .query("DEFINE TABLE IF NOT EXISTS natgw_ipv6_alloc SCHEMALESS")
+        .await
+        .map_err(|e| anyhow::anyhow!("define natgw_ipv6_alloc: {e}"))?
+        .check()
+        .map_err(|e| anyhow::anyhow!("define natgw_ipv6_alloc check: {e}"))?;
+    Ok(())
+}
+
+/// Load the allocation blob for one hypervisor. Returns an empty
+/// [`Ipv6Allocations`] if no row exists yet.
+async fn load(db: &EmbeddedDb, hypervisor_id: &str) -> anyhow::Result<Ipv6Allocations> {
+    ensure_table(db).await?;
+    let mut response = db
+        .client()
+        .query("SELECT data FROM type::record($tbl, $id)")
+        .bind(("tbl", IPV6_ALLOC_TABLE))
+        .bind(("id", hypervisor_id.to_string()))
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let rows: Vec<serde_json::Value> = response.take("data").map_err(|e| anyhow::anyhow!("{e}"))?;
+    let first = rows.into_iter().next();
+    match first {
+        None | Some(serde_json::Value::Null) => Ok(Ipv6Allocations::default()),
+        Some(v) => serde_json::from_value::<Ipv6Allocations>(v)
+            .map_err(|e| anyhow::anyhow!("deserialise ipv6 alloc blob: {e}")),
+    }
+}
+
+/// Persist the allocation blob for one hypervisor. Creates the row
+/// on first write via `UPSERT`.
+async fn save(
+    db: &EmbeddedDb,
+    hypervisor_id: &str,
+    allocs: &Ipv6Allocations,
+) -> anyhow::Result<()> {
+    ensure_table(db).await?;
+    let data = serde_json::to_value(allocs)
+        .map_err(|e| anyhow::anyhow!("serialise ipv6 alloc blob: {e}"))?;
+    db.client()
+        .query("UPSERT type::record($tbl, $id) CONTENT { data: $data }")
+        .bind(("tbl", IPV6_ALLOC_TABLE))
+        .bind(("id", hypervisor_id.to_string()))
+        .bind(("data", data))
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?
+        .check()
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    Ok(())
+}
+
+/// Allocate a public IPv6 address for a NAT gateway from the
+/// hypervisor's /64 block. Idempotent: if the NAT gateway already
+/// has an allocation for this hypervisor, returns the existing
+/// address unchanged.
 pub async fn allocate(
-    db: &ClusterDb,
+    db: &EmbeddedDb,
     hypervisor_id: &str,
     ipv6_block: &str,
     nat_gw_id: &str,
 ) -> anyhow::Result<Ipv6Addr> {
     let mut allocs = load(db, hypervisor_id).await?;
 
-    // Check if already allocated
     if let Some(existing) = allocs.entries.iter().find(|a| a.nat_gw_id == nat_gw_id) {
         return Ok(existing.ipv6);
     }
 
     let addr = derive_ipv6(ipv6_block, nat_gw_id)?;
 
-    // Check for collision (extremely unlikely with SHA-256)
+    // Collision check — extremely unlikely with SHA-256, but cheap.
     if allocs.entries.iter().any(|a| a.ipv6 == addr) {
         anyhow::bail!("IPv6 address collision for {addr} — this should not happen");
     }
@@ -96,33 +166,28 @@ pub async fn allocate(
         ipv6: addr,
         nat_gw_id: nat_gw_id.to_string(),
     });
-
     save(db, hypervisor_id, &allocs).await?;
     Ok(addr)
 }
 
 /// Release the IPv6 address allocated to a NAT gateway.
-pub async fn release(db: &ClusterDb, hypervisor_id: &str, nat_gw_id: &str) -> anyhow::Result<()> {
+pub async fn release(db: &EmbeddedDb, hypervisor_id: &str, nat_gw_id: &str) -> anyhow::Result<()> {
     let mut allocs = load(db, hypervisor_id).await?;
     allocs.entries.retain(|a| a.nat_gw_id != nat_gw_id);
     save(db, hypervisor_id, &allocs).await
 }
 
-async fn load(db: &ClusterDb, hypervisor_id: &str) -> anyhow::Result<Ipv6Allocations> {
-    let allocs: Option<Ipv6Allocations> = db.get(NS_NATGW_IPV6, hypervisor_id).await?;
-    Ok(allocs.unwrap_or(Ipv6Allocations {
-        entries: Vec::new(),
-    }))
-}
-
-async fn save(db: &ClusterDb, hypervisor_id: &str, allocs: &Ipv6Allocations) -> anyhow::Result<()> {
-    db.put(NS_NATGW_IPV6, hypervisor_id, allocs).await?;
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    async fn temp_db() -> (tempfile::TempDir, EmbeddedDb) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = EmbeddedDb::open(&dir.path().join("ipv6.skv"))
+            .await
+            .expect("open EmbeddedDb");
+        (dir, db)
+    }
 
     #[test]
     fn derive_ipv6_deterministic() {
@@ -152,5 +217,45 @@ mod tests {
     fn derive_ipv6_rejects_non_64() {
         assert!(derive_ipv6("2a01:4f8:c012::/48", "nat-test").is_err());
         assert!(derive_ipv6("2a01:4f8:c012:abcd::1/128", "nat-test").is_err());
+    }
+
+    #[tokio::test]
+    async fn allocate_returns_same_ip_for_same_nat_gw() {
+        let (_d, db) = temp_db().await;
+        let a = allocate(&db, "hv-1", "2a01:4f8:c012:abcd::/64", "nat-01")
+            .await
+            .unwrap();
+        let b = allocate(&db, "hv-1", "2a01:4f8:c012:abcd::/64", "nat-01")
+            .await
+            .unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[tokio::test]
+    async fn release_frees_slot() {
+        let (_d, db) = temp_db().await;
+        let a = allocate(&db, "hv-1", "2a01:4f8:c012:abcd::/64", "nat-01")
+            .await
+            .unwrap();
+        release(&db, "hv-1", "nat-01").await.unwrap();
+        // Re-allocating the same id should reproduce the same deterministic addr.
+        let b = allocate(&db, "hv-1", "2a01:4f8:c012:abcd::/64", "nat-01")
+            .await
+            .unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[tokio::test]
+    async fn allocations_are_isolated_per_hypervisor() {
+        let (_d, db) = temp_db().await;
+        allocate(&db, "hv-1", "2a01:4f8:c012:abcd::/64", "nat-01")
+            .await
+            .unwrap();
+        // Hypervisor 2 has a different /64 and should allocate in
+        // its own space without touching hv-1's ledger.
+        let b = allocate(&db, "hv-2", "2a01:4f8:c012:1234::/64", "nat-02")
+            .await
+            .unwrap();
+        assert_eq!(b.segments()[3], 0x1234);
     }
 }

--- a/layers/network/src/vpc/natgw/store.rs
+++ b/layers/network/src/vpc/natgw/store.rs
@@ -1,29 +1,52 @@
+//! NAT gateway persistence on the SurrealDB-backed cluster store.
+//!
+//! P2.12 (sifrah/nauka#216) migrated this module from the legacy
+//! raw-KV cluster path to the native SurrealDB SDK on top of
+//! [`EmbeddedDb`], and shipped the SCHEMAFULL `natgw` table in
+//! `layers/network/schemas/natgw.surql` — net-new in this PR.
+//!
+//! Invariants enforced here:
+//! - At most one NAT gateway per VPC (checked before the SDK write).
+//!   The schema has a non-unique `natgw_vpc` index to make the check
+//!   fast; "partial unique" indexes don't exist in SurrealDB so the
+//!   invariant lives in the application layer.
+//! - Names are unique within a VPC (schema composite unique on
+//!   `(vpc, name)`).
+//! - Public IPv6 addresses are globally unique (schema unique on
+//!   `public_ipv6`). Allocation is deterministic via SHA-256 of the
+//!   NAT gateway id, so collisions require an extremely unlikely
+//!   hash crash.
+
 use nauka_core::id::NatGwId;
+use nauka_core::resource::epoch_to_iso8601;
 use nauka_core::resource::ResourceMeta;
-use nauka_hypervisor::controlplane::ClusterDb;
+use nauka_state::sdk_bridge::{iso8601_to_epoch, thing_to_id_string};
+use nauka_state::EmbeddedDb;
+use serde::Deserialize;
 
 use super::ipv6_alloc;
 use super::types::{NatGw, NatGwState};
 
-const NS_NATGW: &str = "natgw";
-const NS_NATGW_IDX: &str = "natgw-idx";
-const REG_V2_NS: &str = "_reg_v2";
-const REG_V2_PREFIX: &str = "natgw/";
-const REG_V1: (&str, &str) = ("_reg", "natgw-ids");
+/// SurrealDB table backing this store.
+const NATGW_TABLE: &str = "natgw";
 
 pub struct NatGwStore {
-    db: ClusterDb,
+    db: EmbeddedDb,
 }
 
 impl NatGwStore {
-    pub fn new(db: ClusterDb) -> Self {
+    /// Build a [`NatGwStore`] over a SurrealDB handle.
+    ///
+    /// Call sites that already hold a cluster-DB wrapper pass
+    /// `cluster_db.embedded().clone()`.
+    pub fn new(db: EmbeddedDb) -> Self {
         Self { db }
     }
 
     /// Create a NAT gateway for a VPC.
     ///
-    /// Requires that the selected hypervisor has an `ipv6_block` configured.
-    /// Only one NAT gateway per VPC is allowed.
+    /// Requires that the selected hypervisor has an `ipv6_block`
+    /// configured. Only one NAT gateway per VPC is allowed.
     pub async fn create(
         &self,
         name: &str,
@@ -38,19 +61,20 @@ impl NatGwStore {
             .await?
             .ok_or_else(|| anyhow::anyhow!("vpc '{vpc_name_or_id}' not found"))?;
 
-        // Check: one NAT GW per VPC
-        let existing = self.list_by_vpc(Some(&vpc.meta.id)).await?;
-        if !existing.is_empty() {
+        // Enforce "at most one NAT gateway per VPC" at the application
+        // layer — SurrealDB doesn't support partial unique indexes.
+        let existing = self.list_by_vpc(&vpc.meta.id).await?;
+        if let Some(existing_gw) = existing.first() {
             anyhow::bail!(
                 "vpc '{}' already has a NAT gateway '{}'",
                 vpc.meta.name,
-                existing[0].meta.name
+                existing_gw.meta.name
             );
         }
 
         let nat_gw_id = NatGwId::generate();
 
-        // Allocate a public IPv6 from the hypervisor's /64 block
+        // Allocate a public IPv6 from the hypervisor's /64 block.
         let public_ipv6 =
             ipv6_alloc::allocate(&self.db, hypervisor_id, ipv6_block, nat_gw_id.as_str()).await?;
 
@@ -63,46 +87,133 @@ impl NatGwStore {
             state: NatGwState::Provisioning,
         };
 
-        // Persist
-        self.db.put(NS_NATGW, &natgw.meta.id, &natgw).await?;
-        let idx_key = format!("{}/{}", vpc.meta.id, name);
-        self.db.put(NS_NATGW_IDX, &idx_key, &natgw.meta.id).await?;
-        add_id(&self.db, &natgw.meta.id).await?;
+        let created_at_iso = epoch_to_iso8601(natgw.meta.created_at);
+        let updated_at_iso = epoch_to_iso8601(natgw.meta.updated_at);
+        let labels_json = serde_json::to_value(&natgw.meta.labels)
+            .map_err(|e| anyhow::anyhow!("serialise labels: {e}"))?;
+        let state_str = match natgw.state {
+            NatGwState::Provisioning => "provisioning",
+            NatGwState::Active => "active",
+            NatGwState::Error => "error",
+        };
+
+        let insert_result = self
+            .db
+            .client()
+            .query(
+                "CREATE type::record($tbl, $id) SET \
+                 name = $name, \
+                 status = $status, \
+                 labels = $labels, \
+                 vpc = $vpc, \
+                 vpc_name = $vpc_name, \
+                 public_ipv6 = $public_ipv6, \
+                 hypervisor = $hypervisor, \
+                 state = $state, \
+                 created_at = <datetime>$created_at, \
+                 updated_at = <datetime>$updated_at",
+            )
+            .bind(("tbl", NATGW_TABLE))
+            .bind(("id", natgw.meta.id.clone()))
+            .bind(("name", natgw.meta.name.clone()))
+            .bind(("status", natgw.meta.status.clone()))
+            .bind(("labels", labels_json))
+            .bind(("vpc", natgw.vpc_id.as_str().to_string()))
+            .bind(("vpc_name", natgw.vpc_name.clone()))
+            .bind(("public_ipv6", natgw.public_ipv6.to_string()))
+            .bind(("hypervisor", natgw.hypervisor_id.clone()))
+            .bind(("state", state_str))
+            .bind(("created_at", created_at_iso))
+            .bind(("updated_at", updated_at_iso))
+            .await;
+
+        let response = match insert_result {
+            Ok(r) => r,
+            Err(e) => {
+                // Roll back the IPv6 allocation if the DB write
+                // failed — otherwise we'd leak a reservation for a
+                // NAT gateway that doesn't exist.
+                let _ = ipv6_alloc::release(&self.db, hypervisor_id, natgw.meta.id.as_str()).await;
+                return Err(anyhow::anyhow!("{e}"));
+            }
+        };
+        if let Err(e) = response.check() {
+            let _ = ipv6_alloc::release(&self.db, hypervisor_id, natgw.meta.id.as_str()).await;
+            return Err(anyhow::anyhow!("{e}"));
+        }
 
         Ok(natgw)
     }
 
+    /// Look up a NAT gateway by id first, then by (vpc, name) index
+    /// if the id path doesn't match. Matches the pre-P2.12 lookup
+    /// order so CLI error messages stay stable.
     pub async fn get(
         &self,
         name_or_id: &str,
         vpc_name_or_id: Option<&str>,
         org_name: Option<&str>,
     ) -> anyhow::Result<Option<NatGw>> {
-        // Try direct ID lookup first
-        if let Some(natgw) = self.db.get::<NatGw>(NS_NATGW, name_or_id).await? {
+        // Try direct record-id lookup first.
+        if let Some(natgw) = self.get_by_id(name_or_id).await? {
             return Ok(Some(natgw));
         }
 
-        // Try index lookup by vpc + name
+        // Fall back to (vpc, name) lookup.
         if let Some(vpc_ref) = vpc_name_or_id {
             let vpc_store = crate::vpc::store::VpcStore::new(self.db.clone());
             if let Some(vpc) = vpc_store.get(vpc_ref, org_name).await? {
-                let idx_key = format!("{}/{}", vpc.meta.id, name_or_id);
-                if let Some(id) = self.db.get::<String>(NS_NATGW_IDX, &idx_key).await? {
-                    return self
-                        .db
-                        .get::<NatGw>(NS_NATGW, &id)
-                        .await
-                        .map_err(Into::into);
-                }
+                return self.get_by_vpc_and_name(&vpc.meta.id, name_or_id).await;
             }
         }
 
         Ok(None)
     }
 
+    async fn get_by_id(&self, id: &str) -> anyhow::Result<Option<NatGw>> {
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT * FROM type::record($tbl, $id)")
+            .bind(("tbl", NATGW_TABLE))
+            .bind(("id", id.to_string()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let raw: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        decode_first(raw)
+    }
+
+    async fn get_by_vpc_and_name(&self, vpc_id: &str, name: &str) -> anyhow::Result<Option<NatGw>> {
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT * FROM natgw WHERE vpc = $vpc AND name = $name LIMIT 1")
+            .bind(("vpc", vpc_id.to_string()))
+            .bind(("name", name.to_string()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let raw: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        decode_first(raw)
+    }
+
+    /// List NAT gateways, optionally filtered by the owning VPC (by
+    /// name or record id).
     pub async fn list(&self, vpc_name: Option<&str>) -> anyhow::Result<Vec<NatGw>> {
-        let all = self.list_by_vpc(None).await?;
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT * FROM natgw")
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let raw: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        let all: Vec<NatGw> = raw
+            .into_iter()
+            .filter_map(|v| {
+                serde_json::from_value::<NatGwRow>(v)
+                    .ok()
+                    .map(NatGwRow::into_natgw)
+            })
+            .collect();
         match vpc_name {
             Some(name) => Ok(all
                 .into_iter()
@@ -112,23 +223,29 @@ impl NatGwStore {
         }
     }
 
-    async fn list_by_vpc(&self, vpc_id: Option<&str>) -> anyhow::Result<Vec<NatGw>> {
-        let ids = load_ids(&self.db).await?;
-        let mut items = Vec::new();
-        for id in &ids {
-            if let Some(natgw) = self.db.get::<NatGw>(NS_NATGW, id).await? {
-                if let Some(vid) = vpc_id {
-                    if natgw.vpc_id.as_str() == vid {
-                        items.push(natgw);
-                    }
-                } else {
-                    items.push(natgw);
-                }
-            }
-        }
-        Ok(items)
+    /// List NAT gateways for a specific VPC record id. Used by
+    /// `create` to enforce the "at most one NAT gateway per VPC"
+    /// invariant.
+    async fn list_by_vpc(&self, vpc_id: &str) -> anyhow::Result<Vec<NatGw>> {
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT * FROM natgw WHERE vpc = $vpc")
+            .bind(("vpc", vpc_id.to_string()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let raw: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        Ok(raw
+            .into_iter()
+            .filter_map(|v| {
+                serde_json::from_value::<NatGwRow>(v)
+                    .ok()
+                    .map(NatGwRow::into_natgw)
+            })
+            .collect())
     }
 
+    /// Delete a NAT gateway and release its IPv6 allocation.
     pub async fn delete(
         &self,
         name_or_id: &str,
@@ -140,48 +257,196 @@ impl NatGwStore {
             .await?
             .ok_or_else(|| anyhow::anyhow!("nat-gateway '{name_or_id}' not found"))?;
 
-        // Release the allocated IPv6
+        // Release the allocated IPv6 first. If the subsequent DELETE
+        // fails, the caller can re-try and the release path is
+        // idempotent (it just removes the entry from the blob).
         ipv6_alloc::release(&self.db, &natgw.hypervisor_id, &natgw.meta.id).await?;
 
-        // Remove from store
-        let idx_key = format!("{}/{}", natgw.vpc_id.as_str(), natgw.meta.name);
-        self.db.delete(NS_NATGW, &natgw.meta.id).await?;
-        self.db.delete(NS_NATGW_IDX, &idx_key).await?;
-        remove_id(&self.db, &natgw.meta.id).await?;
-
+        let result = self
+            .db
+            .client()
+            .query("DELETE type::record($tbl, $id)")
+            .bind(("tbl", NATGW_TABLE))
+            .bind(("id", natgw.meta.id.clone()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        result.check().map_err(|e| anyhow::anyhow!("{e}"))?;
         Ok(())
     }
 }
 
-async fn load_ids(db: &ClusterDb) -> anyhow::Result<Vec<String>> {
-    let keys = db.scan_keys(REG_V2_NS, REG_V2_PREFIX).await?;
-    let mut ids: Vec<String> = keys
-        .into_iter()
-        .filter_map(|k| k.strip_prefix(REG_V2_PREFIX).map(|s| s.to_string()))
-        .collect();
+/// Row shape returned by `SELECT * FROM natgw`.
+#[derive(Debug, Deserialize)]
+struct NatGwRow {
+    id: serde_json::Value,
+    name: String,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    labels: Option<serde_json::Value>,
+    vpc: String,
+    vpc_name: String,
+    public_ipv6: String,
+    hypervisor: String,
+    state: String,
+    created_at: String,
+    updated_at: String,
+}
 
-    if let Some(v1_ids) = db.get::<Vec<String>>(REG_V1.0, REG_V1.1).await? {
-        for old_id in v1_ids {
-            if !ids.contains(&old_id) {
-                let key = format!("{REG_V2_PREFIX}{old_id}");
-                db.put(REG_V2_NS, &key, &true).await?;
-                ids.push(old_id);
-            }
+impl NatGwRow {
+    fn into_natgw(self) -> NatGw {
+        let id = thing_to_id_string("natgw:", &self.id);
+        let state = match self.state.as_str() {
+            "active" => NatGwState::Active,
+            "error" => NatGwState::Error,
+            // Default to Provisioning for anything else so a bad
+            // migration doesn't crash the list. The schema's ASSERT
+            // keeps this branch unreachable in practice.
+            _ => NatGwState::Provisioning,
+        };
+        NatGw {
+            meta: ResourceMeta {
+                id,
+                name: self.name,
+                status: self.status.unwrap_or_else(|| "active".to_string()),
+                labels: self
+                    .labels
+                    .and_then(|v| serde_json::from_value(v).ok())
+                    .unwrap_or_default(),
+                created_at: iso8601_to_epoch(&self.created_at),
+                updated_at: iso8601_to_epoch(&self.updated_at),
+            },
+            vpc_id: self.vpc.into(),
+            vpc_name: self.vpc_name,
+            public_ipv6: self
+                .public_ipv6
+                .parse()
+                .unwrap_or(std::net::Ipv6Addr::UNSPECIFIED),
+            hypervisor_id: self.hypervisor,
+            state,
         }
-        db.delete(REG_V1.0, REG_V1.1).await?;
+    }
+}
+
+fn decode_first(raw: Vec<serde_json::Value>) -> anyhow::Result<Option<NatGw>> {
+    match raw.into_iter().next() {
+        None => Ok(None),
+        Some(v) => {
+            let row: NatGwRow = serde_json::from_value(v)
+                .map_err(|e| anyhow::anyhow!("deserialise natgw row: {e}"))?;
+            Ok(Some(row.into_natgw()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn temp_store() -> (
+        tempfile::TempDir,
+        NatGwStore,
+        crate::vpc::store::VpcStore,
+        nauka_org::store::OrgStore,
+    ) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = EmbeddedDb::open(&dir.path().join("natgws.skv"))
+            .await
+            .expect("open EmbeddedDb");
+        nauka_state::apply_cluster_schemas(&db)
+            .await
+            .expect("apply cluster schemas");
+        let natgws = NatGwStore::new(db.clone());
+        let vpcs = crate::vpc::store::VpcStore::new(db.clone());
+        let orgs = nauka_org::store::OrgStore::new(db);
+        (dir, natgws, vpcs, orgs)
     }
 
-    Ok(ids)
-}
+    async fn seed_vpc(
+        vpcs: &crate::vpc::store::VpcStore,
+        orgs: &nauka_org::store::OrgStore,
+    ) -> crate::vpc::types::Vpc {
+        orgs.create("acme").await.expect("create org");
+        vpcs.create("web", "acme", "10.0.0.0/16", None, None)
+            .await
+            .expect("create vpc")
+    }
 
-async fn add_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let key = format!("{REG_V2_PREFIX}{id}");
-    db.put(REG_V2_NS, &key, &true).await?;
-    Ok(())
-}
+    #[tokio::test]
+    async fn create_then_get_by_name() {
+        let (_d, natgws, vpcs, orgs) = temp_store().await;
+        seed_vpc(&vpcs, &orgs).await;
+        let natgw = natgws
+            .create("gw1", "web", "acme", "hv-1", "2a01:4f8:c012:abcd::/64")
+            .await
+            .expect("create natgw");
+        assert_eq!(natgw.meta.name, "gw1");
+        // NatGwId prefix is `nat`, not `natgw`.
+        assert!(natgw.meta.id.starts_with("nat-"), "got: {}", natgw.meta.id);
+        assert_eq!(natgw.hypervisor_id, "hv-1");
+        assert!(matches!(natgw.state, NatGwState::Provisioning));
 
-async fn remove_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let key = format!("{REG_V2_PREFIX}{id}");
-    db.delete(REG_V2_NS, &key).await?;
-    Ok(())
+        let got = natgws
+            .get("gw1", Some("web"), Some("acme"))
+            .await
+            .expect("get")
+            .expect("missing");
+        assert_eq!(got.meta.id, natgw.meta.id);
+        assert_eq!(got.public_ipv6, natgw.public_ipv6);
+    }
+
+    #[tokio::test]
+    async fn only_one_natgw_per_vpc() {
+        let (_d, natgws, vpcs, orgs) = temp_store().await;
+        seed_vpc(&vpcs, &orgs).await;
+        natgws
+            .create("gw1", "web", "acme", "hv-1", "2a01:4f8:c012:abcd::/64")
+            .await
+            .unwrap();
+        let err = natgws
+            .create("gw2", "web", "acme", "hv-1", "2a01:4f8:c012:abcd::/64")
+            .await
+            .expect_err("second natgw should fail");
+        assert!(
+            err.to_string().contains("already has a NAT gateway"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_filters_by_vpc() {
+        let (_d, natgws, vpcs, orgs) = temp_store().await;
+        orgs.create("acme").await.expect("create org");
+        vpcs.create("web", "acme", "10.0.0.0/16", None, None)
+            .await
+            .unwrap();
+        vpcs.create("api", "acme", "10.1.0.0/16", None, None)
+            .await
+            .unwrap();
+        natgws
+            .create("gw1", "web", "acme", "hv-1", "2a01:4f8:c012:abcd::/64")
+            .await
+            .unwrap();
+        natgws
+            .create("gw2", "api", "acme", "hv-2", "2a01:4f8:c012:1234::/64")
+            .await
+            .unwrap();
+
+        let web = natgws.list(Some("web")).await.unwrap();
+        assert_eq!(web.len(), 1);
+        let all = natgws.list(None).await.unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn delete_removes_natgw_and_releases_ipv6() {
+        let (_d, natgws, vpcs, orgs) = temp_store().await;
+        seed_vpc(&vpcs, &orgs).await;
+        let gw = natgws
+            .create("gw1", "web", "acme", "hv-1", "2a01:4f8:c012:abcd::/64")
+            .await
+            .unwrap();
+        natgws.delete("gw1", "web", "acme").await.expect("delete");
+        assert!(natgws.get(&gw.meta.id, None, None).await.unwrap().is_none());
+    }
 }

--- a/layers/network/src/vpc/peering/handlers.rs
+++ b/layers/network/src/vpc/peering/handlers.rs
@@ -54,7 +54,11 @@ pub fn handler() -> HandlerFn {
             Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
         > {
             Box::pin(async move {
-                let store = PeeringStore::new(nauka_hypervisor::controlplane::connect().await?);
+                // P2.12 (sifrah/nauka#216): PeeringStore now takes an
+                // EmbeddedDb directly; reach the cluster handle via
+                // the wrapper's `.embedded()` accessor.
+                let cluster_db = nauka_hypervisor::controlplane::connect().await?;
+                let store = PeeringStore::new(cluster_db.embedded().clone());
                 match req.operation.as_str() {
                     "create" => {
                         let vpc = req

--- a/layers/network/src/vpc/peering/store.rs
+++ b/layers/network/src/vpc/peering/store.rs
@@ -1,24 +1,52 @@
+//! VPC peering persistence on the SurrealDB-backed cluster store.
+//!
+//! P2.12 (sifrah/nauka#216) migrated this module from the legacy
+//! raw-KV cluster path to the native SurrealDB SDK on top of
+//! [`EmbeddedDb`], and shipped the SCHEMAFULL `vpc_peering` table in
+//! `layers/network/schemas/peering.surql` — both are net-new in this
+//! PR because P2.5 didn't include peering in its initial schema
+//! bundle.
+//!
+//! The `(vpc, peer_vpc)` pair is enforced unique at the schema level;
+//! the reverse pair `(peer_vpc, vpc)` is enforced at the application
+//! level here because SurrealDB can't express "unique on an unordered
+//! pair of fields" directly. That check runs before the SDK `CREATE`
+//! so we return the classic `"peering already exists between '<a>'
+//! and '<b>'"` error text without racing the schema.
+
 use nauka_core::id::PeeringId;
+use nauka_core::resource::epoch_to_iso8601;
 use nauka_core::resource::ResourceMeta;
-use nauka_hypervisor::controlplane::ClusterDb;
+use nauka_state::sdk_bridge::{iso8601_to_epoch, thing_to_id_string};
+use nauka_state::EmbeddedDb;
+use serde::Deserialize;
 
 use super::types::{PeeringState, VpcPeering};
 
-const NS_PEER: &str = "vpcpeer";
-const NS_PEER_IDX: &str = "vpcpeer-idx";
-const REG_V2_NS: &str = "_reg_v2";
-const REG_V2_PREFIX: &str = "vpcpeer/";
-const REG_V1: (&str, &str) = ("_reg", "vpcpeer-ids");
+/// SurrealDB table backing this store.
+const PEERING_TABLE: &str = "vpc_peering";
 
 pub struct PeeringStore {
-    db: ClusterDb,
+    db: EmbeddedDb,
 }
 
 impl PeeringStore {
-    pub fn new(db: ClusterDb) -> Self {
+    /// Build a [`PeeringStore`] over a SurrealDB handle.
+    ///
+    /// Call sites that already hold a cluster-DB wrapper pass
+    /// `cluster_db.embedded().clone()`.
+    pub fn new(db: EmbeddedDb) -> Self {
         Self { db }
     }
 
+    /// Create a new peering between two VPCs in the same org.
+    ///
+    /// Rejects self-peering, rejects overlapping CIDRs, and rejects
+    /// any attempt to create a pairing that already exists in either
+    /// direction. The schema's composite unique index on
+    /// `(vpc, peer_vpc)` closes the "forward" race; this method
+    /// additionally checks the reverse direction before hitting the
+    /// schema.
     pub async fn create(
         &self,
         vpc_name_or_id: &str,
@@ -35,12 +63,13 @@ impl PeeringStore {
             .await?
             .ok_or_else(|| anyhow::anyhow!("vpc '{peer_vpc_name_or_id}' not found"))?;
 
-        // Can't peer with self
+        // Can't peer with self.
         if vpc.meta.id == peer_vpc.meta.id {
             anyhow::bail!("cannot peer a VPC with itself");
         }
 
-        // CIDRs must not overlap
+        // CIDRs must not overlap (one containing the other would
+        // make routing ambiguous).
         if let (Ok(a), Ok(b)) = (
             vpc.cidr.parse::<ipnet::Ipv4Net>(),
             peer_vpc.cidr.parse::<ipnet::Ipv4Net>(),
@@ -50,12 +79,12 @@ impl PeeringStore {
             }
         }
 
-        // Check no existing peering between these two
-        let idx_key = format!("{}/{}", vpc.meta.id, peer_vpc.meta.id);
-        let reverse_key = format!("{}/{}", peer_vpc.meta.id, vpc.meta.id);
-        let existing: Option<String> = self.db.get(NS_PEER_IDX, &idx_key).await?;
-        let existing_rev: Option<String> = self.db.get(NS_PEER_IDX, &reverse_key).await?;
-        if existing.is_some() || existing_rev.is_some() {
+        // Check no existing peering in either direction. The schema
+        // enforces the forward direction on write; we short-circuit
+        // early so the error message matches the pre-P2.12 wording.
+        if self.exists_pair(&vpc.meta.id, &peer_vpc.meta.id).await?
+            || self.exists_pair(&peer_vpc.meta.id, &vpc.meta.id).await?
+        {
             anyhow::bail!(
                 "peering already exists between '{}' and '{}'",
                 vpc.meta.name,
@@ -73,29 +102,101 @@ impl PeeringStore {
             state: PeeringState::Active,
         };
 
-        self.db.put(NS_PEER, &peering.meta.id, &peering).await?;
-        self.db.put(NS_PEER_IDX, &idx_key, &peering.meta.id).await?;
-        self.db
-            .put(NS_PEER_IDX, &reverse_key, &peering.meta.id)
-            .await?;
-        add_id(&self.db, &peering.meta.id).await?;
+        let created_at_iso = epoch_to_iso8601(peering.meta.created_at);
+        let updated_at_iso = epoch_to_iso8601(peering.meta.updated_at);
+        let labels_json = serde_json::to_value(&peering.meta.labels)
+            .map_err(|e| anyhow::anyhow!("serialise labels: {e}"))?;
+        let state_str = match peering.state {
+            PeeringState::Active => "active",
+            PeeringState::Pending => "pending",
+        };
+
+        let response = self
+            .db
+            .client()
+            .query(
+                "CREATE type::record($tbl, $id) SET \
+                 name = $name, \
+                 status = $status, \
+                 labels = $labels, \
+                 vpc = $vpc, \
+                 vpc_name = $vpc_name, \
+                 peer_vpc = $peer_vpc, \
+                 peer_vpc_name = $peer_vpc_name, \
+                 state = $state, \
+                 created_at = <datetime>$created_at, \
+                 updated_at = <datetime>$updated_at",
+            )
+            .bind(("tbl", PEERING_TABLE))
+            .bind(("id", peering.meta.id.clone()))
+            .bind(("name", peering.meta.name.clone()))
+            .bind(("status", peering.meta.status.clone()))
+            .bind(("labels", labels_json))
+            .bind(("vpc", peering.vpc_id.as_str().to_string()))
+            .bind(("vpc_name", peering.vpc_name.clone()))
+            .bind(("peer_vpc", peering.peer_vpc_id.as_str().to_string()))
+            .bind(("peer_vpc_name", peering.peer_vpc_name.clone()))
+            .bind(("state", state_str))
+            .bind(("created_at", created_at_iso))
+            .bind(("updated_at", updated_at_iso))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        response.check().map_err(|e| anyhow::anyhow!("{e}"))?;
 
         Ok(peering)
     }
 
-    pub async fn get(&self, name_or_id: &str) -> anyhow::Result<Option<VpcPeering>> {
-        // Peerings are always looked up by ID (names are auto-generated)
-        self.db.get(NS_PEER, name_or_id).await.map_err(Into::into)
+    async fn exists_pair(&self, vpc_id: &str, peer_vpc_id: &str) -> anyhow::Result<bool> {
+        let mut response = self
+            .db
+            .client()
+            .query(
+                "SELECT name FROM vpc_peering \
+                 WHERE vpc = $vpc AND peer_vpc = $peer_vpc LIMIT 1",
+            )
+            .bind(("vpc", vpc_id.to_string()))
+            .bind(("peer_vpc", peer_vpc_id.to_string()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let rows: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        Ok(!rows.is_empty())
     }
 
+    /// Look up a peering by id. Peerings don't have a user-facing
+    /// name so they're always retrieved by their auto-generated
+    /// record id.
+    pub async fn get(&self, name_or_id: &str) -> anyhow::Result<Option<VpcPeering>> {
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT * FROM type::record($tbl, $id)")
+            .bind(("tbl", PEERING_TABLE))
+            .bind(("id", name_or_id.to_string()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let raw: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        decode_first(raw)
+    }
+
+    /// List peerings, optionally filtered to those touching a
+    /// specific VPC (by name or record id) on either side of the
+    /// pair.
     pub async fn list(&self, vpc_name: Option<&str>) -> anyhow::Result<Vec<VpcPeering>> {
-        let ids = load_ids(&self.db).await?;
-        let mut peers = Vec::new();
-        for id in &ids {
-            if let Some(p) = self.db.get::<VpcPeering>(NS_PEER, id).await? {
-                peers.push(p);
-            }
-        }
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT * FROM vpc_peering")
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let raw: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        let peers: Vec<VpcPeering> = raw
+            .into_iter()
+            .filter_map(|v| {
+                serde_json::from_value::<PeeringRow>(v)
+                    .ok()
+                    .map(PeeringRow::into_peering)
+            })
+            .collect();
         match vpc_name {
             Some(name) => Ok(peers
                 .into_iter()
@@ -110,58 +211,222 @@ impl PeeringStore {
         }
     }
 
+    /// Delete a peering. Peerings have no children, so this is a
+    /// single record-id DELETE.
     pub async fn delete(&self, name_or_id: &str) -> anyhow::Result<()> {
         let peering = self
             .get(name_or_id)
             .await?
             .ok_or_else(|| anyhow::anyhow!("peering '{name_or_id}' not found"))?;
-        let idx_key = format!(
-            "{}/{}",
-            peering.vpc_id.as_str(),
-            peering.peer_vpc_id.as_str()
-        );
-        let reverse_key = format!(
-            "{}/{}",
-            peering.peer_vpc_id.as_str(),
-            peering.vpc_id.as_str()
-        );
-        self.db.delete(NS_PEER, &peering.meta.id).await?;
-        self.db.delete(NS_PEER_IDX, &idx_key).await?;
-        self.db.delete(NS_PEER_IDX, &reverse_key).await?;
-        remove_id(&self.db, &peering.meta.id).await?;
+        let result = self
+            .db
+            .client()
+            .query("DELETE type::record($tbl, $id)")
+            .bind(("tbl", PEERING_TABLE))
+            .bind(("id", peering.meta.id.clone()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        result.check().map_err(|e| anyhow::anyhow!("{e}"))?;
         Ok(())
     }
 }
 
-async fn load_ids(db: &ClusterDb) -> anyhow::Result<Vec<String>> {
-    let keys = db.scan_keys(REG_V2_NS, REG_V2_PREFIX).await?;
-    let mut ids: Vec<String> = keys
-        .into_iter()
-        .filter_map(|k| k.strip_prefix(REG_V2_PREFIX).map(|s| s.to_string()))
-        .collect();
+/// Row shape returned by `SELECT * FROM vpc_peering`.
+#[derive(Debug, Deserialize)]
+struct PeeringRow {
+    id: serde_json::Value,
+    name: String,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    labels: Option<serde_json::Value>,
+    vpc: String,
+    vpc_name: String,
+    peer_vpc: String,
+    peer_vpc_name: String,
+    state: String,
+    created_at: String,
+    updated_at: String,
+}
 
-    if let Some(v1_ids) = db.get::<Vec<String>>(REG_V1.0, REG_V1.1).await? {
-        for old_id in v1_ids {
-            if !ids.contains(&old_id) {
-                let key = format!("{REG_V2_PREFIX}{old_id}");
-                db.put(REG_V2_NS, &key, &true).await?;
-                ids.push(old_id);
-            }
+impl PeeringRow {
+    fn into_peering(self) -> VpcPeering {
+        let id = thing_to_id_string("vpc_peering:", &self.id);
+        let state = match self.state.as_str() {
+            "pending" => PeeringState::Pending,
+            // Default to Active for anything else so a malformed row
+            // doesn't crash the list. The schema's ASSERT keeps this
+            // branch unreachable in practice.
+            _ => PeeringState::Active,
+        };
+        VpcPeering {
+            meta: ResourceMeta {
+                id,
+                name: self.name,
+                status: self.status.unwrap_or_else(|| "active".to_string()),
+                labels: self
+                    .labels
+                    .and_then(|v| serde_json::from_value(v).ok())
+                    .unwrap_or_default(),
+                created_at: iso8601_to_epoch(&self.created_at),
+                updated_at: iso8601_to_epoch(&self.updated_at),
+            },
+            vpc_id: self.vpc.into(),
+            vpc_name: self.vpc_name,
+            peer_vpc_id: self.peer_vpc.into(),
+            peer_vpc_name: self.peer_vpc_name,
+            state,
         }
-        db.delete(REG_V1.0, REG_V1.1).await?;
+    }
+}
+
+fn decode_first(raw: Vec<serde_json::Value>) -> anyhow::Result<Option<VpcPeering>> {
+    match raw.into_iter().next() {
+        None => Ok(None),
+        Some(v) => {
+            let row: PeeringRow = serde_json::from_value(v)
+                .map_err(|e| anyhow::anyhow!("deserialise peering row: {e}"))?;
+            Ok(Some(row.into_peering()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn temp_store() -> (
+        tempfile::TempDir,
+        PeeringStore,
+        crate::vpc::store::VpcStore,
+        nauka_org::store::OrgStore,
+    ) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = EmbeddedDb::open(&dir.path().join("peerings.skv"))
+            .await
+            .expect("open EmbeddedDb");
+        nauka_state::apply_cluster_schemas(&db)
+            .await
+            .expect("apply cluster schemas");
+        let peerings = PeeringStore::new(db.clone());
+        let vpcs = crate::vpc::store::VpcStore::new(db.clone());
+        let orgs = nauka_org::store::OrgStore::new(db);
+        (dir, peerings, vpcs, orgs)
     }
 
-    Ok(ids)
-}
+    async fn seed_two_vpcs(
+        vpcs: &crate::vpc::store::VpcStore,
+        orgs: &nauka_org::store::OrgStore,
+    ) -> (crate::vpc::types::Vpc, crate::vpc::types::Vpc) {
+        orgs.create("acme").await.unwrap();
+        let a = vpcs
+            .create("web", "acme", "10.0.0.0/16", None, None)
+            .await
+            .unwrap();
+        let b = vpcs
+            .create("db", "acme", "10.1.0.0/16", None, None)
+            .await
+            .unwrap();
+        (a, b)
+    }
 
-async fn add_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let key = format!("{REG_V2_PREFIX}{id}");
-    db.put(REG_V2_NS, &key, &true).await?;
-    Ok(())
-}
+    #[tokio::test]
+    async fn create_then_get_by_id() {
+        let (_d, peerings, vpcs, orgs) = temp_store().await;
+        seed_two_vpcs(&vpcs, &orgs).await;
+        let p = peerings
+            .create("web", "db", Some("acme"))
+            .await
+            .expect("create");
+        assert_eq!(p.meta.name, "web-to-db");
+        // `PeeringId` uses the `peer` prefix; the SurrealDB record
+        // ends up at `vpc_peering:peer-01J…`.
+        assert!(p.meta.id.starts_with("peer-"), "got: {}", p.meta.id);
+        let got = peerings.get(&p.meta.id).await.unwrap().expect("missing");
+        assert_eq!(got.meta.id, p.meta.id);
+    }
 
-async fn remove_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let key = format!("{REG_V2_PREFIX}{id}");
-    db.delete(REG_V2_NS, &key).await?;
-    Ok(())
+    #[tokio::test]
+    async fn self_peering_is_rejected() {
+        let (_d, peerings, vpcs, orgs) = temp_store().await;
+        seed_two_vpcs(&vpcs, &orgs).await;
+        let err = peerings
+            .create("web", "web", Some("acme"))
+            .await
+            .expect_err("self-peering");
+        assert!(err.to_string().contains("cannot peer"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn overlapping_cidr_peering_is_rejected_upstream() {
+        // The VPC layer already rejects overlapping CIDRs at creation
+        // time, so a peering between two overlapping VPCs is
+        // unreachable in practice — the second `VpcStore::create`
+        // fails first. This test pins that upstream invariant so a
+        // future change that relaxes `VpcStore` overlap checking
+        // fails here instead of silently widening the surface.
+        let (_d, _peerings, vpcs, orgs) = temp_store().await;
+        orgs.create("acme").await.unwrap();
+        vpcs.create("a", "acme", "10.0.0.0/16", None, None)
+            .await
+            .unwrap();
+        vpcs.create("b", "acme", "10.0.0.0/24", None, None)
+            .await
+            .expect_err("overlap at vpc creation");
+    }
+
+    #[tokio::test]
+    async fn duplicate_pair_rejected_forward() {
+        let (_d, peerings, vpcs, orgs) = temp_store().await;
+        seed_two_vpcs(&vpcs, &orgs).await;
+        peerings.create("web", "db", Some("acme")).await.unwrap();
+        let err = peerings
+            .create("web", "db", Some("acme"))
+            .await
+            .expect_err("duplicate");
+        assert!(err.to_string().contains("already exists"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn duplicate_pair_rejected_reverse() {
+        let (_d, peerings, vpcs, orgs) = temp_store().await;
+        seed_two_vpcs(&vpcs, &orgs).await;
+        peerings.create("web", "db", Some("acme")).await.unwrap();
+        let err = peerings
+            .create("db", "web", Some("acme"))
+            .await
+            .expect_err("reverse duplicate");
+        assert!(err.to_string().contains("already exists"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn list_touching_vpc() {
+        let (_d, peerings, vpcs, orgs) = temp_store().await;
+        orgs.create("acme").await.unwrap();
+        vpcs.create("a", "acme", "10.0.0.0/16", None, None)
+            .await
+            .unwrap();
+        vpcs.create("b", "acme", "10.1.0.0/16", None, None)
+            .await
+            .unwrap();
+        vpcs.create("c", "acme", "10.2.0.0/16", None, None)
+            .await
+            .unwrap();
+        peerings.create("a", "b", Some("acme")).await.unwrap();
+        peerings.create("b", "c", Some("acme")).await.unwrap();
+
+        let touching_b = peerings.list(Some("b")).await.unwrap();
+        assert_eq!(touching_b.len(), 2);
+        let touching_a = peerings.list(Some("a")).await.unwrap();
+        assert_eq!(touching_a.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn delete_removes_peering() {
+        let (_d, peerings, vpcs, orgs) = temp_store().await;
+        seed_two_vpcs(&vpcs, &orgs).await;
+        let p = peerings.create("web", "db", Some("acme")).await.unwrap();
+        peerings.delete(&p.meta.id).await.expect("delete");
+        assert!(peerings.get(&p.meta.id).await.unwrap().is_none());
+    }
 }

--- a/layers/network/src/vpc/store.rs
+++ b/layers/network/src/vpc/store.rs
@@ -1,36 +1,100 @@
+//! VPC persistence on the SurrealDB-backed cluster store.
+//!
+//! P2.12 (sifrah/nauka#216) migrated this module from the legacy
+//! raw-KV cluster path to the native SurrealDB SDK on top of
+//! [`EmbeddedDb`], following the same pattern P2.9/P2.10/P2.11
+//! established for the org-layer stores. Every method now reaches the
+//! SDK via `self.db.client()` and writes/reads against the SCHEMAFULL
+//! `vpc` table defined in `layers/network/schemas/vpc.surql` (applied
+//! to the cluster by `nauka_state::apply_cluster_schemas` at
+//! bootstrap per ADR 0004).
+//!
+//! The store holds an [`EmbeddedDb`] directly. Call sites pass
+//! `cluster_db.embedded().clone()` at construction time; the clone is
+//! cheap (`Arc`-shared `Surreal<Db>` router).
+//!
+//! The legacy `vpc` / `vpc-idx` / `_reg_v2` sidecar namespaces are
+//! gone: the schema's composite unique index on `(org, name)` is now
+//! the source of truth for "have we seen this (org, name) pair before?",
+//! and `SELECT * FROM vpc` walks every row directly.
+//!
+//! The VNI counter, which the pre-P2.12 version kept in a raw-KV
+//! `_reg:vni-counter` key, is now computed as `max(vni) + 1` across
+//! the `vpc` table, falling back to [`VNI_START`] (100) on an empty
+//! table. Concurrent creators still race, but the SCHEMAFULL `vpc_vni`
+//! unique index guarantees at most one of the racing `CREATE`s wins
+//! and the other gets a clean "already exists" rollback — the store
+//! retries the allocation in a loop to stay obviously-correct under
+//! concurrency.
+
 use nauka_core::id::VpcId;
+use nauka_core::resource::epoch_to_iso8601;
 use nauka_core::resource::ResourceMeta;
-use nauka_hypervisor::controlplane::ClusterDb;
+use nauka_state::sdk_bridge::{classify_create_error, iso8601_to_epoch, thing_to_id_string};
+use nauka_state::EmbeddedDb;
+use serde::Deserialize;
 
 use super::types::Vpc;
 
-const NS_VPC: &str = "vpc";
-const NS_VPC_IDX: &str = "vpc-idx";
-const REG_V2_NS: &str = "_reg_v2";
-const REG_V2_PREFIX: &str = "vpc/";
-/// Legacy v1 registry key — read during migration, never written.
-const REG_V1: (&str, &str) = ("_reg", "vpc-ids");
-const VNI_COUNTER: (&str, &str) = ("_reg", "vni-counter");
+/// SurrealDB table backing this store. Defined by
+/// `layers/network/schemas/vpc.surql` as `DEFINE TABLE vpc SCHEMAFULL`
+/// and applied at bootstrap via `nauka_state::apply_cluster_schemas`.
+const VPC_TABLE: &str = "vpc";
+
+/// First VNI value handed out on a fresh cluster. VNIs below 100 are
+/// reserved for future system use.
 const VNI_START: u32 = 100;
 
+/// Maximum number of VNI allocation retries before giving up. A real
+/// failure mode is extreme concurrency on `create`, which is not a
+/// production path today (VPCs are created via operator CLI). 8
+/// retries is plenty of headroom without risking a runaway loop.
+const VNI_RETRY_LIMIT: u32 = 8;
+
 pub struct VpcStore {
-    db: ClusterDb,
+    db: EmbeddedDb,
 }
 
 impl VpcStore {
-    pub fn new(db: ClusterDb) -> Self {
+    /// Build a [`VpcStore`] over a SurrealDB handle.
+    ///
+    /// Call sites that already hold a cluster-DB wrapper pass
+    /// `cluster_db.embedded().clone()`.
+    pub fn new(db: EmbeddedDb) -> Self {
         Self { db }
     }
 
+    /// Pick the next VNI to allocate.
+    ///
+    /// Reads `math::max(vni)` from the `vpc` table and returns
+    /// `max + 1`, or [`VNI_START`] on an empty table. The SCHEMAFULL
+    /// `vpc_vni` unique index closes the concurrent-allocation race:
+    /// if two creators see the same `max`, one of their `CREATE`s
+    /// will fail the unique-index check, and the caller retries.
     async fn next_vni(&self) -> anyhow::Result<u32> {
-        let current: Option<u32> = self.db.get(VNI_COUNTER.0, VNI_COUNTER.1).await?;
-        let vni = current.unwrap_or(VNI_START);
-        self.db
-            .put(VNI_COUNTER.0, VNI_COUNTER.1, &(vni + 1))
-            .await?;
-        Ok(vni)
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT math::max(vni) AS max_vni FROM vpc GROUP ALL")
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let rows: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        let max_vni = rows
+            .into_iter()
+            .next()
+            .and_then(|row| row.get("max_vni").cloned())
+            .and_then(|v| v.as_u64())
+            .map(|v| v as u32);
+        Ok(max_vni.map(|v| v + 1).unwrap_or(VNI_START))
     }
 
+    /// Create a new VPC within an org.
+    ///
+    /// The duplicate-name path is closed by the SCHEMAFULL
+    /// `vpc_org_name` composite unique index. The duplicate-VNI path
+    /// is closed by the `vpc_vni` unique index; on a rare race (two
+    /// creators observing the same `max(vni)`) the loser retries the
+    /// whole allocation. [`VNI_RETRY_LIMIT`] caps the retry count.
     pub async fn create(
         &self,
         name: &str,
@@ -39,82 +103,175 @@ impl VpcStore {
         project_id: Option<String>,
         env_id: Option<String>,
     ) -> anyhow::Result<Vpc> {
-        // Resolve org. P2.9 (sifrah/nauka#213) migrated `OrgStore` to
-        // take an `EmbeddedDb` directly; we hand it the cluster-DB
-        // wrapper's internal SurrealDB handle via `.embedded().clone()`.
-        let org_store = nauka_org::store::OrgStore::new(self.db.embedded().clone());
+        // Resolve the owning org via the post-P2.9 OrgStore API.
+        let org_store = nauka_org::store::OrgStore::new(self.db.clone());
         let org = org_store
             .get(org_name)
             .await?
             .ok_or_else(|| anyhow::anyhow!("org '{org_name}' not found"))?;
 
-        // Validate CIDR
+        // Validate CIDR is in the private-address space.
         let new_net = crate::validate::private_cidr(cidr)?;
 
-        // Check CIDR doesn't overlap with existing VPCs in this org
+        // Check CIDR doesn't overlap with existing VPCs in this org.
         let existing_vpcs = self.list(Some(org_name)).await?;
         let existing_cidrs: Vec<String> = existing_vpcs.iter().map(|v| v.cidr.clone()).collect();
         crate::validate::no_overlap(&new_net, &existing_cidrs)?;
 
-        // Check uniqueness within org
-        let idx_key = format!("{}/{}", org.meta.id, name);
-        let existing: Option<String> = self.db.get(NS_VPC_IDX, &idx_key).await?;
-        if existing.is_some() {
-            anyhow::bail!("vpc '{name}' already exists in org '{org_name}'");
+        // Retry loop: on a VNI collision, re-read `max(vni)` and try
+        // again. Any other error (including the composite `(org,
+        // name)` duplicate) breaks out immediately.
+        let mut attempt = 0u32;
+        loop {
+            let vni = self.next_vni().await?;
+            let vpc = Vpc {
+                meta: ResourceMeta::new(VpcId::generate().to_string(), name),
+                cidr: cidr.to_string(),
+                org_id: org.meta.id.clone().into(),
+                org_name: org.meta.name.clone(),
+                vni,
+                project_id: project_id.clone().map(|s| s.into()),
+                env_id: env_id.clone().map(|s| s.into()),
+            };
+
+            match self.insert(&vpc).await {
+                Ok(()) => return Ok(vpc),
+                Err(e) => {
+                    let msg = e.to_string().to_lowercase();
+                    let is_vni_conflict = msg.contains("vpc_vni");
+                    let is_org_name_conflict = msg.contains("vpc_org_name");
+                    let is_name_conflict = is_org_name_conflict
+                        || (msg.contains("already exists") && !is_vni_conflict);
+
+                    if is_name_conflict {
+                        return Err(anyhow::anyhow!(
+                            "vpc '{name}' already exists in org '{org_name}'"
+                        ));
+                    }
+
+                    if is_vni_conflict && attempt + 1 < VNI_RETRY_LIMIT {
+                        attempt += 1;
+                        continue;
+                    }
+
+                    return Err(anyhow::anyhow!(classify_create_error("vpc", name, &msg)));
+                }
+            }
         }
-
-        let vni = self.next_vni().await?;
-
-        let vpc = Vpc {
-            meta: ResourceMeta::new(VpcId::generate().to_string(), name),
-            cidr: cidr.to_string(),
-            org_id: org.meta.id.clone().into(),
-            org_name: org.meta.name.clone(),
-            vni,
-            project_id: project_id.map(|s| s.into()),
-            env_id: env_id.map(|s| s.into()),
-        };
-
-        self.db.put(NS_VPC, &vpc.meta.id, &vpc).await?;
-        self.db.put(NS_VPC_IDX, &idx_key, &vpc.meta.id).await?;
-        add_id(&self.db, &vpc.meta.id).await?;
-
-        Ok(vpc)
     }
 
+    /// Write the row. Returns the raw SurrealDB error on failure so
+    /// the caller can classify it.
+    async fn insert(&self, vpc: &Vpc) -> anyhow::Result<()> {
+        let created_at_iso = epoch_to_iso8601(vpc.meta.created_at);
+        let updated_at_iso = epoch_to_iso8601(vpc.meta.updated_at);
+        let labels_json = serde_json::to_value(&vpc.meta.labels)
+            .map_err(|e| anyhow::anyhow!("serialise labels: {e}"))?;
+
+        let response = self
+            .db
+            .client()
+            .query(
+                "CREATE type::record($tbl, $id) SET \
+                 name = $name, \
+                 status = $status, \
+                 labels = $labels, \
+                 cidr = $cidr, \
+                 vni = $vni, \
+                 org = $org, \
+                 org_name = $org_name, \
+                 project = $project, \
+                 env = $env, \
+                 created_at = <datetime>$created_at, \
+                 updated_at = <datetime>$updated_at",
+            )
+            .bind(("tbl", VPC_TABLE))
+            .bind(("id", vpc.meta.id.clone()))
+            .bind(("name", vpc.meta.name.clone()))
+            .bind(("status", vpc.meta.status.clone()))
+            .bind(("labels", labels_json))
+            .bind(("cidr", vpc.cidr.clone()))
+            .bind(("vni", vpc.vni as i64))
+            .bind(("org", vpc.org_id.as_str().to_string()))
+            .bind(("org_name", vpc.org_name.clone()))
+            .bind((
+                "project",
+                vpc.project_id.as_ref().map(|p| p.as_str().to_string()),
+            ))
+            .bind(("env", vpc.env_id.as_ref().map(|e| e.as_str().to_string())))
+            .bind(("created_at", created_at_iso))
+            .bind(("updated_at", updated_at_iso))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        response.check().map_err(|e| anyhow::anyhow!("{e}"))?;
+        Ok(())
+    }
+
+    /// Look up a VPC by id (when the input looks like a [`VpcId`])
+    /// or by name (otherwise).
     pub async fn get(
         &self,
         name_or_id: &str,
         org_name: Option<&str>,
     ) -> anyhow::Result<Option<Vpc>> {
         if VpcId::looks_like_id(name_or_id) {
-            return self.db.get(NS_VPC, name_or_id).await.map_err(Into::into);
+            return self.get_by_id(name_or_id).await;
         }
         let org_name =
             org_name.ok_or_else(|| anyhow::anyhow!("--org required to resolve VPC by name"))?;
-        // P2.9 migration: `OrgStore` now takes an `EmbeddedDb` directly,
-        // see the comment in `create()`.
-        let org_store = nauka_org::store::OrgStore::new(self.db.embedded().clone());
+
+        let org_store = nauka_org::store::OrgStore::new(self.db.clone());
         let org = org_store
             .get(org_name)
             .await?
             .ok_or_else(|| anyhow::anyhow!("org '{org_name}' not found"))?;
-        let idx_key = format!("{}/{}", org.meta.id, name_or_id);
-        let id: Option<String> = self.db.get(NS_VPC_IDX, &idx_key).await?;
-        match id {
-            Some(id) => self.db.get(NS_VPC, &id).await.map_err(Into::into),
-            None => Ok(None),
-        }
+
+        self.get_by_org_and_name(&org.meta.id, name_or_id).await
     }
 
+    async fn get_by_id(&self, id: &str) -> anyhow::Result<Option<Vpc>> {
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT * FROM type::record($tbl, $id)")
+            .bind(("tbl", VPC_TABLE))
+            .bind(("id", id.to_string()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let raw: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        decode_first(raw)
+    }
+
+    async fn get_by_org_and_name(&self, org_id: &str, name: &str) -> anyhow::Result<Option<Vpc>> {
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT * FROM vpc WHERE org = $org AND name = $name LIMIT 1")
+            .bind(("org", org_id.to_string()))
+            .bind(("name", name.to_string()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let raw: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        decode_first(raw)
+    }
+
+    /// List every VPC, optionally filtered by the owning org.
     pub async fn list(&self, org_name: Option<&str>) -> anyhow::Result<Vec<Vpc>> {
-        let ids = load_ids(&self.db).await?;
-        let mut vpcs = Vec::new();
-        for id in &ids {
-            if let Some(v) = self.db.get::<Vpc>(NS_VPC, id).await? {
-                vpcs.push(v);
-            }
-        }
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT * FROM vpc")
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let raw: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        let vpcs: Vec<Vpc> = raw
+            .into_iter()
+            .filter_map(|v| {
+                serde_json::from_value::<VpcRow>(v)
+                    .ok()
+                    .map(VpcRow::into_vpc)
+            })
+            .collect();
         match org_name {
             Some(name) => Ok(vpcs
                 .into_iter()
@@ -124,70 +281,350 @@ impl VpcStore {
         }
     }
 
+    /// Delete a VPC. Refuses to delete if the VPC still has subnets
+    /// or a NAT gateway — the caller must remove the children first.
     pub async fn delete(&self, name_or_id: &str, org_name: &str) -> anyhow::Result<()> {
         let vpc = self
             .get(name_or_id, Some(org_name))
             .await?
             .ok_or_else(|| anyhow::anyhow!("vpc '{name_or_id}' not found in org '{org_name}'"))?;
 
-        // Check for child subnets
-        let sub_store = super::subnet::store::SubnetStore::new(self.db.clone());
-        let subs = sub_store.list(Some(&vpc.meta.name), Some(org_name)).await?;
-        if !subs.is_empty() {
+        // Check for child subnets directly on the SCHEMAFULL `subnet`
+        // table — don't build a SubnetStore here, that would force a
+        // circular import dance when tests link it in. Same pattern
+        // OrgStore::delete uses to count projects.
+        let subnet_count = self.count_subnets_in_vpc(&vpc.meta.id).await?;
+        if subnet_count > 0 {
             anyhow::bail!(
                 "vpc '{}' has {} subnet(s). Delete them first.",
                 vpc.meta.name,
-                subs.len()
+                subnet_count
             );
         }
 
-        // Check for child NAT gateways
-        let natgw_store = super::natgw::store::NatGwStore::new(self.db.clone());
-        let natgws = natgw_store.list(Some(&vpc.meta.name)).await?;
-        if !natgws.is_empty() {
+        // Check for the NAT gateway (at most one per VPC).
+        let natgw_count = self.count_natgws_in_vpc(&vpc.meta.id).await?;
+        if natgw_count > 0 {
             anyhow::bail!(
                 "vpc '{}' has a NAT gateway. Delete it first.",
-                vpc.meta.name,
+                vpc.meta.name
             );
         }
 
-        let idx_key = format!("{}/{}", vpc.org_id.as_str(), vpc.meta.name);
-        self.db.delete(NS_VPC, &vpc.meta.id).await?;
-        self.db.delete(NS_VPC_IDX, &idx_key).await?;
-        remove_id(&self.db, &vpc.meta.id).await?;
+        // Check for peerings that still reference this VPC (on either
+        // side of the pair — peerings are bidirectional, and a live
+        // peering to a VPC that's about to disappear would leave a
+        // dangling row pointing at a dead record id).
+        let peering_count = self.count_peerings_touching_vpc(&vpc.meta.id).await?;
+        if peering_count > 0 {
+            anyhow::bail!(
+                "vpc '{}' has {} peering(s). Delete them first.",
+                vpc.meta.name,
+                peering_count
+            );
+        }
+
+        let result = self
+            .db
+            .client()
+            .query("DELETE type::record($tbl, $id)")
+            .bind(("tbl", VPC_TABLE))
+            .bind(("id", vpc.meta.id.clone()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        result.check().map_err(|e| anyhow::anyhow!("{e}"))?;
         Ok(())
     }
-}
 
-async fn load_ids(db: &ClusterDb) -> anyhow::Result<Vec<String>> {
-    let keys = db.scan_keys(REG_V2_NS, REG_V2_PREFIX).await?;
-    let mut ids: Vec<String> = keys
-        .into_iter()
-        .filter_map(|k| k.strip_prefix(REG_V2_PREFIX).map(|s| s.to_string()))
-        .collect();
-
-    if let Some(v1_ids) = db.get::<Vec<String>>(REG_V1.0, REG_V1.1).await? {
-        for old_id in v1_ids {
-            if !ids.contains(&old_id) {
-                let key = format!("{REG_V2_PREFIX}{old_id}");
-                db.put(REG_V2_NS, &key, &true).await?;
-                ids.push(old_id);
-            }
-        }
-        db.delete(REG_V1.0, REG_V1.1).await?;
+    async fn count_subnets_in_vpc(&self, vpc_id: &str) -> anyhow::Result<usize> {
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT name FROM subnet WHERE vpc = $vpc")
+            .bind(("vpc", vpc_id.to_string()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let rows: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        Ok(rows.len())
     }
 
-    Ok(ids)
+    async fn count_natgws_in_vpc(&self, vpc_id: &str) -> anyhow::Result<usize> {
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT name FROM natgw WHERE vpc = $vpc")
+            .bind(("vpc", vpc_id.to_string()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let rows: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        Ok(rows.len())
+    }
+
+    async fn count_peerings_touching_vpc(&self, vpc_id: &str) -> anyhow::Result<usize> {
+        let mut response = self
+            .db
+            .client()
+            .query(
+                "SELECT name FROM vpc_peering \
+                 WHERE vpc = $vpc OR peer_vpc = $vpc",
+            )
+            .bind(("vpc", vpc_id.to_string()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let rows: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        Ok(rows.len())
+    }
 }
 
-async fn add_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let key = format!("{REG_V2_PREFIX}{id}");
-    db.put(REG_V2_NS, &key, &true).await?;
-    Ok(())
+/// Row shape returned by `SELECT * FROM vpc`.
+#[derive(Debug, Deserialize)]
+struct VpcRow {
+    id: serde_json::Value,
+    name: String,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    labels: Option<serde_json::Value>,
+    cidr: String,
+    vni: i64,
+    org: String,
+    org_name: String,
+    #[serde(default)]
+    project: Option<String>,
+    #[serde(default)]
+    env: Option<String>,
+    created_at: String,
+    updated_at: String,
 }
 
-async fn remove_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let key = format!("{REG_V2_PREFIX}{id}");
-    db.delete(REG_V2_NS, &key).await?;
-    Ok(())
+impl VpcRow {
+    fn into_vpc(self) -> Vpc {
+        let id = thing_to_id_string("vpc:", &self.id);
+        let labels = self
+            .labels
+            .and_then(|v| serde_json::from_value(v).ok())
+            .unwrap_or_default();
+        Vpc {
+            meta: ResourceMeta {
+                id,
+                name: self.name,
+                status: self.status.unwrap_or_else(|| "active".to_string()),
+                labels,
+                created_at: iso8601_to_epoch(&self.created_at),
+                updated_at: iso8601_to_epoch(&self.updated_at),
+            },
+            cidr: self.cidr,
+            org_id: self.org.into(),
+            org_name: self.org_name,
+            vni: self.vni as u32,
+            project_id: self.project.map(Into::into),
+            env_id: self.env.map(Into::into),
+        }
+    }
+}
+
+fn decode_first(raw: Vec<serde_json::Value>) -> anyhow::Result<Option<Vpc>> {
+    match raw.into_iter().next() {
+        None => Ok(None),
+        Some(v) => {
+            let row: VpcRow = serde_json::from_value(v)
+                .map_err(|e| anyhow::anyhow!("deserialise vpc row: {e}"))?;
+            Ok(Some(row.into_vpc()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn temp_store() -> (tempfile::TempDir, VpcStore, nauka_org::store::OrgStore) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = EmbeddedDb::open(&dir.path().join("vpcs.skv"))
+            .await
+            .expect("open EmbeddedDb at temp path");
+        nauka_state::apply_cluster_schemas(&db)
+            .await
+            .expect("apply cluster schemas");
+        let vpcs = VpcStore::new(db.clone());
+        let orgs = nauka_org::store::OrgStore::new(db);
+        (dir, vpcs, orgs)
+    }
+
+    #[tokio::test]
+    async fn create_then_get_by_name() {
+        let (_d, vpcs, orgs) = temp_store().await;
+        orgs.create("acme").await.expect("create org");
+
+        let vpc = vpcs
+            .create("web", "acme", "10.0.0.0/16", None, None)
+            .await
+            .expect("create vpc");
+        assert_eq!(vpc.meta.name, "web");
+        assert!(vpc.meta.id.starts_with("vpc-"));
+        assert_eq!(vpc.cidr, "10.0.0.0/16");
+        assert_eq!(vpc.vni, VNI_START);
+
+        let got = vpcs
+            .get("web", Some("acme"))
+            .await
+            .expect("get")
+            .expect("missing");
+        assert_eq!(got.meta.id, vpc.meta.id);
+        assert_eq!(got.vni, VNI_START);
+    }
+
+    #[tokio::test]
+    async fn create_then_get_by_id() {
+        let (_d, vpcs, orgs) = temp_store().await;
+        orgs.create("acme").await.expect("create org");
+        let vpc = vpcs
+            .create("web", "acme", "10.0.0.0/16", None, None)
+            .await
+            .expect("create vpc");
+        let got = vpcs
+            .get(&vpc.meta.id, None)
+            .await
+            .expect("get")
+            .expect("missing");
+        assert_eq!(got.meta.id, vpc.meta.id);
+    }
+
+    #[tokio::test]
+    async fn vni_is_monotonic() {
+        let (_d, vpcs, orgs) = temp_store().await;
+        orgs.create("acme").await.expect("create org");
+        let a = vpcs
+            .create("a", "acme", "10.0.0.0/16", None, None)
+            .await
+            .unwrap();
+        let b = vpcs
+            .create("b", "acme", "10.1.0.0/16", None, None)
+            .await
+            .unwrap();
+        let c = vpcs
+            .create("c", "acme", "10.2.0.0/16", None, None)
+            .await
+            .unwrap();
+        assert_eq!(a.vni, VNI_START);
+        assert_eq!(b.vni, VNI_START + 1);
+        assert_eq!(c.vni, VNI_START + 2);
+    }
+
+    #[tokio::test]
+    async fn create_duplicate_name_in_same_org_fails() {
+        let (_d, vpcs, orgs) = temp_store().await;
+        orgs.create("acme").await.expect("create org");
+        vpcs.create("web", "acme", "10.0.0.0/16", None, None)
+            .await
+            .unwrap();
+        let err = vpcs
+            .create("web", "acme", "10.1.0.0/16", None, None)
+            .await
+            .expect_err("duplicate name should fail");
+        assert!(err.to_string().contains("already exists"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn overlapping_cidr_fails() {
+        let (_d, vpcs, orgs) = temp_store().await;
+        orgs.create("acme").await.expect("create org");
+        vpcs.create("web", "acme", "10.0.0.0/16", None, None)
+            .await
+            .unwrap();
+        let err = vpcs
+            .create("api", "acme", "10.0.1.0/24", None, None)
+            .await
+            .expect_err("overlapping cidr should fail");
+        assert!(
+            err.to_string().to_lowercase().contains("overlap"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_filters_by_org() {
+        let (_d, vpcs, orgs) = temp_store().await;
+        orgs.create("acme").await.expect("create acme");
+        orgs.create("globex").await.expect("create globex");
+        vpcs.create("web", "acme", "10.0.0.0/16", None, None)
+            .await
+            .unwrap();
+        vpcs.create("api", "acme", "10.1.0.0/16", None, None)
+            .await
+            .unwrap();
+        vpcs.create("web", "globex", "10.2.0.0/16", None, None)
+            .await
+            .unwrap();
+
+        let acme_vpcs = vpcs.list(Some("acme")).await.unwrap();
+        assert_eq!(acme_vpcs.len(), 2);
+        let all = vpcs.list(None).await.unwrap();
+        assert_eq!(all.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn delete_removes_vpc() {
+        let (_d, vpcs, orgs) = temp_store().await;
+        orgs.create("acme").await.expect("create org");
+        vpcs.create("web", "acme", "10.0.0.0/16", None, None)
+            .await
+            .unwrap();
+        vpcs.delete("web", "acme").await.expect("delete");
+        assert!(vpcs.get("web", Some("acme")).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_missing_vpc_errors() {
+        let (_d, vpcs, orgs) = temp_store().await;
+        orgs.create("acme").await.expect("create org");
+        let err = vpcs
+            .delete("does-not-exist", "acme")
+            .await
+            .expect_err("missing");
+        assert!(err.to_string().contains("not found"), "got: {err}");
+    }
+
+    /// VPC delete is forbidden while a child subnet still exists.
+    /// We seed the `subnet` row directly via a raw SurrealQL `CREATE`
+    /// to keep this test self-contained — the real SubnetStore is
+    /// exercised in its own test module.
+    #[tokio::test]
+    async fn delete_refuses_while_child_subnet_remains() {
+        let (_d, vpcs, orgs) = temp_store().await;
+        orgs.create("acme").await.expect("create org");
+        let vpc = vpcs
+            .create("web", "acme", "10.0.0.0/16", None, None)
+            .await
+            .unwrap();
+
+        vpcs.db
+            .client()
+            .query(
+                "CREATE type::record('subnet', 'subnet-fake') SET \
+                 name = 'sub1', \
+                 status = 'active', \
+                 labels = {}, \
+                 cidr = '10.0.1.0/24', \
+                 gateway = '10.0.1.1', \
+                 vpc = $vpc, \
+                 vpc_name = 'web', \
+                 created_at = time::now(), \
+                 updated_at = time::now()",
+            )
+            .bind(("vpc", vpc.meta.id.clone()))
+            .await
+            .unwrap()
+            .check()
+            .unwrap();
+
+        let err = vpcs
+            .delete("web", "acme")
+            .await
+            .expect_err("should refuse while child subnet exists");
+        assert!(
+            err.to_string().contains("subnet") && err.to_string().contains("Delete them first"),
+            "got: {err}"
+        );
+    }
 }

--- a/layers/network/src/vpc/subnet/handlers.rs
+++ b/layers/network/src/vpc/subnet/handlers.rs
@@ -55,7 +55,11 @@ pub fn handler() -> HandlerFn {
             Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
         > {
             Box::pin(async move {
-                let store = SubnetStore::new(nauka_hypervisor::controlplane::connect().await?);
+                // P2.12 (sifrah/nauka#216): SubnetStore now takes an
+                // EmbeddedDb directly; reach the cluster handle via
+                // the wrapper's `.embedded()` accessor.
+                let cluster_db = nauka_hypervisor::controlplane::connect().await?;
+                let store = SubnetStore::new(cluster_db.embedded().clone());
                 match req.operation.as_str() {
                     "create" => {
                         let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name"))?;

--- a/layers/network/src/vpc/subnet/ipam.rs
+++ b/layers/network/src/vpc/subnet/ipam.rs
@@ -1,35 +1,102 @@
 //! IPAM — IP Address Management for subnets.
 //!
-//! Allocates private IPs from a subnet's CIDR range. Uses a simple
-//! list of allocated IPs stored in TiKV (one key per subnet).
+//! Allocates private IPv4 addresses from a subnet's CIDR range. Each
+//! subnet gets one row in the SCHEMALESS `subnet_ipam` table holding
+//! the list of `(ip, vm_id)` allocations as a JSON blob; that blob is
+//! swapped on every allocate/release.
 //!
-//! Reserved addresses:
-//! - .0 = network address
-//! - .1 = gateway (assigned to the bridge)
-//! - .255 = broadcast (for /24)
+//! P2.12 (sifrah/nauka#216) migrated this helper from the legacy
+//! raw-KV cluster surface to the native SurrealDB SDK. The
+//! `subnet_ipam` table is deliberately SCHEMALESS (not in the
+//! `apply_cluster_schemas` bundle) because it's a transitional
+//! single-blob-per-subnet shape — Phase 3 codegen or a dedicated
+//! IPAM rewrite may normalise it into a `subnet_ip` table with one
+//! row per allocated address, at which point this helper goes away.
+//!
+//! Reserved addresses (skipped by the allocator):
+//! - `.0`  = network address
+//! - `.1`  = gateway (assigned to the bridge)
+//! - `.N`  = any IP already present in the allocation list
 
-use nauka_hypervisor::controlplane::ClusterDb;
+use nauka_state::EmbeddedDb;
+use serde::{Deserialize, Serialize};
 
-const NS_IPAM: &str = "ipam";
+/// Transitional SCHEMALESS table that holds the IPAM state. One row
+/// per subnet, keyed by the subnet's record id, with a `data` column
+/// containing the JSON blob of allocations.
+const IPAM_TABLE: &str = "subnet_ipam";
 
-/// Allocated IPs for a subnet, stored as a list in TiKV.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
+/// Allocated IPs for a subnet, stored as a single JSON blob per row.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct Allocations {
     ips: Vec<Allocation>,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct Allocation {
     ip: String,
     vm_id: String,
 }
 
+/// Ensure the transitional SCHEMALESS `subnet_ipam` table exists.
+/// Idempotent thanks to `IF NOT EXISTS`.
+async fn ensure_table(db: &EmbeddedDb) -> anyhow::Result<()> {
+    db.client()
+        .query("DEFINE TABLE IF NOT EXISTS subnet_ipam SCHEMALESS")
+        .await
+        .map_err(|e| anyhow::anyhow!("define subnet_ipam: {e}"))?
+        .check()
+        .map_err(|e| anyhow::anyhow!("define subnet_ipam check: {e}"))?;
+    Ok(())
+}
+
+/// Load the allocation blob for one subnet. Returns an empty
+/// [`Allocations`] if no row exists yet.
+async fn load(db: &EmbeddedDb, subnet_id: &str) -> anyhow::Result<Allocations> {
+    ensure_table(db).await?;
+    let mut response = db
+        .client()
+        .query("SELECT data FROM type::record($tbl, $id)")
+        .bind(("tbl", IPAM_TABLE))
+        .bind(("id", subnet_id.to_string()))
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    // SurrealDB returns one row per record; `.take("data")` pulls
+    // the `data` column into a flat `Vec<serde_json::Value>`.
+    let rows: Vec<serde_json::Value> = response.take("data").map_err(|e| anyhow::anyhow!("{e}"))?;
+    let first = rows.into_iter().next();
+    match first {
+        None | Some(serde_json::Value::Null) => Ok(Allocations::default()),
+        Some(v) => serde_json::from_value::<Allocations>(v)
+            .map_err(|e| anyhow::anyhow!("deserialise ipam blob: {e}")),
+    }
+}
+
+/// Persist the allocation blob for one subnet. Creates the row on
+/// first write via `UPSERT`.
+async fn save(db: &EmbeddedDb, subnet_id: &str, allocs: &Allocations) -> anyhow::Result<()> {
+    ensure_table(db).await?;
+    let data =
+        serde_json::to_value(allocs).map_err(|e| anyhow::anyhow!("serialise ipam blob: {e}"))?;
+    db.client()
+        .query("UPSERT type::record($tbl, $id) CONTENT { data: $data }")
+        .bind(("tbl", IPAM_TABLE))
+        .bind(("id", subnet_id.to_string()))
+        .bind(("data", data))
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?
+        .check()
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    Ok(())
+}
+
 /// Allocate the next available IP from a subnet.
 ///
-/// Skips network (.0), gateway (.1), and broadcast addresses.
-/// Returns the allocated IP as a string (e.g., "10.0.1.2").
+/// Skips the network address (`.0`), the gateway, and any IPs that
+/// are already allocated. If the VM already has an allocation in
+/// this subnet, returns the existing IP unchanged (idempotent).
 pub async fn allocate(
-    db: &ClusterDb,
+    db: &EmbeddedDb,
     subnet_id: &str,
     subnet_cidr: &str,
     gateway: &str,
@@ -39,37 +106,28 @@ pub async fn allocate(
         .parse()
         .map_err(|e| anyhow::anyhow!("invalid subnet CIDR: {e}"))?;
 
-    // Load current allocations
-    let mut allocs: Allocations = db.get(NS_IPAM, subnet_id).await?.unwrap_or_default();
+    let mut allocs = load(db, subnet_id).await?;
 
-    // Check if this VM already has an IP
+    // Check if this VM already has an IP in this subnet.
     if let Some(existing) = allocs.ips.iter().find(|a| a.vm_id == vm_id) {
         return Ok(existing.ip.clone());
     }
 
     let allocated_ips: Vec<&str> = allocs.ips.iter().map(|a| a.ip.as_str()).collect();
 
-    // Find next available host IP
     for host_ip in net.hosts() {
         let ip_str = host_ip.to_string();
-
-        // Skip gateway
         if ip_str == gateway {
             continue;
         }
-
-        // Skip already allocated
         if allocated_ips.contains(&ip_str.as_str()) {
             continue;
         }
-
-        // Found one — allocate it
         allocs.ips.push(Allocation {
             ip: ip_str.clone(),
             vm_id: vm_id.to_string(),
         });
-        db.put(NS_IPAM, subnet_id, &allocs).await?;
-
+        save(db, subnet_id, &allocs).await?;
         return Ok(ip_str);
     }
 
@@ -80,24 +138,21 @@ pub async fn allocate(
     )
 }
 
-/// Release an IP allocation for a VM.
-pub async fn release(db: &ClusterDb, subnet_id: &str, vm_id: &str) -> anyhow::Result<()> {
-    let mut allocs: Allocations = db.get(NS_IPAM, subnet_id).await?.unwrap_or_default();
-
+/// Release the IP allocation for a VM.
+pub async fn release(db: &EmbeddedDb, subnet_id: &str, vm_id: &str) -> anyhow::Result<()> {
+    let mut allocs = load(db, subnet_id).await?;
     allocs.ips.retain(|a| a.vm_id != vm_id);
-    db.put(NS_IPAM, subnet_id, &allocs).await?;
-
-    Ok(())
+    save(db, subnet_id, &allocs).await
 }
 
-/// Get the allocated IP for a VM in a subnet.
+/// Get the allocated IP for a VM in a subnet, or `None` if no
+/// allocation exists.
 pub async fn get_allocation(
-    db: &ClusterDb,
+    db: &EmbeddedDb,
     subnet_id: &str,
     vm_id: &str,
 ) -> anyhow::Result<Option<String>> {
-    let allocs: Allocations = db.get(NS_IPAM, subnet_id).await?.unwrap_or_default();
-
+    let allocs = load(db, subnet_id).await?;
     Ok(allocs
         .ips
         .iter()
@@ -108,6 +163,14 @@ pub async fn get_allocation(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    async fn temp_db() -> (tempfile::TempDir, EmbeddedDb) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = EmbeddedDb::open(&dir.path().join("ipam.skv"))
+            .await
+            .expect("open EmbeddedDb");
+        (dir, db)
+    }
 
     #[test]
     fn allocations_serde_roundtrip() {
@@ -127,5 +190,61 @@ mod tests {
         let back: Allocations = serde_json::from_str(&json).unwrap();
         assert_eq!(back.ips.len(), 2);
         assert_eq!(back.ips[0].ip, "10.0.1.2");
+    }
+
+    #[tokio::test]
+    async fn allocate_first_ip_skips_gateway() {
+        let (_d, db) = temp_db().await;
+        let ip = allocate(&db, "subnet-test", "10.0.1.0/24", "10.0.1.1", "vm-01")
+            .await
+            .unwrap();
+        assert_eq!(ip, "10.0.1.2");
+    }
+
+    #[tokio::test]
+    async fn allocate_is_idempotent_per_vm() {
+        let (_d, db) = temp_db().await;
+        let ip_a = allocate(&db, "subnet-test", "10.0.1.0/24", "10.0.1.1", "vm-01")
+            .await
+            .unwrap();
+        let ip_b = allocate(&db, "subnet-test", "10.0.1.0/24", "10.0.1.1", "vm-01")
+            .await
+            .unwrap();
+        assert_eq!(ip_a, ip_b);
+    }
+
+    #[tokio::test]
+    async fn allocate_multiple_vms_returns_distinct_ips() {
+        let (_d, db) = temp_db().await;
+        let a = allocate(&db, "subnet-test", "10.0.1.0/24", "10.0.1.1", "vm-01")
+            .await
+            .unwrap();
+        let b = allocate(&db, "subnet-test", "10.0.1.0/24", "10.0.1.1", "vm-02")
+            .await
+            .unwrap();
+        assert_ne!(a, b);
+    }
+
+    #[tokio::test]
+    async fn release_frees_ip_for_reuse() {
+        let (_d, db) = temp_db().await;
+        allocate(&db, "subnet-test", "10.0.1.0/24", "10.0.1.1", "vm-01")
+            .await
+            .unwrap();
+        release(&db, "subnet-test", "vm-01").await.unwrap();
+        let again = allocate(&db, "subnet-test", "10.0.1.0/24", "10.0.1.1", "vm-02")
+            .await
+            .unwrap();
+        // vm-02 should be able to grab the first available slot
+        // (10.0.1.2), not a later one, because vm-01's release
+        // cleared the slot.
+        assert_eq!(again, "10.0.1.2");
+    }
+
+    #[tokio::test]
+    async fn get_allocation_returns_none_for_unknown_vm() {
+        let (_d, db) = temp_db().await;
+        let got = get_allocation(&db, "subnet-test", "vm-01").await.unwrap();
+        assert!(got.is_none());
     }
 }

--- a/layers/network/src/vpc/subnet/store.rs
+++ b/layers/network/src/vpc/subnet/store.rs
@@ -1,24 +1,48 @@
+//! Subnet persistence on the SurrealDB-backed cluster store.
+//!
+//! P2.12 (sifrah/nauka#216) migrated this module from the legacy
+//! raw-KV cluster path to the native SurrealDB SDK on top of
+//! [`EmbeddedDb`]. Every method reaches the SDK via
+//! `self.db.client()` and writes/reads against the SCHEMAFULL
+//! `subnet` table defined in `layers/network/schemas/subnet.surql`.
+//!
+//! The legacy `sub` / `sub-idx` / `_reg_v2` sidecar namespaces are
+//! gone: the schema's composite unique index on `(vpc, name)` plus
+//! the secondary uniqueness on `(vpc, cidr)` enforce every invariant
+//! the pre-P2.12 store checked manually.
+
 use nauka_core::id::SubnetId;
+use nauka_core::resource::epoch_to_iso8601;
 use nauka_core::resource::ResourceMeta;
-use nauka_hypervisor::controlplane::ClusterDb;
+use nauka_state::sdk_bridge::{classify_create_error, iso8601_to_epoch, thing_to_id_string};
+use nauka_state::EmbeddedDb;
+use serde::Deserialize;
 
 use super::types::Subnet;
 
-const NS_SUB: &str = "sub";
-const NS_SUB_IDX: &str = "sub-idx";
-const REG_V2_NS: &str = "_reg_v2";
-const REG_V2_PREFIX: &str = "sub/";
-const REG_V1: (&str, &str) = ("_reg", "sub-ids");
+/// SurrealDB table backing this store.
+const SUBNET_TABLE: &str = "subnet";
 
 pub struct SubnetStore {
-    db: ClusterDb,
+    db: EmbeddedDb,
 }
 
 impl SubnetStore {
-    pub fn new(db: ClusterDb) -> Self {
+    /// Build a [`SubnetStore`] over a SurrealDB handle.
+    ///
+    /// Call sites that already hold a cluster-DB wrapper pass
+    /// `cluster_db.embedded().clone()`.
+    pub fn new(db: EmbeddedDb) -> Self {
         Self { db }
     }
 
+    /// Create a new subnet within a VPC.
+    ///
+    /// Resolves the owning VPC, validates the CIDR is inside the
+    /// VPC's address space and doesn't overlap any sibling subnet,
+    /// then writes the row via `CREATE` against the SCHEMAFULL
+    /// `subnet` table. Duplicate-name + duplicate-CIDR conflicts are
+    /// rejected by the schema's composite unique indexes.
     pub async fn create(
         &self,
         name: &str,
@@ -32,38 +56,69 @@ impl SubnetStore {
             .await?
             .ok_or_else(|| anyhow::anyhow!("vpc '{vpc_name_or_id}' not found"))?;
 
-        // Validate subnet is within VPC
+        // Validate subnet is within VPC.
         let subnet_net = crate::validate::subnet_within_vpc(cidr, &vpc.cidr)?;
 
-        // Check overlap with existing subnets
+        // Check overlap with existing sibling subnets in the VPC.
         let existing_subs = self.list(Some(&vpc.meta.id), None).await?;
         let existing_cidrs: Vec<String> = existing_subs.iter().map(|s| s.cidr.clone()).collect();
         crate::validate::no_overlap(&subnet_net, &existing_cidrs)?;
 
-        // Check uniqueness within VPC
-        let idx_key = format!("{}/{}", vpc.meta.id, name);
-        let existing: Option<String> = self.db.get(NS_SUB_IDX, &idx_key).await?;
-        if existing.is_some() {
-            anyhow::bail!("subnet '{name}' already exists in vpc '{}'", vpc.meta.name);
-        }
-
-        let gw = crate::validate::gateway(&subnet_net);
+        let gateway = crate::validate::gateway(&subnet_net);
 
         let subnet = Subnet {
             meta: ResourceMeta::new(SubnetId::generate().to_string(), name),
             vpc_id: vpc.meta.id.clone().into(),
             vpc_name: vpc.meta.name.clone(),
             cidr: cidr.to_string(),
-            gateway: gw,
+            gateway,
         };
 
-        self.db.put(NS_SUB, &subnet.meta.id, &subnet).await?;
-        self.db.put(NS_SUB_IDX, &idx_key, &subnet.meta.id).await?;
-        add_id(&self.db, &subnet.meta.id).await?;
+        let created_at_iso = epoch_to_iso8601(subnet.meta.created_at);
+        let updated_at_iso = epoch_to_iso8601(subnet.meta.updated_at);
+        let labels_json = serde_json::to_value(&subnet.meta.labels)
+            .map_err(|e| anyhow::anyhow!("serialise labels: {e}"))?;
+
+        let query_result = self
+            .db
+            .client()
+            .query(
+                "CREATE type::record($tbl, $id) SET \
+                 name = $name, \
+                 status = $status, \
+                 labels = $labels, \
+                 cidr = $cidr, \
+                 gateway = $gateway, \
+                 vpc = $vpc, \
+                 vpc_name = $vpc_name, \
+                 created_at = <datetime>$created_at, \
+                 updated_at = <datetime>$updated_at",
+            )
+            .bind(("tbl", SUBNET_TABLE))
+            .bind(("id", subnet.meta.id.clone()))
+            .bind(("name", subnet.meta.name.clone()))
+            .bind(("status", subnet.meta.status.clone()))
+            .bind(("labels", labels_json))
+            .bind(("cidr", subnet.cidr.clone()))
+            .bind(("gateway", subnet.gateway.clone()))
+            .bind(("vpc", subnet.vpc_id.as_str().to_string()))
+            .bind(("vpc_name", subnet.vpc_name.clone()))
+            .bind(("created_at", created_at_iso))
+            .bind(("updated_at", updated_at_iso))
+            .await;
+        let response = match query_result {
+            Ok(r) => r,
+            Err(e) => return Err(classify_subnet_error(name, &vpc.meta.name, &e.to_string())),
+        };
+        if let Err(e) = response.check() {
+            return Err(classify_subnet_error(name, &vpc.meta.name, &e.to_string()));
+        }
 
         Ok(subnet)
     }
 
+    /// Look up a subnet by id (when the input looks like a
+    /// [`SubnetId`]) or by name (otherwise).
     pub async fn get(
         &self,
         name_or_id: &str,
@@ -71,44 +126,85 @@ impl SubnetStore {
         org_name: Option<&str>,
     ) -> anyhow::Result<Option<Subnet>> {
         if SubnetId::looks_like_id(name_or_id) {
-            return self.db.get(NS_SUB, name_or_id).await.map_err(Into::into);
+            return self.get_by_id(name_or_id).await;
         }
-        let vpc_name = vpc_name_or_id
+        let vpc_ref = vpc_name_or_id
             .ok_or_else(|| anyhow::anyhow!("--vpc required to resolve subnet by name"))?;
         let vpc_store = crate::vpc::store::VpcStore::new(self.db.clone());
         let vpc = vpc_store
-            .get(vpc_name, org_name)
+            .get(vpc_ref, org_name)
             .await?
-            .ok_or_else(|| anyhow::anyhow!("vpc '{vpc_name}' not found"))?;
-        let idx_key = format!("{}/{}", vpc.meta.id, name_or_id);
-        let id: Option<String> = self.db.get(NS_SUB_IDX, &idx_key).await?;
-        match id {
-            Some(id) => self.db.get(NS_SUB, &id).await.map_err(Into::into),
-            None => Ok(None),
-        }
+            .ok_or_else(|| anyhow::anyhow!("vpc '{vpc_ref}' not found"))?;
+
+        self.get_by_vpc_and_name(&vpc.meta.id, name_or_id).await
     }
 
+    async fn get_by_id(&self, id: &str) -> anyhow::Result<Option<Subnet>> {
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT * FROM type::record($tbl, $id)")
+            .bind(("tbl", SUBNET_TABLE))
+            .bind(("id", id.to_string()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let raw: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        decode_first(raw)
+    }
+
+    async fn get_by_vpc_and_name(
+        &self,
+        vpc_id: &str,
+        name: &str,
+    ) -> anyhow::Result<Option<Subnet>> {
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT * FROM subnet WHERE vpc = $vpc AND name = $name LIMIT 1")
+            .bind(("vpc", vpc_id.to_string()))
+            .bind(("name", name.to_string()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let raw: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        decode_first(raw)
+    }
+
+    /// List every subnet, optionally filtered by the owning VPC (by
+    /// name or record id).
     pub async fn list(
         &self,
         vpc_name: Option<&str>,
         _org_name: Option<&str>,
     ) -> anyhow::Result<Vec<Subnet>> {
-        let ids = load_ids(&self.db).await?;
-        let mut subs = Vec::new();
-        for id in &ids {
-            if let Some(s) = self.db.get::<Subnet>(NS_SUB, id).await? {
-                subs.push(s);
-            }
-        }
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT * FROM subnet")
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let raw: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        let subnets: Vec<Subnet> = raw
+            .into_iter()
+            .filter_map(|v| {
+                serde_json::from_value::<SubnetRow>(v)
+                    .ok()
+                    .map(SubnetRow::into_subnet)
+            })
+            .collect();
         match vpc_name {
-            Some(name) => Ok(subs
+            Some(name) => Ok(subnets
                 .into_iter()
                 .filter(|s| s.vpc_name == name || s.vpc_id.as_str() == name)
                 .collect()),
-            None => Ok(subs),
+            None => Ok(subnets),
         }
     }
 
+    /// Delete a subnet. `subnet` is effectively the bottom of the
+    /// network hierarchy — VMs reference a subnet via IPAM rows, but
+    /// those rows are cleared with the subnet's `ipam` side table (P2.13
+    /// will migrate the VM store to take ownership of its IP release),
+    /// so `delete` is a single DELETE today.
     pub async fn delete(
         &self,
         name_or_id: &str,
@@ -121,43 +217,219 @@ impl SubnetStore {
             .ok_or_else(|| {
                 anyhow::anyhow!("subnet '{name_or_id}' not found in vpc '{vpc_name}'")
             })?;
-        let idx_key = format!("{}/{}", subnet.vpc_id.as_str(), subnet.meta.name);
-        self.db.delete(NS_SUB, &subnet.meta.id).await?;
-        self.db.delete(NS_SUB_IDX, &idx_key).await?;
-        remove_id(&self.db, &subnet.meta.id).await?;
+
+        let result = self
+            .db
+            .client()
+            .query("DELETE type::record($tbl, $id)")
+            .bind(("tbl", SUBNET_TABLE))
+            .bind(("id", subnet.meta.id.clone()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        result.check().map_err(|e| anyhow::anyhow!("{e}"))?;
         Ok(())
     }
 }
 
-async fn load_ids(db: &ClusterDb) -> anyhow::Result<Vec<String>> {
-    let keys = db.scan_keys(REG_V2_NS, REG_V2_PREFIX).await?;
-    let mut ids: Vec<String> = keys
-        .into_iter()
-        .filter_map(|k| k.strip_prefix(REG_V2_PREFIX).map(|s| s.to_string()))
-        .collect();
+/// Row shape returned by `SELECT * FROM subnet`.
+#[derive(Debug, Deserialize)]
+struct SubnetRow {
+    id: serde_json::Value,
+    name: String,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    labels: Option<serde_json::Value>,
+    cidr: String,
+    gateway: String,
+    vpc: String,
+    vpc_name: String,
+    created_at: String,
+    updated_at: String,
+}
 
-    if let Some(v1_ids) = db.get::<Vec<String>>(REG_V1.0, REG_V1.1).await? {
-        for old_id in v1_ids {
-            if !ids.contains(&old_id) {
-                let key = format!("{REG_V2_PREFIX}{old_id}");
-                db.put(REG_V2_NS, &key, &true).await?;
-                ids.push(old_id);
-            }
+impl SubnetRow {
+    fn into_subnet(self) -> Subnet {
+        let id = thing_to_id_string("subnet:", &self.id);
+        Subnet {
+            meta: ResourceMeta {
+                id,
+                name: self.name,
+                status: self.status.unwrap_or_else(|| "active".to_string()),
+                labels: self
+                    .labels
+                    .and_then(|v| serde_json::from_value(v).ok())
+                    .unwrap_or_default(),
+                created_at: iso8601_to_epoch(&self.created_at),
+                updated_at: iso8601_to_epoch(&self.updated_at),
+            },
+            vpc_id: self.vpc.into(),
+            vpc_name: self.vpc_name,
+            cidr: self.cidr,
+            gateway: self.gateway,
         }
-        db.delete(REG_V1.0, REG_V1.1).await?;
+    }
+}
+
+fn decode_first(raw: Vec<serde_json::Value>) -> anyhow::Result<Option<Subnet>> {
+    match raw.into_iter().next() {
+        None => Ok(None),
+        Some(v) => {
+            let row: SubnetRow = serde_json::from_value(v)
+                .map_err(|e| anyhow::anyhow!("deserialise subnet row: {e}"))?;
+            Ok(Some(row.into_subnet()))
+        }
+    }
+}
+
+/// Map a SurrealDB create error into a friendly message. Duplicate
+/// `(vpc, name)` pairs get the classic "subnet '<name>' already exists
+/// in vpc '<vpc>'" wording; everything else falls through the shared
+/// [`classify_create_error`] helper.
+fn classify_subnet_error(name: &str, vpc_name: &str, err_msg: &str) -> anyhow::Error {
+    let lowered = err_msg.to_lowercase();
+    if lowered.contains("already contains")
+        || lowered.contains("already exists")
+        || lowered.contains("duplicate")
+    {
+        anyhow::anyhow!("subnet '{name}' already exists in vpc '{vpc_name}'")
+    } else {
+        anyhow::anyhow!(classify_create_error("subnet", name, err_msg))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn temp_store() -> (
+        tempfile::TempDir,
+        SubnetStore,
+        crate::vpc::store::VpcStore,
+        nauka_org::store::OrgStore,
+    ) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = EmbeddedDb::open(&dir.path().join("subnets.skv"))
+            .await
+            .expect("open EmbeddedDb at temp path");
+        nauka_state::apply_cluster_schemas(&db)
+            .await
+            .expect("apply cluster schemas");
+        let subnets = SubnetStore::new(db.clone());
+        let vpcs = crate::vpc::store::VpcStore::new(db.clone());
+        let orgs = nauka_org::store::OrgStore::new(db);
+        (dir, subnets, vpcs, orgs)
     }
 
-    Ok(ids)
-}
+    async fn seed_vpc(
+        vpcs: &crate::vpc::store::VpcStore,
+        orgs: &nauka_org::store::OrgStore,
+    ) -> crate::vpc::types::Vpc {
+        orgs.create("acme").await.expect("create org");
+        vpcs.create("web", "acme", "10.0.0.0/16", None, None)
+            .await
+            .expect("create vpc")
+    }
 
-async fn add_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let key = format!("{REG_V2_PREFIX}{id}");
-    db.put(REG_V2_NS, &key, &true).await?;
-    Ok(())
-}
+    #[tokio::test]
+    async fn create_then_get_by_name() {
+        let (_d, subs, vpcs, orgs) = temp_store().await;
+        seed_vpc(&vpcs, &orgs).await;
+        let sub = subs
+            .create("public", "web", Some("acme"), "10.0.1.0/24")
+            .await
+            .expect("create subnet");
+        assert_eq!(sub.meta.name, "public");
+        // `SubnetId` uses the `sub` prefix (not `subnet`); the
+        // SurrealDB record ends up at `subnet:sub-01J…`.
+        assert!(sub.meta.id.starts_with("sub-"), "got: {}", sub.meta.id);
+        assert_eq!(sub.cidr, "10.0.1.0/24");
+        assert_eq!(sub.gateway, "10.0.1.1");
+        let got = subs
+            .get("public", Some("web"), Some("acme"))
+            .await
+            .expect("get")
+            .expect("missing");
+        assert_eq!(got.meta.id, sub.meta.id);
+    }
 
-async fn remove_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let key = format!("{REG_V2_PREFIX}{id}");
-    db.delete(REG_V2_NS, &key).await?;
-    Ok(())
+    #[tokio::test]
+    async fn create_duplicate_name_in_same_vpc_fails() {
+        let (_d, subs, vpcs, orgs) = temp_store().await;
+        seed_vpc(&vpcs, &orgs).await;
+        subs.create("public", "web", Some("acme"), "10.0.1.0/24")
+            .await
+            .unwrap();
+        let err = subs
+            .create("public", "web", Some("acme"), "10.0.2.0/24")
+            .await
+            .expect_err("duplicate name should fail");
+        assert!(err.to_string().contains("already exists"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn overlapping_cidr_fails() {
+        let (_d, subs, vpcs, orgs) = temp_store().await;
+        seed_vpc(&vpcs, &orgs).await;
+        subs.create("a", "web", Some("acme"), "10.0.1.0/24")
+            .await
+            .unwrap();
+        let err = subs
+            .create("b", "web", Some("acme"), "10.0.1.128/25")
+            .await
+            .expect_err("overlap should fail");
+        assert!(
+            err.to_string().to_lowercase().contains("overlap"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn subnet_outside_vpc_fails() {
+        let (_d, subs, vpcs, orgs) = temp_store().await;
+        seed_vpc(&vpcs, &orgs).await;
+        let err = subs
+            .create("a", "web", Some("acme"), "192.168.0.0/24")
+            .await
+            .expect_err("outside vpc should fail");
+        let _ = err;
+    }
+
+    #[tokio::test]
+    async fn list_filters_by_vpc() {
+        let (_d, subs, vpcs, orgs) = temp_store().await;
+        seed_vpc(&vpcs, &orgs).await;
+        vpcs.create("api", "acme", "10.1.0.0/16", None, None)
+            .await
+            .unwrap();
+        subs.create("a", "web", Some("acme"), "10.0.1.0/24")
+            .await
+            .unwrap();
+        subs.create("b", "web", Some("acme"), "10.0.2.0/24")
+            .await
+            .unwrap();
+        subs.create("a", "api", Some("acme"), "10.1.1.0/24")
+            .await
+            .unwrap();
+
+        let web_subs = subs.list(Some("web"), Some("acme")).await.unwrap();
+        assert_eq!(web_subs.len(), 2);
+        let all = subs.list(None, None).await.unwrap();
+        assert_eq!(all.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn delete_removes_subnet() {
+        let (_d, subs, vpcs, orgs) = temp_store().await;
+        seed_vpc(&vpcs, &orgs).await;
+        subs.create("a", "web", Some("acme"), "10.0.1.0/24")
+            .await
+            .unwrap();
+        subs.delete("a", "web", Some("acme")).await.expect("delete");
+        assert!(subs
+            .get("a", Some("web"), Some("acme"))
+            .await
+            .unwrap()
+            .is_none());
+    }
 }

--- a/layers/org/src/lib.rs
+++ b/layers/org/src/lib.rs
@@ -9,7 +9,6 @@
 
 pub mod handlers;
 pub mod project;
-mod sdk_bridge;
 pub mod store;
 pub mod types;
 

--- a/layers/org/src/project/env/store.rs
+++ b/layers/org/src/project/env/store.rs
@@ -35,11 +35,11 @@
 use nauka_core::id::{EnvId, OrgId, ProjectId};
 use nauka_core::resource::epoch_to_iso8601;
 use nauka_core::resource::ResourceMeta;
+use nauka_state::sdk_bridge::{classify_create_error, iso8601_to_epoch, thing_to_id_string};
 use nauka_state::EmbeddedDb;
 use serde::Deserialize;
 
 use crate::project;
-use crate::sdk_bridge::{classify_create_error, iso8601_to_epoch, thing_to_id_string};
 
 use super::types::Environment;
 
@@ -297,7 +297,7 @@ impl EnvStore {
 /// which serde_json renders as one of several shapes; we bridge
 /// through `serde_json::Value` and pull the inner string out in
 /// [`EnvRow::into_environment`] via
-/// [`crate::sdk_bridge::thing_to_id_string`].
+/// [`nauka_state::sdk_bridge::thing_to_id_string`].
 #[derive(Debug, Deserialize)]
 struct EnvRow {
     id: serde_json::Value,
@@ -351,7 +351,7 @@ fn decode_first(raw: Vec<serde_json::Value>) -> anyhow::Result<Option<Environmen
     }
 }
 
-/// Wrap [`crate::sdk_bridge::classify_create_error`] so the user-facing
+/// Wrap [`nauka_state::sdk_bridge::classify_create_error`] so the user-facing
 /// duplicate message includes the owning project. The composite
 /// unique index on `(project, name)` rejects
 /// `(proj_a, "prod")` + `(proj_a, "prod")` but allows
@@ -372,7 +372,7 @@ fn classify_create_error_with_project(
     } else {
         // Fall back to the shared helper for anything that isn't a
         // duplicate — it preserves the raw error text.
-        classify_create_error("environment", name, err_msg)
+        anyhow::anyhow!(classify_create_error("environment", name, err_msg))
     }
 }
 

--- a/layers/org/src/project/store.rs
+++ b/layers/org/src/project/store.rs
@@ -37,7 +37,7 @@ use nauka_core::resource::ResourceMeta;
 use nauka_state::EmbeddedDb;
 use serde::Deserialize;
 
-use crate::sdk_bridge::{classify_create_error, iso8601_to_epoch, thing_to_id_string};
+use nauka_state::sdk_bridge::{classify_create_error, iso8601_to_epoch, thing_to_id_string};
 
 use super::types::Project;
 
@@ -294,7 +294,7 @@ impl ProjectStore {
 /// serde_json renders as one of several shapes; we bridge through
 /// `serde_json::Value` and pull the inner string out in
 /// [`ProjectRow::into_project`] via
-/// [`crate::sdk_bridge::thing_to_id_string`].
+/// [`nauka_state::sdk_bridge::thing_to_id_string`].
 #[derive(Debug, Deserialize)]
 struct ProjectRow {
     id: serde_json::Value,
@@ -344,7 +344,7 @@ fn decode_first(raw: Vec<serde_json::Value>) -> anyhow::Result<Option<Project>> 
     }
 }
 
-/// Wrap [`crate::sdk_bridge::classify_create_error`] so the user-facing
+/// Wrap [`nauka_state::sdk_bridge::classify_create_error`] so the user-facing
 /// duplicate message includes the owning org. The composite unique
 /// index on `(org, name)` rejects `(org_a, "web")` + `(org_a, "web")`
 /// but allows `(org_a, "web")` + `(org_b, "web")`, so the error
@@ -360,7 +360,7 @@ fn classify_create_error_with_org(name: &str, org_name: &str, err_msg: &str) -> 
     } else {
         // Fall back to the shared helper for anything that isn't a
         // duplicate — it preserves the raw error text.
-        classify_create_error("project", name, err_msg)
+        anyhow::anyhow!(classify_create_error("project", name, err_msg))
     }
 }
 

--- a/layers/org/src/store.rs
+++ b/layers/org/src/store.rs
@@ -41,10 +41,10 @@
 use nauka_core::id::OrgId;
 use nauka_core::resource::epoch_to_iso8601;
 use nauka_core::resource::ResourceMeta;
+use nauka_state::sdk_bridge::{classify_create_error, iso8601_to_epoch, thing_to_id_string};
 use nauka_state::EmbeddedDb;
 use serde::Deserialize;
 
-use crate::sdk_bridge::{classify_create_error, iso8601_to_epoch, thing_to_id_string};
 use crate::types::Org;
 
 /// SurrealDB table backing this store. Defined in
@@ -118,10 +118,20 @@ impl OrgStore {
             .await;
         let response = match query_result {
             Ok(r) => r,
-            Err(e) => return Err(classify_create_error("org", name, &e.to_string())),
+            Err(e) => {
+                return Err(anyhow::anyhow!(classify_create_error(
+                    "org",
+                    name,
+                    &e.to_string()
+                )))
+            }
         };
         if let Err(e) = response.check() {
-            return Err(classify_create_error("org", name, &e.to_string()));
+            return Err(anyhow::anyhow!(classify_create_error(
+                "org",
+                name,
+                &e.to_string()
+            )));
         }
 
         Ok(org)

--- a/layers/state/src/embedded.rs
+++ b/layers/state/src/embedded.rs
@@ -1067,6 +1067,9 @@ mod tests {
         // resolves relative to *this* source file (`layers/state/src/embedded.rs`),
         // so the paths climb out of `state/src` and back down into each
         // sibling layer's `schemas/` directory.
+        // Mirrors `crate::schema::CLUSTER_SCHEMAS`. P2.12
+        // (sifrah/nauka#216) added the `peering` and `natgw`
+        // schemas alongside the network-layer SurrealDB migration.
         const SCHEMAS: &[(&str, &str)] = &[
             ("org", include_str!("../../org/schemas/org.surql")),
             ("project", include_str!("../../org/schemas/project.surql")),
@@ -1074,6 +1077,11 @@ mod tests {
             ("user", include_str!("../../org/schemas/user.surql")),
             ("vpc", include_str!("../../network/schemas/vpc.surql")),
             ("subnet", include_str!("../../network/schemas/subnet.surql")),
+            (
+                "vpc_peering",
+                include_str!("../../network/schemas/peering.surql"),
+            ),
+            ("natgw", include_str!("../../network/schemas/natgw.surql")),
             ("vm", include_str!("../../compute/schemas/vm.surql")),
         ];
 

--- a/layers/state/src/lib.rs
+++ b/layers/state/src/lib.rs
@@ -46,6 +46,7 @@
 pub mod cluster;
 pub mod embedded;
 pub mod schema;
+pub mod sdk_bridge;
 
 pub use cluster::ClusterDb;
 pub use embedded::{pd_endpoints_for, EmbeddedDb};

--- a/layers/state/src/schema.rs
+++ b/layers/state/src/schema.rs
@@ -32,6 +32,14 @@ const CLUSTER_SCHEMAS: &[(&str, &str)] = &[
     ("env", include_str!("../../org/schemas/env.surql")),
     ("vpc", include_str!("../../network/schemas/vpc.surql")),
     ("subnet", include_str!("../../network/schemas/subnet.surql")),
+    // P2.12 (sifrah/nauka#216): peering + natgw schemas ship alongside
+    // the network layer's SurrealDB-SDK migration so the new stores
+    // write to SCHEMAFULL tables instead of legacy raw-KV catch-alls.
+    (
+        "vpc_peering",
+        include_str!("../../network/schemas/peering.surql"),
+    ),
+    ("natgw", include_str!("../../network/schemas/natgw.surql")),
     ("vm", include_str!("../../compute/schemas/vm.surql")),
 ];
 

--- a/layers/state/src/sdk_bridge.rs
+++ b/layers/state/src/sdk_bridge.rs
@@ -1,18 +1,18 @@
-//! Shared SurrealDB SDK → Rust bridge helpers used by the org-layer stores.
+//! Shared SurrealDB SDK → Rust bridge helpers used by every cluster
+//! store in the workspace.
 //!
-//! Every store in this crate talks to the cluster database through the
-//! `EmbeddedDb::client()` SDK handle and the JSON-bridge pattern
-//! established by `nauka_hypervisor::fabric::state::FabricState::save`:
+//! The pattern was established by
+//! `nauka_hypervisor::fabric::state::FabricState::save` during P1.10:
 //! write via an explicit `CREATE … SET …` statement, read via
-//! `SELECT * FROM …`, and bounce the row through `serde_json::Value` so
-//! the Rust side doesn't need a `surrealdb::types::SurrealValue` derive
-//! cascade over every resource type in the workspace.
+//! `SELECT * FROM …`, and bounce the row through `serde_json::Value`
+//! so the Rust side doesn't need a `surrealdb::types::SurrealValue`
+//! derive cascade over every resource type in the workspace.
 //!
-//! The helpers in this module are the small amount of glue every store
-//! needs for that pattern:
+//! The helpers in this module are the small amount of glue every
+//! store needs for that pattern:
 //!
-//! - [`thing_to_id_string`] extracts the bare `<table>-<ulid>` id from
-//!   the `Thing` value that SurrealDB hands back on `SELECT`.
+//! - [`thing_to_id_string`] extracts the bare `<table>-<ulid>` id
+//!   from the `Thing` value that SurrealDB hands back on `SELECT`.
 //! - [`iso8601_to_epoch`] parses the RFC 3339 `datetime` strings that
 //!   SurrealDB emits back into the `u64` Unix-epoch seconds that
 //!   [`nauka_core::resource::ResourceMeta`] carries.
@@ -21,10 +21,14 @@
 //!   `"<kind> '<name>' already exists"` flat `anyhow::Error` so every
 //!   store produces the same CLI-facing message shape.
 //!
-//! P2.9 (sifrah/nauka#213) introduced the first copies of these helpers
-//! inline in `crate::store` (the org store). P2.10 (sifrah/nauka#214)
-//! extracted them here so the newly-migrated project store can reuse
-//! them without drift.
+//! History: P2.9 (sifrah/nauka#213) introduced inline copies of these
+//! helpers in the org store. P2.10 (sifrah/nauka#214) extracted them
+//! to a private `sdk_bridge` module inside `nauka-org`. P2.12
+//! (sifrah/nauka#216) moved the module here into `nauka-state` — the
+//! lowest crate that holds the [`crate::EmbeddedDb`] wrapper — so
+//! every downstream layer (`nauka-org`, `nauka-network`,
+//! `nauka-compute`, `nauka-forge`, `nauka-hypervisor`) can reuse the
+//! same helpers without drifting into three different copies.
 
 /// Pull the bare id string out of a SurrealDB `Thing` rendered as
 /// `serde_json::Value`.
@@ -49,7 +53,7 @@
 /// Always returns the bare `<table>-<ulid>` id (without the `tb:`
 /// prefix or any wrapping backticks) because that's what the rest of
 /// Nauka has been carrying around as `ResourceMeta::id` since day one.
-pub(crate) fn thing_to_id_string(table_prefix: &str, value: &serde_json::Value) -> String {
+pub fn thing_to_id_string(table_prefix: &str, value: &serde_json::Value) -> String {
     let trim_backticks = |s: &str| s.trim_start_matches('`').trim_end_matches('`').to_string();
 
     if let Some(s) = value.as_str() {
@@ -90,7 +94,7 @@ pub(crate) fn thing_to_id_string(table_prefix: &str, value: &serde_json::Value) 
 /// value back — the alternative would be to fail a whole list/get path
 /// on a single malformed row, which is strictly worse for operators
 /// trying to clean up bad data.
-pub(crate) fn iso8601_to_epoch(s: &str) -> u64 {
+pub fn iso8601_to_epoch(s: &str) -> u64 {
     // Stripped-down parser: YYYY-MM-DDTHH:MM:SS… — accepts a trailing
     // `Z`, an optional fractional seconds part, and an optional
     // timezone offset (which we ignore — the only writers are the
@@ -150,35 +154,41 @@ fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
     era * 146097 + doe - 719468
 }
 
-/// Map a SurrealDB error message from a `CREATE` into a flat
-/// `anyhow::Error` with a human-friendly message.
+/// Classify a SurrealDB error message from a `CREATE` into a
+/// human-friendly flat `String` message.
 ///
 /// Each cluster-state store has a unique index on its natural key
 /// (e.g. `org_name`, `project_org_name`) that surfaces duplicate
 /// inserts as `surrealdb::Error::already_exists`, whose `Display`
-/// rendering includes the phrase "already contains" (the substring is
-/// stable across surrealdb-types releases and is what the
-/// `From<surrealdb::Error>` impl in `nauka_state::lib.rs` documents as
-/// the `is_already_exists()` signal). We key on that substring rather
-/// than re-introducing a direct `surrealdb` dependency in this crate,
-/// so duplicate-name conflicts still surface as the same
+/// rendering includes the phrase "already contains" (the substring
+/// is stable across surrealdb-types releases and is what the
+/// `From<surrealdb::Error>` impl in [`crate::lib`] documents as the
+/// `is_already_exists()` signal). We key on that substring rather
+/// than pulling in a direct `surrealdb` dependency at this layer, so
+/// duplicate-name conflicts still surface as the same
 /// `<kind> '<name>' already exists` wording every store returned
-/// before the SurrealDB migration — CLI error-message tests downstream
-/// keep passing without edits.
+/// before the SurrealDB migration — CLI error-message tests
+/// downstream keep passing without edits.
 ///
 /// `kind` is the resource noun used in the message (`"org"`,
-/// `"project"`, `"environment"`, …). `name` is the human-readable name
-/// that was rejected. Everything else collapses to the underlying
-/// error text verbatim.
-pub(crate) fn classify_create_error(kind: &str, name: &str, err_msg: &str) -> anyhow::Error {
+/// `"project"`, `"environment"`, `"vpc"`, `"subnet"`, …). `name` is
+/// the human-readable name that was rejected. Everything else
+/// collapses to the underlying error text verbatim.
+///
+/// Callers wrap the returned `String` in whatever error type they
+/// use — typically `anyhow::anyhow!(classify_create_error(...))`.
+/// The helper deliberately returns `String` rather than
+/// `anyhow::Error` so that `nauka-state` does not need to pull in
+/// `anyhow` just to format a message.
+pub fn classify_create_error(kind: &str, name: &str, err_msg: &str) -> String {
     let lowered = err_msg.to_lowercase();
     if lowered.contains("already contains")
         || lowered.contains("already exists")
         || lowered.contains("duplicate")
     {
-        anyhow::anyhow!("{kind} '{name}' already exists")
+        format!("{kind} '{name}' already exists")
     } else {
-        anyhow::anyhow!("{err_msg}")
+        err_msg.to_string()
     }
 }
 
@@ -237,17 +247,17 @@ mod tests {
 
     #[test]
     fn classify_create_error_detects_duplicate() {
-        let err = classify_create_error(
+        let msg = classify_create_error(
             "project",
             "web",
             "database contains already contains an entry for `web`",
         );
-        assert_eq!(err.to_string(), "project 'web' already exists");
+        assert_eq!(msg, "project 'web' already exists");
     }
 
     #[test]
     fn classify_create_error_passes_through_unrelated() {
-        let err = classify_create_error("project", "web", "disk full");
-        assert_eq!(err.to_string(), "disk full");
+        let msg = classify_create_error("project", "web", "disk full");
+        assert_eq!(msg, "disk full");
     }
 }


### PR DESCRIPTION
## Summary

Closes sifrah/nauka#216. Epic: sifrah/nauka#183.

Replaces the raw-KV cluster path in every store under `layers/network/src/vpc/` with direct SurrealDB SDK calls against SCHEMAFULL tables, following the pattern P2.9–P2.11 established for the org layer. Post-migration, `grep -rn "ClusterDb\|RawClient" layers/network/src` returns **zero** hits — the strict reading of the AC.

## Stores migrated (4)

| Store | Table | Notes |
|---|---|---|
| `VpcStore` | `vpc` (P2.5) | VNI counter via `SELECT math::max(vni)` + retry on collision; schema's `vpc_vni UNIQUE` index closes the race. `delete` inlines child-count queries on `subnet`, `natgw`, and `vpc_peering` directly. |
| `SubnetStore` | `subnet` (P2.5) | Composite unique on `(vpc, name)` + `(vpc, cidr)`. |
| `PeeringStore` | **NEW `vpc_peering`** | Schema ships in `layers/network/schemas/peering.surql`. Composite unique on `(vpc, peer_vpc)`; reverse pair checked at the application layer because SurrealDB can't express "unique on an unordered pair". |
| `NatGwStore` | **NEW `natgw`** | Schema ships in `layers/network/schemas/natgw.surql`. "At most one NAT gateway per VPC" enforced at the application layer (no partial unique indexes in SurrealDB). Unique on `public_ipv6`. `create` rolls back the IPv6 allocation on DB-write failure. |

## Helpers migrated (2)

- `subnet/ipam.rs` — IP allocations moved to a SCHEMALESS `subnet_ipam` table, one row per subnet holding the JSON blob of `(ip, vm_id)` allocations. Same transitional shape as `FabricState` / `RegionRegistry`.
- `natgw/ipv6_alloc.rs` — IPv6 `/128` deterministic allocation ledger moved to a SCHEMALESS `natgw_ipv6_alloc` table, one row per hypervisor.

## Shared bridge module moved

`layers/org/src/sdk_bridge.rs` → **`layers/state/src/sdk_bridge.rs`**. The helpers (`thing_to_id_string`, `iso8601_to_epoch`, `classify_create_error`) are now `pub` and live in the lowest crate that holds `EmbeddedDb`, so every downstream layer (`nauka-org`, `nauka-network`, `nauka-compute`, `nauka-forge`, `nauka-hypervisor`) reuses one copy instead of drifting into three.

`classify_create_error` now returns `String` (not `anyhow::Error`) so `nauka-state` doesn't need an `anyhow` dep just to format a message; callers wrap with `anyhow::anyhow!(...)` at the use site.

## Schema bundle extension

`nauka_state::schema::CLUSTER_SCHEMAS` gains `vpc_peering` and `natgw` between `subnet` and `vm`. The matching `embedded::tests::cluster_schemas_parse_cleanly` mirror is updated so both schemas are exercised in unit tests.

## Call-site cascade

Every workspace caller of `{Vpc,Subnet,Peering,NatGw}Store::new` now passes `cluster_db.embedded().clone()`. Touched:
- `layers/network/src/vpc/{handlers, natgw/handlers, peering/handlers, subnet/handlers}.rs`
- `layers/compute/src/vm/store.rs` (+ IPAM helper now takes `self.db.embedded()`)
- `layers/forge/src/reconciler/{vm, vpc, natgw}.rs`
- `layers/org/src/{store, project/store, project/env/store}.rs` for the `sdk_bridge` import rewire

## Acceptance criteria (sifrah/nauka#216) — all met

- [x] No `ClusterDb` / `RawClient` references left in the network layer
- [x] All network tests pass: **59 nauka-network tests** (up from 44 in main — +15 new tests across all 4 stores and both helpers)

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p nauka-network` → 59 pass
- [x] `cargo test -p nauka-state` → 33 pass (new `vpc_peering` + `natgw` parse-cleanly cases)
- [x] `cargo test -p nauka-org` → 39 pass (after `sdk_bridge` import rewire; no store logic touched)
- [x] `cargo test --workspace -- --test-threads=1` → every crate green (pre-existing macOS `doctor::tests::disk_free_check` failure unrelated; tracked separately)
- [x] Cross-compile `x86_64-unknown-linux-musl --release` — clean

## Stats

**24 files changed, +2216 / −456.** Two new schemas (`peering.surql`, `natgw.surql`), one file renamed (`sdk_bridge.rs` moved from `nauka-org` to `nauka-state`), the four store rewrites, two helper rewrites, and the call-site cascade.