### PR TITLE
feat(P2.13): migrate VmStore to native SurrealDB SDK

### DIFF
--- a/layers/compute/src/vm/handlers.rs
+++ b/layers/compute/src/vm/handlers.rs
@@ -119,7 +119,11 @@ pub fn handler() -> HandlerFn {
             Box<dyn Future<Output = anyhow::Result<OperationResponse>> + Send>,
         > {
             Box::pin(async move {
-                let store = VmStore::new(nauka_hypervisor::controlplane::connect().await?);
+                // P2.13 (sifrah/nauka#217): VmStore now takes an
+                // EmbeddedDb directly; reach the cluster handle via
+                // the wrapper's `.embedded()` accessor.
+                let cluster_db = nauka_hypervisor::controlplane::connect().await?;
+                let store = VmStore::new(cluster_db.embedded().clone());
                 match req.operation.as_str() {
                     "create" => {
                         let name = req.name.ok_or_else(|| anyhow::anyhow!("missing name"))?;
@@ -183,10 +187,17 @@ pub fn handler() -> HandlerFn {
                             .unwrap_or_else(|| "default".to_string());
 
                         nauka_core::validate::name(&name)?;
+                        // P2.13 (sifrah/nauka#217): scheduling lives
+                        // outside `VmStore::create` so the store
+                        // stays decoupled from live fabric state
+                        // and can be unit-tested. The handler
+                        // resolves a hypervisor via the scheduler
+                        // immediately before persisting the row.
+                        let hypervisor_id = crate::scheduler::schedule(&region, &zone).await?;
                         let vm = store
                             .create(
                                 &name, &org, &project, &env, &vpc, &subnet, cpu, memory, disk,
-                                &image, &region, &zone,
+                                &image, &region, &zone, hypervisor_id,
                             )
                             .await?;
                         Ok(OperationResponse::Resource(vm.to_api_json()))

--- a/layers/compute/src/vm/store.rs
+++ b/layers/compute/src/vm/store.rs
@@ -1,24 +1,68 @@
-use nauka_core::id::VmId;
+//! VM persistence on the SurrealDB-backed cluster store.
+//!
+//! P2.13 (sifrah/nauka#217) migrated this module from the legacy
+//! raw-KV cluster path to the native SurrealDB SDK on top of
+//! [`EmbeddedDb`], completing the compute-layer migration. Every
+//! method reaches the SDK via `self.db.client()` and writes/reads
+//! against the SCHEMAFULL `vm` table defined in
+//! `layers/compute/schemas/vm.surql` (applied by
+//! `nauka_state::apply_cluster_schemas` at bootstrap per ADR 0004).
+//!
+//! The legacy `vm` / `vm-idx` / `_reg_v2` sidecar namespaces are
+//! gone: the schema's composite unique index on `(env, name)` is
+//! now the source of truth for "have we seen this (env, name) pair
+//! before?", and `SELECT * FROM vm` walks every row directly.
+//!
+//! The composite unique index on `(subnet, private_ip)` closes the
+//! allocation-collision race that the pre-P2.13 store enforced only
+//! at the IPAM helper level.
+//!
+//! State transitions continue to use the validated-FSM pattern from
+//! the pre-P2.13 version: `update_state` reads the row, checks the
+//! `(from, to)` pair against the allowed transitions, then writes
+//! back via `UPDATE type::record($tbl, $id) MERGE …`.
+
+use nauka_core::id::{EnvId, OrgId, ProjectId, SubnetId, VmId, VpcId};
+use nauka_core::resource::epoch_to_iso8601;
 use nauka_core::resource::ResourceMeta;
-use nauka_hypervisor::controlplane::ClusterDb;
+use nauka_state::sdk_bridge::{iso8601_to_epoch, thing_to_id_string};
+use nauka_state::EmbeddedDb;
+use serde::Deserialize;
 
 use super::types::{Vm, VmState};
 
-const NS_VM: &str = "vm";
-const NS_VM_IDX: &str = "vm-idx";
-const REG_V2_NS: &str = "_reg_v2";
-const REG_V2_PREFIX: &str = "vm/";
-const REG_V1: (&str, &str) = ("_reg", "vm-ids");
+/// SurrealDB table backing this store. Defined by
+/// `layers/compute/schemas/vm.surql` as `DEFINE TABLE vm SCHEMAFULL`
+/// and applied at bootstrap via `nauka_state::apply_cluster_schemas`.
+const VM_TABLE: &str = "vm";
 
 pub struct VmStore {
-    db: ClusterDb,
+    db: EmbeddedDb,
 }
 
 impl VmStore {
-    pub fn new(db: ClusterDb) -> Self {
+    /// Build a [`VmStore`] over a SurrealDB handle.
+    ///
+    /// Call sites that already hold a cluster-DB wrapper pass
+    /// `cluster_db.embedded().clone()`.
+    pub fn new(db: EmbeddedDb) -> Self {
         Self { db }
     }
 
+    /// Create a new VM in the given environment.
+    ///
+    /// Resolves the full `(org → project → env, vpc → subnet)` path,
+    /// allocates a private IP via the subnet's IPAM helper, then
+    /// writes the row through `CREATE type::record($tbl, $id) SET …`.
+    /// The schema's composite unique index on `(env, name)` rejects
+    /// duplicates.
+    ///
+    /// `hypervisor_id` is passed in by the caller (typically the CLI
+    /// handler) so the store stays decoupled from
+    /// `crate::scheduler::schedule`, which needs live fabric state
+    /// and can't run in unit tests. The CLI path resolves the id via
+    /// the scheduler immediately before calling `create`; tests pass
+    /// a placeholder id directly.
     #[allow(clippy::too_many_arguments)]
     pub async fn create(
         &self,
@@ -34,24 +78,17 @@ impl VmStore {
         image: &str,
         region: &str,
         zone: &str,
+        hypervisor_id: String,
     ) -> anyhow::Result<Vm> {
-        // Resolve org -> project -> env. P2.9 (sifrah/nauka#213)
-        // migrated `OrgStore` to the native SurrealDB SDK on top of
-        // `EmbeddedDb`, so we hand it the cluster-DB wrapper's
-        // internal handle via `.embedded().clone()`. The clone is
-        // cheap (Arc-shared `Surreal<Db>` router) and leaves the
-        // legacy `ProjectStore` below on the same underlying
-        // connection until P2.10 ports it over.
-        let org_store = nauka_org::store::OrgStore::new(self.db.embedded().clone());
+        // Resolve org → project → env. Every upstream store already
+        // takes an `EmbeddedDb` directly after P2.9-P2.11.
+        let org_store = nauka_org::store::OrgStore::new(self.db.clone());
         let org = org_store
             .get(org_name)
             .await?
             .ok_or_else(|| anyhow::anyhow!("org '{org_name}' not found"))?;
 
-        // P2.10 (sifrah/nauka#214) migrated `ProjectStore` to take an
-        // `EmbeddedDb` directly, same as `OrgStore` above. Reach the
-        // handle through the cluster wrapper's `.embedded().clone()`.
-        let proj_store = nauka_org::project::store::ProjectStore::new(self.db.embedded().clone());
+        let proj_store = nauka_org::project::store::ProjectStore::new(self.db.clone());
         let project = proj_store
             .get(project_name, Some(org_name))
             .await?
@@ -59,10 +96,7 @@ impl VmStore {
                 anyhow::anyhow!("project '{project_name}' not found in org '{org_name}'")
             })?;
 
-        // P2.11 (sifrah/nauka#215): `EnvStore::new` takes an
-        // `EmbeddedDb` directly, same pattern as `OrgStore` /
-        // `ProjectStore` above.
-        let env_store = nauka_org::project::env::store::EnvStore::new(self.db.embedded().clone());
+        let env_store = nauka_org::project::env::store::EnvStore::new(self.db.clone());
         let env = env_store
             .get(env_name, Some(project_name), Some(org_name))
             .await?
@@ -70,17 +104,15 @@ impl VmStore {
                 anyhow::anyhow!("environment '{env_name}' not found in project '{project_name}'")
             })?;
 
-        // Resolve vpc -> subnet. P2.12 (sifrah/nauka#216) migrated
-        // both stores to take an `EmbeddedDb` directly; reach the
-        // inner handle via `ClusterDb::embedded().clone()`.
-        let vpc_store = nauka_network::vpc::store::VpcStore::new(self.db.embedded().clone());
+        // Resolve vpc → subnet. Both stores take an `EmbeddedDb`
+        // directly after P2.12.
+        let vpc_store = nauka_network::vpc::store::VpcStore::new(self.db.clone());
         let vpc = vpc_store
             .get(vpc_name, Some(org_name))
             .await?
             .ok_or_else(|| anyhow::anyhow!("vpc '{vpc_name}' not found"))?;
 
-        let sub_store =
-            nauka_network::vpc::subnet::store::SubnetStore::new(self.db.embedded().clone());
+        let sub_store = nauka_network::vpc::subnet::store::SubnetStore::new(self.db.clone());
         let subnet = sub_store
             .get(subnet_name, Some(vpc_name), Some(org_name))
             .await?
@@ -88,21 +120,13 @@ impl VmStore {
                 anyhow::anyhow!("subnet '{subnet_name}' not found in vpc '{vpc_name}'")
             })?;
 
-        // Check uniqueness within env
-        let idx_key = format!("{}/{}", env.meta.id, name);
-        let existing: Option<String> = self.db.get(NS_VM_IDX, &idx_key).await?;
-        if existing.is_some() {
-            anyhow::bail!("vm '{name}' already exists in environment '{env_name}'");
-        }
-
-        // Generate VM ID first — needed for IPAM allocation
+        // Generate VM ID first — needed for IPAM allocation.
         let vm_id = VmId::generate().to_string();
 
-        // Allocate private IP from subnet IPAM. P2.12 (sifrah/nauka#216)
-        // migrated the IPAM helper to take an `EmbeddedDb`; reach it
-        // via `ClusterDb::embedded()`.
+        // Allocate private IP from subnet IPAM. P2.12 migrated the
+        // helper to take an `EmbeddedDb` directly.
         let private_ip = nauka_network::vpc::subnet::ipam::allocate(
-            self.db.embedded(),
+            &self.db,
             &subnet.meta.id,
             &subnet.cidr,
             &subnet.gateway,
@@ -111,7 +135,7 @@ impl VmStore {
         .await?;
 
         let vm = Vm {
-            meta: ResourceMeta::new(vm_id, name),
+            meta: ResourceMeta::new(vm_id.clone(), name),
             org_id: org.meta.id.clone().into(),
             org_name: org.meta.name.clone(),
             project_id: project.meta.id.clone().into(),
@@ -129,17 +153,109 @@ impl VmStore {
             region: region.to_string(),
             zone: zone.to_string(),
             private_ip: Some(private_ip),
-            hypervisor_id: Some(crate::scheduler::schedule(region, zone).await?),
+            hypervisor_id: Some(hypervisor_id),
             state: VmState::Pending,
         };
 
-        self.db.put(NS_VM, &vm.meta.id, &vm).await?;
-        self.db.put(NS_VM_IDX, &idx_key, &vm.meta.id).await?;
-        add_id(&self.db, &vm.meta.id).await?;
+        // Write the row through the SDK. If the DB write fails we
+        // release the IPAM allocation so the address slot doesn't
+        // leak — same rollback pattern as `NatGwStore::create`.
+        if let Err(e) = self.insert(&vm).await {
+            let msg = e.to_string().to_lowercase();
+            let _ = nauka_network::vpc::subnet::ipam::release(
+                &self.db,
+                vm.subnet_id.as_str(),
+                &vm.meta.id,
+            )
+            .await;
+
+            if msg.contains("already contains")
+                || msg.contains("already exists")
+                || msg.contains("duplicate")
+            {
+                return Err(anyhow::anyhow!(
+                    "vm '{name}' already exists in environment '{env_name}'"
+                ));
+            }
+            return Err(e);
+        }
 
         Ok(vm)
     }
 
+    /// Write the row via SurrealQL `CREATE`. Extracted from `create`
+    /// so the rollback path there can cleanly handle the error.
+    async fn insert(&self, vm: &Vm) -> anyhow::Result<()> {
+        let created_at_iso = epoch_to_iso8601(vm.meta.created_at);
+        let updated_at_iso = epoch_to_iso8601(vm.meta.updated_at);
+        let labels_json = serde_json::to_value(&vm.meta.labels)
+            .map_err(|e| anyhow::anyhow!("serialise labels: {e}"))?;
+
+        let response = self
+            .db
+            .client()
+            .query(
+                "CREATE type::record($tbl, $id) SET \
+                 name = $name, \
+                 status = $status, \
+                 labels = $labels, \
+                 org = $org, \
+                 org_name = $org_name, \
+                 project = $project, \
+                 project_name = $project_name, \
+                 env = $env, \
+                 env_name = $env_name, \
+                 vpc = $vpc, \
+                 vpc_name = $vpc_name, \
+                 subnet = $subnet, \
+                 subnet_name = $subnet_name, \
+                 vcpus = $vcpus, \
+                 memory_mb = $memory_mb, \
+                 disk_gb = $disk_gb, \
+                 image = $image, \
+                 region = $region, \
+                 zone = $zone, \
+                 private_ip = $private_ip, \
+                 hypervisor = $hypervisor, \
+                 state = $state, \
+                 created_at = <datetime>$created_at, \
+                 updated_at = <datetime>$updated_at",
+            )
+            .bind(("tbl", VM_TABLE))
+            .bind(("id", vm.meta.id.clone()))
+            .bind(("name", vm.meta.name.clone()))
+            .bind(("status", vm.meta.status.clone()))
+            .bind(("labels", labels_json))
+            .bind(("org", vm.org_id.as_str().to_string()))
+            .bind(("org_name", vm.org_name.clone()))
+            .bind(("project", vm.project_id.as_str().to_string()))
+            .bind(("project_name", vm.project_name.clone()))
+            .bind(("env", vm.env_id.as_str().to_string()))
+            .bind(("env_name", vm.env_name.clone()))
+            .bind(("vpc", vm.vpc_id.as_str().to_string()))
+            .bind(("vpc_name", vm.vpc_name.clone()))
+            .bind(("subnet", vm.subnet_id.as_str().to_string()))
+            .bind(("subnet_name", vm.subnet_name.clone()))
+            .bind(("vcpus", vm.vcpus as i64))
+            .bind(("memory_mb", vm.memory_mb as i64))
+            .bind(("disk_gb", vm.disk_gb as i64))
+            .bind(("image", vm.image.clone()))
+            .bind(("region", vm.region.clone()))
+            .bind(("zone", vm.zone.clone()))
+            .bind(("private_ip", vm.private_ip.clone()))
+            .bind(("hypervisor", vm.hypervisor_id.clone()))
+            .bind(("state", vm.state.to_string()))
+            .bind(("created_at", created_at_iso))
+            .bind(("updated_at", updated_at_iso))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        response.check().map_err(|e| anyhow::anyhow!("{e}"))?;
+        Ok(())
+    }
+
+    /// Look up a VM by id (when the input looks like a [`VmId`]) or
+    /// by name (otherwise, requires the full `(org, project, env)`
+    /// scope).
     pub async fn get(
         &self,
         name_or_id: &str,
@@ -148,10 +264,9 @@ impl VmStore {
         env_name: Option<&str>,
     ) -> anyhow::Result<Option<Vm>> {
         if VmId::looks_like_id(name_or_id) {
-            return self.db.get(NS_VM, name_or_id).await.map_err(Into::into);
+            return self.get_by_id(name_or_id).await;
         }
 
-        // Need full scope to resolve by name
         let org_name =
             org_name.ok_or_else(|| anyhow::anyhow!("--org required to resolve VM by name"))?;
         let project_name = project_name
@@ -159,38 +274,64 @@ impl VmStore {
         let env_name =
             env_name.ok_or_else(|| anyhow::anyhow!("--env required to resolve VM by name"))?;
 
-        // P2.11 (sifrah/nauka#215): `EnvStore::new` takes an
-        // `EmbeddedDb` directly; reach the inner handle via
-        // `ClusterDb::embedded().clone()`.
-        let env_store = nauka_org::project::env::store::EnvStore::new(self.db.embedded().clone());
+        // Resolve the owning env so we can query by its record id
+        // via the composite `(env, name)` unique index.
+        let env_store = nauka_org::project::env::store::EnvStore::new(self.db.clone());
         let env = env_store
             .get(env_name, Some(project_name), Some(org_name))
             .await?
             .ok_or_else(|| anyhow::anyhow!("environment '{env_name}' not found"))?;
 
-        let idx_key = format!("{}/{}", env.meta.id, name_or_id);
-        let id: Option<String> = self.db.get(NS_VM_IDX, &idx_key).await?;
-        match id {
-            Some(id) => self.db.get(NS_VM, &id).await.map_err(Into::into),
-            None => Ok(None),
-        }
+        self.get_by_env_and_name(&env.meta.id, name_or_id).await
     }
 
+    async fn get_by_id(&self, id: &str) -> anyhow::Result<Option<Vm>> {
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT * FROM type::record($tbl, $id)")
+            .bind(("tbl", VM_TABLE))
+            .bind(("id", id.to_string()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let raw: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        decode_first(raw)
+    }
+
+    async fn get_by_env_and_name(&self, env_id: &str, name: &str) -> anyhow::Result<Option<Vm>> {
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT * FROM vm WHERE env = $env AND name = $name LIMIT 1")
+            .bind(("env", env_id.to_string()))
+            .bind(("name", name.to_string()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let raw: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        decode_first(raw)
+    }
+
+    /// List every VM, with optional `(org, project, env)` filters
+    /// applied progressively by the application layer after the
+    /// `SELECT *`.
     pub async fn list(
         &self,
         org_name: Option<&str>,
         project_name: Option<&str>,
         env_name: Option<&str>,
     ) -> anyhow::Result<Vec<Vm>> {
-        let ids = load_ids(&self.db).await?;
-        let mut vms = Vec::new();
-        for id in &ids {
-            if let Some(vm) = self.db.get::<Vm>(NS_VM, id).await? {
-                vms.push(vm);
-            }
-        }
+        let mut response = self
+            .db
+            .client()
+            .query("SELECT * FROM vm")
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let raw: Vec<serde_json::Value> = response.take(0).map_err(|e| anyhow::anyhow!("{e}"))?;
+        let mut vms: Vec<Vm> = raw
+            .into_iter()
+            .filter_map(|v| serde_json::from_value::<VmRow>(v).ok().map(VmRow::into_vm))
+            .collect();
 
-        // Progressive filtering
         if let Some(org) = org_name {
             vms.retain(|v| v.org_name == org || v.org_id.as_str() == org);
         }
@@ -204,6 +345,11 @@ impl VmStore {
         Ok(vms)
     }
 
+    /// Apply a state transition to a VM.
+    ///
+    /// Validates the `(from, to)` pair against the allowed VM FSM
+    /// edges, then rewrites `state` + `updated_at` atomically via
+    /// `UPDATE … MERGE`.
     pub async fn update_state(
         &self,
         name_or_id: &str,
@@ -217,7 +363,6 @@ impl VmStore {
             .await?
             .ok_or_else(|| anyhow::anyhow!("vm '{name_or_id}' not found"))?;
 
-        // Validate state transition
         match (&vm.state, &new_state) {
             (VmState::Pending, VmState::Running) => {}
             (VmState::Stopped, VmState::Running) => {}
@@ -233,10 +378,28 @@ impl VmStore {
             .unwrap_or_default()
             .as_secs();
 
-        self.db.put(NS_VM, &vm.meta.id, &vm).await?;
+        let updated_at_iso = epoch_to_iso8601(vm.meta.updated_at);
+        let response = self
+            .db
+            .client()
+            .query(
+                "UPDATE type::record($tbl, $id) MERGE { \
+                 state: $state, \
+                 updated_at: <datetime>$updated_at \
+                 }",
+            )
+            .bind(("tbl", VM_TABLE))
+            .bind(("id", vm.meta.id.clone()))
+            .bind(("state", vm.state.to_string()))
+            .bind(("updated_at", updated_at_iso))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        response.check().map_err(|e| anyhow::anyhow!("{e}"))?;
         Ok(vm)
     }
 
+    /// Delete a VM. Refuses to delete unless in `pending` / `stopped`.
+    /// Releases the IPAM allocation on success.
     pub async fn delete(
         &self,
         name_or_id: &str,
@@ -256,52 +419,399 @@ impl VmStore {
             );
         }
 
-        // Release IPAM allocation. P2.12 migrated the helper to take
-        // an `EmbeddedDb` directly.
-        nauka_network::vpc::subnet::ipam::release(
-            self.db.embedded(),
-            vm.subnet_id.as_str(),
-            &vm.meta.id,
-        )
-        .await?;
+        // Release IPAM allocation. The helper is idempotent — a
+        // retry after a partial failure just removes the entry
+        // from the blob.
+        nauka_network::vpc::subnet::ipam::release(&self.db, vm.subnet_id.as_str(), &vm.meta.id)
+            .await?;
 
-        let idx_key = format!("{}/{}", vm.env_id.as_str(), vm.meta.name);
-        self.db.delete(NS_VM, &vm.meta.id).await?;
-        self.db.delete(NS_VM_IDX, &idx_key).await?;
-        remove_id(&self.db, &vm.meta.id).await?;
+        let result = self
+            .db
+            .client()
+            .query("DELETE type::record($tbl, $id)")
+            .bind(("tbl", VM_TABLE))
+            .bind(("id", vm.meta.id.clone()))
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        result.check().map_err(|e| anyhow::anyhow!("{e}"))?;
         Ok(())
     }
 }
 
-async fn load_ids(db: &ClusterDb) -> anyhow::Result<Vec<String>> {
-    let keys = db.scan_keys(REG_V2_NS, REG_V2_PREFIX).await?;
-    let mut ids: Vec<String> = keys
-        .into_iter()
-        .filter_map(|k| k.strip_prefix(REG_V2_PREFIX).map(|s| s.to_string()))
-        .collect();
+/// Row shape returned by `SELECT * FROM vm`.
+#[derive(Debug, Deserialize)]
+struct VmRow {
+    id: serde_json::Value,
+    name: String,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    labels: Option<serde_json::Value>,
+    org: String,
+    org_name: String,
+    project: String,
+    project_name: String,
+    env: String,
+    env_name: String,
+    vpc: String,
+    vpc_name: String,
+    subnet: String,
+    subnet_name: String,
+    vcpus: i64,
+    memory_mb: i64,
+    disk_gb: i64,
+    image: String,
+    region: String,
+    zone: String,
+    #[serde(default)]
+    private_ip: Option<String>,
+    #[serde(default)]
+    hypervisor: Option<String>,
+    state: String,
+    created_at: String,
+    updated_at: String,
+}
 
-    if let Some(v1_ids) = db.get::<Vec<String>>(REG_V1.0, REG_V1.1).await? {
-        for old_id in v1_ids {
-            if !ids.contains(&old_id) {
-                let key = format!("{REG_V2_PREFIX}{old_id}");
-                db.put(REG_V2_NS, &key, &true).await?;
-                ids.push(old_id);
-            }
+impl VmRow {
+    fn into_vm(self) -> Vm {
+        let id = thing_to_id_string("vm:", &self.id);
+        let state = match self.state.as_str() {
+            "pending" => VmState::Pending,
+            "creating" => VmState::Creating,
+            "running" => VmState::Running,
+            "stopped" => VmState::Stopped,
+            "deleting" => VmState::Deleting,
+            "deleted" => VmState::Deleted,
+            // Default to Pending for anything else so a bad
+            // migration doesn't crash the list. The schema's
+            // ASSERT keeps this branch unreachable in practice.
+            _ => VmState::Pending,
+        };
+        Vm {
+            meta: ResourceMeta {
+                id,
+                name: self.name,
+                status: self.status.unwrap_or_else(|| "active".to_string()),
+                labels: self
+                    .labels
+                    .and_then(|v| serde_json::from_value(v).ok())
+                    .unwrap_or_default(),
+                created_at: iso8601_to_epoch(&self.created_at),
+                updated_at: iso8601_to_epoch(&self.updated_at),
+            },
+            org_id: OrgId::from(self.org),
+            org_name: self.org_name,
+            project_id: ProjectId::from(self.project),
+            project_name: self.project_name,
+            env_id: EnvId::from(self.env),
+            env_name: self.env_name,
+            vpc_id: VpcId::from(self.vpc),
+            vpc_name: self.vpc_name,
+            subnet_id: SubnetId::from(self.subnet),
+            subnet_name: self.subnet_name,
+            vcpus: self.vcpus as u32,
+            memory_mb: self.memory_mb as u32,
+            disk_gb: self.disk_gb as u32,
+            image: self.image,
+            region: self.region,
+            zone: self.zone,
+            private_ip: self.private_ip,
+            hypervisor_id: self.hypervisor,
+            state,
         }
-        db.delete(REG_V1.0, REG_V1.1).await?;
+    }
+}
+
+fn decode_first(raw: Vec<serde_json::Value>) -> anyhow::Result<Option<Vm>> {
+    match raw.into_iter().next() {
+        None => Ok(None),
+        Some(v) => {
+            let row: VmRow = serde_json::from_value(v)
+                .map_err(|e| anyhow::anyhow!("deserialise vm row: {e}"))?;
+            Ok(Some(row.into_vm()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build an in-process `VmStore` backed by a fresh SurrealKV
+    /// datastore at a temporary path, with the cluster schema
+    /// bundle applied. Returns the whole tenant hierarchy stack so
+    /// individual tests can seed org/project/env/vpc/subnet ahead
+    /// of creating VMs.
+    async fn temp_store() -> (
+        tempfile::TempDir,
+        VmStore,
+        nauka_org::store::OrgStore,
+        nauka_org::project::store::ProjectStore,
+        nauka_org::project::env::store::EnvStore,
+        nauka_network::vpc::store::VpcStore,
+        nauka_network::vpc::subnet::store::SubnetStore,
+    ) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = EmbeddedDb::open(&dir.path().join("vms.skv"))
+            .await
+            .expect("open EmbeddedDb");
+        nauka_state::apply_cluster_schemas(&db)
+            .await
+            .expect("apply cluster schemas");
+        let vms = VmStore::new(db.clone());
+        let orgs = nauka_org::store::OrgStore::new(db.clone());
+        let projs = nauka_org::project::store::ProjectStore::new(db.clone());
+        let envs = nauka_org::project::env::store::EnvStore::new(db.clone());
+        let vpcs = nauka_network::vpc::store::VpcStore::new(db.clone());
+        let subs = nauka_network::vpc::subnet::store::SubnetStore::new(db);
+        (dir, vms, orgs, projs, envs, vpcs, subs)
     }
 
-    Ok(ids)
-}
+    async fn seed_stack(
+        orgs: &nauka_org::store::OrgStore,
+        projs: &nauka_org::project::store::ProjectStore,
+        envs: &nauka_org::project::env::store::EnvStore,
+        vpcs: &nauka_network::vpc::store::VpcStore,
+        subs: &nauka_network::vpc::subnet::store::SubnetStore,
+    ) {
+        orgs.create("acme").await.unwrap();
+        projs.create("web", "acme").await.unwrap();
+        envs.create("prod", "web", "acme").await.unwrap();
+        vpcs.create("vpc1", "acme", "10.0.0.0/16", None, None)
+            .await
+            .unwrap();
+        subs.create("public", "vpc1", Some("acme"), "10.0.1.0/24")
+            .await
+            .unwrap();
+    }
 
-async fn add_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let key = format!("{REG_V2_PREFIX}{id}");
-    db.put(REG_V2_NS, &key, &true).await?;
-    Ok(())
-}
+    /// Shorthand `create` wrapper for tests — threads a fake
+    /// `hypervisor_id` through so we don't need to spin up a real
+    /// scheduler in unit tests. The CLI path resolves a real
+    /// hypervisor id via `crate::scheduler::schedule` before
+    /// calling `VmStore::create`.
+    #[allow(clippy::too_many_arguments)]
+    async fn create_vm(
+        vms: &VmStore,
+        name: &str,
+        org: &str,
+        project: &str,
+        env: &str,
+        vpc: &str,
+        subnet: &str,
+        vcpus: u32,
+        memory_mb: u32,
+        disk_gb: u32,
+    ) -> Vm {
+        vms.create(
+            name,
+            org,
+            project,
+            env,
+            vpc,
+            subnet,
+            vcpus,
+            memory_mb,
+            disk_gb,
+            "ubuntu-24.04",
+            "eu",
+            "fsn1",
+            "hv-test".to_string(),
+        )
+        .await
+        .expect("create vm")
+    }
 
-async fn remove_id(db: &ClusterDb, id: &str) -> anyhow::Result<()> {
-    let key = format!("{REG_V2_PREFIX}{id}");
-    db.delete(REG_V2_NS, &key).await?;
-    Ok(())
+    #[tokio::test]
+    async fn create_then_get_by_name() {
+        let (_d, vms, orgs, projs, envs, vpcs, subs) = temp_store().await;
+        seed_stack(&orgs, &projs, &envs, &vpcs, &subs).await;
+
+        let vm = create_vm(
+            &vms, "web1", "acme", "web", "prod", "vpc1", "public", 2, 1024, 20,
+        )
+        .await;
+
+        assert_eq!(vm.meta.name, "web1");
+        assert!(vm.meta.id.starts_with("vm-"), "got: {}", vm.meta.id);
+        assert_eq!(vm.vcpus, 2);
+        assert_eq!(vm.memory_mb, 1024);
+        assert!(matches!(vm.state, VmState::Pending));
+        assert!(vm.private_ip.is_some());
+
+        let got = vms
+            .get("web1", Some("acme"), Some("web"), Some("prod"))
+            .await
+            .expect("get by name")
+            .expect("missing");
+        assert_eq!(got.meta.id, vm.meta.id);
+        assert_eq!(got.vcpus, 2);
+    }
+
+    #[tokio::test]
+    async fn create_then_get_by_id() {
+        let (_d, vms, orgs, projs, envs, vpcs, subs) = temp_store().await;
+        seed_stack(&orgs, &projs, &envs, &vpcs, &subs).await;
+        let vm = create_vm(
+            &vms, "web1", "acme", "web", "prod", "vpc1", "public", 1, 512, 10,
+        )
+        .await;
+        let got = vms
+            .get(&vm.meta.id, None, None, None)
+            .await
+            .expect("get by id")
+            .expect("missing");
+        assert_eq!(got.meta.id, vm.meta.id);
+    }
+
+    #[tokio::test]
+    async fn duplicate_name_in_same_env_is_rejected() {
+        let (_d, vms, orgs, projs, envs, vpcs, subs) = temp_store().await;
+        seed_stack(&orgs, &projs, &envs, &vpcs, &subs).await;
+        create_vm(
+            &vms, "web1", "acme", "web", "prod", "vpc1", "public", 1, 512, 10,
+        )
+        .await;
+        let err = vms
+            .create(
+                "web1",
+                "acme",
+                "web",
+                "prod",
+                "vpc1",
+                "public",
+                1,
+                512,
+                10,
+                "ubuntu-24.04",
+                "eu",
+                "fsn1",
+                "hv-test".to_string(),
+            )
+            .await
+            .expect_err("duplicate name");
+        assert!(err.to_string().contains("already exists"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn list_filters_progressively() {
+        let (_d, vms, orgs, projs, envs, vpcs, subs) = temp_store().await;
+        seed_stack(&orgs, &projs, &envs, &vpcs, &subs).await;
+        envs.create("staging", "web", "acme").await.unwrap();
+        create_vm(
+            &vms, "a", "acme", "web", "prod", "vpc1", "public", 1, 512, 10,
+        )
+        .await;
+        create_vm(
+            &vms, "b", "acme", "web", "prod", "vpc1", "public", 1, 512, 10,
+        )
+        .await;
+        create_vm(
+            &vms, "c", "acme", "web", "staging", "vpc1", "public", 1, 512, 10,
+        )
+        .await;
+
+        let all = vms.list(None, None, None).await.unwrap();
+        assert_eq!(all.len(), 3);
+        let web = vms.list(Some("acme"), Some("web"), None).await.unwrap();
+        assert_eq!(web.len(), 3);
+        let prod = vms
+            .list(Some("acme"), Some("web"), Some("prod"))
+            .await
+            .unwrap();
+        assert_eq!(prod.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn update_state_valid_transition() {
+        let (_d, vms, orgs, projs, envs, vpcs, subs) = temp_store().await;
+        seed_stack(&orgs, &projs, &envs, &vpcs, &subs).await;
+        let vm = create_vm(
+            &vms, "web1", "acme", "web", "prod", "vpc1", "public", 1, 512, 10,
+        )
+        .await;
+        assert!(matches!(vm.state, VmState::Pending));
+
+        let updated = vms
+            .update_state(&vm.meta.id, VmState::Running, None, None, None)
+            .await
+            .expect("pending -> running");
+        assert!(matches!(updated.state, VmState::Running));
+        assert!(updated.meta.updated_at >= vm.meta.updated_at);
+
+        let got = vms
+            .get(&vm.meta.id, None, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(got.state, VmState::Running));
+    }
+
+    #[tokio::test]
+    async fn update_state_invalid_transition_rejected() {
+        let (_d, vms, orgs, projs, envs, vpcs, subs) = temp_store().await;
+        seed_stack(&orgs, &projs, &envs, &vpcs, &subs).await;
+        let vm = create_vm(
+            &vms, "web1", "acme", "web", "prod", "vpc1", "public", 1, 512, 10,
+        )
+        .await;
+        let err = vms
+            .update_state(&vm.meta.id, VmState::Stopped, None, None, None)
+            .await
+            .expect_err("pending -> stopped not allowed");
+        assert!(
+            err.to_string().contains("invalid state transition"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_in_running_state_is_rejected() {
+        let (_d, vms, orgs, projs, envs, vpcs, subs) = temp_store().await;
+        seed_stack(&orgs, &projs, &envs, &vpcs, &subs).await;
+        let vm = create_vm(
+            &vms, "web1", "acme", "web", "prod", "vpc1", "public", 1, 512, 10,
+        )
+        .await;
+        vms.update_state(&vm.meta.id, VmState::Running, None, None, None)
+            .await
+            .unwrap();
+
+        let err = vms
+            .delete("web1", Some("acme"), Some("web"), Some("prod"))
+            .await
+            .expect_err("delete running vm");
+        assert!(
+            err.to_string().contains("must be stopped or pending"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_pending_vm_releases_ipam() {
+        let (_d, vms, orgs, projs, envs, vpcs, subs) = temp_store().await;
+        seed_stack(&orgs, &projs, &envs, &vpcs, &subs).await;
+        let vm = create_vm(
+            &vms, "web1", "acme", "web", "prod", "vpc1", "public", 1, 512, 10,
+        )
+        .await;
+        let ip = vm.private_ip.clone().unwrap();
+
+        vms.delete("web1", Some("acme"), Some("web"), Some("prod"))
+            .await
+            .expect("delete");
+        assert!(vms
+            .get(&vm.meta.id, None, None, None)
+            .await
+            .unwrap()
+            .is_none());
+
+        // The IP slot should be re-allocable to another VM (same
+        // slot, because no other VM has been allocated yet).
+        let vm2 = create_vm(
+            &vms, "web2", "acme", "web", "prod", "vpc1", "public", 1, 512, 10,
+        )
+        .await;
+        assert_eq!(vm2.private_ip.as_deref(), Some(ip.as_str()));
+    }
 }

--- a/layers/forge/src/reconciler/vm.rs
+++ b/layers/forge/src/reconciler/vm.rs
@@ -87,8 +87,9 @@ impl super::Reconciler for VmReconciler {
         let mut result = ReconcileResult::new("vm");
         let rt = Self::runtime(ctx);
 
-        // 1. Get VMs assigned to this node
-        let vm_store = nauka_compute::vm::store::VmStore::new(ctx.db.clone());
+        // 1. Get VMs assigned to this node. P2.13 (sifrah/nauka#217)
+        // migrated `VmStore` to take an `EmbeddedDb` directly.
+        let vm_store = nauka_compute::vm::store::VmStore::new(ctx.db.embedded().clone());
         let all_vms = vm_store.list(None, None, None).await?;
         let local_vms: Vec<_> = all_vms
             .iter()

--- a/layers/forge/src/reconciler/vpc.rs
+++ b/layers/forge/src/reconciler/vpc.rs
@@ -82,8 +82,9 @@ impl super::Reconciler for VpcReconciler {
     async fn reconcile(&self, ctx: &ReconcileContext) -> anyhow::Result<ReconcileResult> {
         let mut result = ReconcileResult::new("vpc");
 
-        // 1. Find which VMs are on this node
-        let vm_store = nauka_compute::vm::store::VmStore::new(ctx.db.clone());
+        // 1. Find which VMs are on this node. P2.13 (sifrah/nauka#217)
+        // migrated `VmStore` to take an `EmbeddedDb` directly.
+        let vm_store = nauka_compute::vm::store::VmStore::new(ctx.db.embedded().clone());
         let all_vms = vm_store.list(None, None, None).await?;
         let local_vms: Vec<_> = all_vms
             .iter()


### PR DESCRIPTION
## Summary
- Rewrite `layers/compute/src/vm/store.rs` to use `EmbeddedDb` + SCHEMAFULL `vm` table via SurrealDB SDK (replaces legacy raw-KV ClusterDb path).
- Decouple `VmStore::create` from the scheduler — takes `hypervisor_id: String` as a parameter; handler resolves the hypervisor before persisting. Lets unit tests run without live fabric state.
- Update forge reconciler call sites (`reconciler/vm.rs`, `reconciler/vpc.rs`) to pass `ctx.db.embedded().clone()`.

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo test -p nauka-compute` — 13 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `grep -rn 'ClusterDb\|RawClient' layers/compute/src` → 0 hits
- [x] Cross-compile musl release
- [x] Hetzner node-5 end-to-end: vm create / list / get / stop / start / delete full CRUD, scheduler assigned hypervisor, IPAM allocated 10.0.1.2, state transitions correct

Closes #217