### PR TITLE
feat(P2.17): doctor checks SurrealDB connectivity + schemas

### DIFF
--- a/layers/hypervisor/src/doctor.rs
+++ b/layers/hypervisor/src/doctor.rs
@@ -702,7 +702,7 @@ mod tests {
     async fn run_doctor_no_panic() {
         // On a test system, doctor should run without panic
         let report = run().await;
-        // Should have 4 sections
-        assert_eq!(report.checks.len(), 4);
+        // 5 sections: Fabric, Controlplane, SurrealDB (P2.17), Storage, System.
+        assert_eq!(report.checks.len(), 5);
     }
 }

--- a/layers/hypervisor/src/doctor.rs
+++ b/layers/hypervisor/src/doctor.rs
@@ -138,6 +138,7 @@ pub async fn run() -> DoctorReport {
 
     check_fabric(&mut report, &state);
     check_controlplane(&mut report, mesh_ipv6.as_ref());
+    check_surrealdb(&mut report).await;
     check_storage(&mut report, &storage_statuses);
     check_system(&mut report);
 
@@ -393,6 +394,130 @@ fn check_controlplane(report: &mut DoctorReport, mesh_ipv6: Option<&Ipv6Addr>) {
             }
         }
     }
+}
+
+// ═══════════════════════════════════════════════════
+// SurrealDB checks (P2.17 — sifrah/nauka#221)
+// ═══════════════════════════════════════════════════
+
+/// Verify the cluster-side SurrealDB is reachable, that the configured
+/// namespace/database is selected, and that every expected schema
+/// table from [`nauka_state::CLUSTER_TABLE_NAMES`] is present.
+///
+/// All three checks degrade gracefully: if `controlplane::connect`
+/// fails (PD/TiKV down, cluster not initialised, …) the rest of the
+/// section is skipped with an actionable hint pointing at the next
+/// command to run, not a stack trace.
+async fn check_surrealdb(report: &mut DoctorReport) {
+    let checks = report.add_section("SurrealDB");
+
+    // 1. Connectivity — go through the same controlplane helper every
+    //    other layer uses so we exercise the real connect path
+    //    (PD endpoint discovery, TiKv handshake, NS/DB select).
+    let db = match controlplane::connect().await {
+        Ok(db) => {
+            checks.push(ok(
+                "connectivity",
+                "cluster reachable via controlplane::connect",
+            ));
+            db
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            // Two distinct failure modes → two distinct fixes.
+            let hint = if msg.contains("not initialized") {
+                "run `nauka hypervisor init` to bootstrap a cluster"
+            } else {
+                "check PD/TiKV services with `nauka hypervisor cp-status`"
+            };
+            checks.push(fail("connectivity", &format!("{msg} — {hint}")));
+            checks.push(skip("namespace/database", "skipped (no connection)"));
+            checks.push(skip("schemas", "skipped (no connection)"));
+            return;
+        }
+    };
+
+    // 2. NS/DB sanity — `INFO FOR DB` returns the catalog of the
+    //    currently-selected database, which is exactly the namespace
+    //    [`nauka_state::EmbeddedDb::open_tikv`] selected on connect.
+    //    A failure here means we connected but the use_ns/use_db call
+    //    silently no-op'd (shouldn't happen) or the user pointed us at
+    //    a database that exists but lacks SCHEMAFULL definitions.
+    let info_value: Option<serde_json::Value> = match db.client().query("INFO FOR DB").await {
+        Ok(mut res) => match res.take::<Option<serde_json::Value>>(0) {
+            Ok(Some(v)) => {
+                checks.push(ok(
+                    "namespace/database",
+                    &format!(
+                        "{}/{} selected",
+                        nauka_state::NAUKA_NS,
+                        nauka_state::CLUSTER_DB
+                    ),
+                ));
+                Some(v)
+            }
+            Ok(None) => {
+                checks.push(fail("namespace/database", "INFO FOR DB returned no rows"));
+                None
+            }
+            Err(e) => {
+                checks.push(fail(
+                    "namespace/database",
+                    &format!("INFO FOR DB take failed: {e}"),
+                ));
+                None
+            }
+        },
+        Err(e) => {
+            checks.push(fail(
+                "namespace/database",
+                &format!(
+                    "INFO FOR DB failed: {e} — schemas are not applied, \
+                     re-run `nauka hypervisor init` on the bootstrap node"
+                ),
+            ));
+            None
+        }
+    };
+
+    // 3. Schemas — every table in the canonical list must appear in
+    //    INFO FOR DB's `tables` map. Anything missing is actionable:
+    //    upgrade the binary or re-bootstrap.
+    if let Some(info) = info_value {
+        let present: std::collections::HashSet<&str> = info
+            .get("tables")
+            .and_then(|t| t.as_object())
+            .map(|m| m.keys().map(String::as_str).collect())
+            .unwrap_or_default();
+
+        let missing: Vec<&str> = nauka_state::CLUSTER_TABLE_NAMES
+            .iter()
+            .copied()
+            .filter(|t| !present.contains(t))
+            .collect();
+
+        if missing.is_empty() {
+            checks.push(ok(
+                "schemas",
+                &format!(
+                    "all {} cluster tables present",
+                    nauka_state::CLUSTER_TABLE_NAMES.len()
+                ),
+            ));
+        } else {
+            checks.push(fail(
+                "schemas",
+                &format!(
+                    "missing tables: {} — re-run `nauka hypervisor init` to apply schemas",
+                    missing.join(", ")
+                ),
+            ));
+        }
+    } else {
+        checks.push(skip("schemas", "skipped (INFO FOR DB unavailable)"));
+    }
+
+    let _ = db.shutdown().await;
 }
 
 // ═══════════════════════════════════════════════════

--- a/layers/state/src/lib.rs
+++ b/layers/state/src/lib.rs
@@ -48,7 +48,7 @@ pub mod schema;
 pub mod sdk_bridge;
 
 pub use embedded::{pd_endpoints_for, EmbeddedDb};
-pub use schema::apply_cluster_schemas;
+pub use schema::{apply_cluster_schemas, CLUSTER_TABLE_NAMES};
 
 // ═══════════════════════════════════════════════════
 // SurrealDB namespace / database constants (ADR 0003)

--- a/layers/state/src/schema.rs
+++ b/layers/state/src/schema.rs
@@ -25,6 +25,25 @@ use crate::{EmbeddedDb, Result, StateError};
 /// (`layers/state/src/schema.rs`), so the paths climb out of
 /// `state/src` and back down into each sibling layer's `schemas/`
 /// directory.
+/// Table names defined by the cluster schemas, in application order.
+///
+/// Exposed publicly so callers (`nauka hypervisor doctor`, the migration
+/// runner, etc.) can verify that every expected table is present in a
+/// running cluster without having to re-parse the `.surql` files.
+/// Kept in lockstep with [`CLUSTER_SCHEMAS`] by
+/// [`tests::cluster_table_names_matches_schemas`].
+pub const CLUSTER_TABLE_NAMES: &[&str] = &[
+    "user",
+    "org",
+    "project",
+    "env",
+    "vpc",
+    "subnet",
+    "vpc_peering",
+    "natgw",
+    "vm",
+];
+
 const CLUSTER_SCHEMAS: &[(&str, &str)] = &[
     ("user", include_str!("../../org/schemas/user.surql")),
     ("org", include_str!("../../org/schemas/org.surql")),
@@ -107,5 +126,21 @@ mod tests {
             .expect("second apply (idempotency) should succeed");
 
         db.shutdown().await.expect("shutdown");
+    }
+
+    /// P2.17 (sifrah/nauka#221) — the public [`CLUSTER_TABLE_NAMES`]
+    /// list must stay in sync with the schemas actually applied. If
+    /// somebody adds a `.surql` file to [`CLUSTER_SCHEMAS`] without
+    /// updating the names list (or vice versa), the doctor's
+    /// schema-presence check would silently miss the new table.
+    #[test]
+    fn cluster_table_names_matches_schemas() {
+        let schema_names: Vec<&str> = CLUSTER_SCHEMAS.iter().map(|(n, _)| *n).collect();
+        assert_eq!(
+            CLUSTER_TABLE_NAMES,
+            &schema_names[..],
+            "CLUSTER_TABLE_NAMES drifted from CLUSTER_SCHEMAS — \
+             update layers/state/src/schema.rs to keep them in lockstep"
+        );
     }
 }


### PR DESCRIPTION
## Summary
\`nauka hypervisor doctor\` now has a **SurrealDB** section that exercises the live cluster connect path and reports three distinct checks:

1. **connectivity** — TiKv handshake via the same \`controlplane::connect\` helper every other layer uses
2. **namespace/database** — \`INFO FOR DB\` against the connected handle, confirming \`nauka/cluster\` is selected
3. **schemas** — every table in the new \`nauka_state::CLUSTER_TABLE_NAMES\` export must appear in the \`INFO FOR DB\` \`tables\` map; missing ones are listed by name with a remediation hint

Failure modes degrade gracefully:
- \"cluster not initialized\" → \`nauka hypervisor init\`
- PD/TiKV unreachable → \`nauka hypervisor cp-status\`

A new \`CLUSTER_TABLE_NAMES\` public const is exported from \`nauka-state\` and pinned against \`CLUSTER_SCHEMAS\` by a unit test, so any new \`.surql\` file that's added without updating both lists fails the build.

## Test plan
- [x] \`cargo build --workspace\` clean
- [x] \`cargo test -p nauka-state --lib schema\` — \`cluster_table_names_matches_schemas\` passes
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] Cross-compile musl release
- [x] Hetzner node-5 — green path renders all 3 SurrealDB checks ✓ on a healthy cluster
- [x] Hetzner node-5 — uninitialized path: \"cluster not initialized\" with \`nauka hypervisor init\` hint
- [x] Hetzner node-5 — broken-cluster path (region leader missing): connectivity ✗ with \`cp-status\` hint, ns/db + schemas skipped

Closes #221