### PR TITLE
fix(#281): one-shot peering listener by default, no background spawns

### DIFF
--- a/layers/hypervisor/src/fabric/ops.rs
+++ b/layers/hypervisor/src/fabric/ops.rs
@@ -152,6 +152,7 @@ pub async fn listen_for_peers(
     pin: &str,
     peering_port: u16,
     timeout_secs: u64,
+    max_joins: usize,
 ) -> Result<usize, NaukaError> {
     let bind_addr = format!("[::]:{peering_port}")
         .parse()
@@ -159,43 +160,61 @@ pub async fn listen_for_peers(
 
     let timeout = std::time::Duration::from_secs(timeout_secs);
 
-    // Start health check loop in background
-    tokio::spawn(async move {
-        super::health::run_loop(
-            open_db,
-            super::health::DEFAULT_INTERVAL_SECS,
-            super::health::DEFAULT_STALE_THRESHOLD_SECS,
-        )
-        .await;
-    });
+    // P2/#281: only spawn the long-running background helpers (health
+    // loop, announce listener, periodic mesh reconciliation) in the
+    // explicit unlimited-accept mode (`max_joins == 0`), which is what
+    // `hypervisor init --peering` uses for a bootstrap-then-daemon
+    // flow. In one-shot mode (`max_joins > 0`, the new default for
+    // standalone `nauka hypervisor peering`) we skip them entirely so
+    // the process can exit cleanly after the listen loop returns — a
+    // detached `tokio::spawn` keeps the runtime alive indefinitely
+    // otherwise, which is exactly how #281 manifested. The helpers
+    // are also redundant in that mode because `nauka-announce` is
+    // already installed as a systemd service by `init` / `join` and
+    // runs continuously in the background.
+    if max_joins == 0 {
+        // Start health check loop in background
+        tokio::spawn(async move {
+            super::health::run_loop(
+                open_db,
+                super::health::DEFAULT_INTERVAL_SECS,
+                super::health::DEFAULT_STALE_THRESHOLD_SECS,
+            )
+            .await;
+        });
 
-    // Start announce listener in background (peering_port + 1 = announce port)
-    let announce_port = peering_port + 1;
-    let announce_addr: std::net::SocketAddr = format!("[::]:{announce_port}")
-        .parse()
-        .map_err(|_| NaukaError::internal("invalid announce bind address"))?;
-    tokio::spawn(async move {
-        if let Err(e) = super::announce::listen(open_db, announce_addr).await {
-            tracing::warn!(error = %e, "announce listener stopped");
-        }
-    });
+        // Start announce listener in background (peering_port + 1 = announce port)
+        let announce_port = peering_port + 1;
+        let announce_addr: std::net::SocketAddr = format!("[::]:{announce_port}")
+            .parse()
+            .map_err(|_| NaukaError::internal("invalid announce bind address"))?;
+        tokio::spawn(async move {
+            if let Err(e) = super::announce::listen(open_db, announce_addr).await {
+                tracing::warn!(error = %e, "announce listener stopped");
+            }
+        });
 
-    // Start periodic mesh reconciliation in background.
-    // Every 30s, re-read the full peer list and announce every peer to every
-    // other peer. This is idempotent (known peers are skipped) and guarantees
-    // full mesh convergence even after concurrent joins.
-    let reconcile_wg_port = peering_port - 1; // wg_port = peering_port - 1
-    tokio::spawn(async move {
-        // Initial delay — let the first joins settle
-        tokio::time::sleep(std::time::Duration::from_secs(30)).await;
-        loop {
-            reconcile_mesh(reconcile_wg_port).await;
+        // Start periodic mesh reconciliation in background.
+        // Every 30s, re-read the full peer list and announce every peer to every
+        // other peer. This is idempotent (known peers are skipped) and guarantees
+        // full mesh convergence even after concurrent joins.
+        let reconcile_wg_port = peering_port - 1; // wg_port = peering_port - 1
+        tokio::spawn(async move {
+            // Initial delay — let the first joins settle
             tokio::time::sleep(std::time::Duration::from_secs(30)).await;
-        }
-    });
+            loop {
+                reconcile_mesh(reconcile_wg_port).await;
+                tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+            }
+        });
+    }
 
-    // Main peering listener (blocks)
-    super::peering_server::listen(open_db, pin, bind_addr, timeout, 0).await
+    // Main peering listener (blocks until `max_joins` is reached or
+    // the idle timeout elapses). P2/#281: the previous hard-coded
+    // `0` here meant "accept forever", turning every `nauka hypervisor
+    // peering` invocation into a long-lived daemon that had to be
+    // killed manually.
+    super::peering_server::listen(open_db, pin, bind_addr, timeout, max_joins).await
 }
 
 /// Reconciliation interval in seconds (matches the sleep in the spawned task).

--- a/layers/hypervisor/src/handlers.rs
+++ b/layers/hypervisor/src/handlers.rs
@@ -194,9 +194,18 @@ pub fn resource_def() -> ResourceDef {
         .op(|op| {
             op.with_arg(OperationArg::optional(
                 "timeout",
-                FieldDef::integer("timeout", "Listener timeout in seconds").with_default("3600"),
+                FieldDef::integer("timeout", "Listener idle timeout in seconds").with_default("300"),
+            ))
+            .with_arg(OperationArg::optional(
+                "max-joins",
+                FieldDef::integer(
+                    "max-joins",
+                    "Number of joins to accept before exiting (0 = unlimited)",
+                )
+                .with_default("1"),
             ))
             .with_example("nauka hypervisor peering")
+            .with_example("nauka hypervisor peering --max-joins 3 --timeout 600")
         })
         .action("backup", "Create a backup of PD and TiKV data to S3")
         .op(|op| {
@@ -579,13 +588,12 @@ async fn handle_init(req: OperationRequest) -> anyhow::Result<OperationResponse>
         eprintln!("  Waiting for joins... (Ctrl+C to stop)");
         eprintln!();
 
-        // Block here listening for joins (DB opened per-request, no lock held)
-        let accepted = fabric::ops::listen_for_peers(
-            &result.pin,
-            peering_port,
-            3600, // 1 hour timeout
-        )
-        .await?;
+        // Block here listening for joins (DB opened per-request, no lock held).
+        // P2/#281: `init --peering` is the bootstrap-then-accept-unlimited-
+        // joins flow, so we explicitly request unlimited mode (0) with the
+        // legacy 1-hour idle timeout. The standalone `nauka hypervisor
+        // peering` command defaults to 1-join-then-exit instead.
+        let accepted = fabric::ops::listen_for_peers(&result.pin, peering_port, 3600, 0).await?;
 
         eprintln!("  {} node(s) joined.", accepted);
 
@@ -820,11 +828,22 @@ async fn handle_join(req: OperationRequest) -> anyhow::Result<OperationResponse>
 }
 
 async fn handle_peering(req: OperationRequest) -> anyhow::Result<OperationResponse> {
+    // P2/#281: default to accepting ONE join then exiting. The
+    // operator-intuitive model is "run this, wait for a join, get
+    // your shell back". Unlimited-accept mode is still available via
+    // `--max-joins 0` for scripted bulk-join workflows. Default idle
+    // timeout is also dropped from 1 h to 5 min so a forgotten
+    // listener cleans up quickly instead of parking resources.
     let timeout_secs: u64 = req
         .fields
         .get("timeout")
         .and_then(|s| s.parse().ok())
-        .unwrap_or(3600);
+        .unwrap_or(300);
+    let max_joins: usize = req
+        .fields
+        .get("max-joins")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1);
 
     let db = open_db().await?;
     let state = fabric::state::FabricState::load(&db)
@@ -844,14 +863,21 @@ async fn handle_peering(req: OperationRequest) -> anyhow::Result<OperationRespon
     eprintln!();
     eprintln!("  Peering active on port {peering_port}");
     eprintln!("  PIN: {pin}");
+    if max_joins > 0 {
+        eprintln!(
+            "  Accepting up to {max_joins} join{} (idle timeout {timeout_secs}s)",
+            if max_joins == 1 { "" } else { "s" }
+        );
+    } else {
+        eprintln!("  Accepting unlimited joins (idle timeout {timeout_secs}s)");
+    }
     eprintln!();
     eprintln!("  Nodes can join with:");
     eprintln!("    nauka hypervisor join --target <this-ip>:{peering_port} --pin {pin}");
     eprintln!();
-    eprintln!("  Waiting for joins... (Ctrl+C to stop)");
-    eprintln!();
 
-    let accepted = fabric::ops::listen_for_peers(&pin, peering_port, timeout_secs).await?;
+    let accepted =
+        fabric::ops::listen_for_peers(&pin, peering_port, timeout_secs, max_joins).await?;
 
     Ok(OperationResponse::Message(format!(
         "{accepted} node(s) joined."


### PR DESCRIPTION
## Summary
\`nauka hypervisor peering\` previously doubled as both a one-shot command and a long-running daemon. It spawned three detached \`tokio::spawn\` background tasks (health loop, announce listener, periodic mesh reconcile), passed \`max_joins = 0\` (\"accept forever\") to the listen loop, and ran with a 1-hour idle timeout. Result: the command never exited on its own, kept holding the \`bootstrap.skv\` SurrealKV flock, and every subsequent CLI call on the same node hit \`#280\` until the process was killed by hand.

This PR splits the two flows cleanly:

1. **Standalone \`nauka hypervisor peering\`** is now one-shot by default. New CLI arg \`--max-joins N\` (default \`1\`), default idle timeout dropped from \`3600\` s to \`300\` s. Running with no args accepts exactly one join, prints \"1 node(s) joined.\", and returns.

2. **\`init --peering\`** keeps the bootstrap-then-daemon semantics by passing \`max_joins = 0\` + the legacy 1-hour timeout explicitly.

3. **Background tasks gated on \`max_joins == 0\`**. In one-shot mode we never \`tokio::spawn\` the health / announce / reconcile loops, so when the main listen loop returns the tokio runtime has no detached futures keeping it alive. \`nauka-announce\` is already installed as a systemd service at init / join time, so the in-process duplicate wasn't needed anyway.

## Test plan
- [x] \`cargo build --workspace\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] Cross-compile musl release
- [x] Hetzner end-to-end (fsn1 cpx22, two nodes on \`basics\`):
  - Started \`nauka hypervisor peering\` on node-1 via nohup. Output shows \`Accepting up to 1 join (idle timeout 300s)\` — new CLI header.
  - Ran \`nauka hypervisor join --target 91.98.144.178 --pin 5160\` from node-2.
  - After the join: \`ps -ef | grep 'hypervisor peering' | grep -v grep\` → empty. \`cat /tmp/peering.log\` → \`1 node(s) joined.\`. \`fuser /var/lib/nauka/bootstrap.skv/LOCK\` → \`lock_free\`.
- [x] No \`systemctl\` / \`pkill\` workaround used to force the listener to exit — the fix itself is responsible.

Closes #281