### PR TITLE
fix(#293): self-announce before storage setup + filter phantom PD endpoints

### DIFF
--- a/layers/hypervisor/src/controlplane/ops.rs
+++ b/layers/hypervisor/src/controlplane/ops.rs
@@ -620,6 +620,123 @@ pub fn leave() -> Result<(), NaukaError> {
     service::uninstall()
 }
 
+/// Resolve the set of real, currently-reachable PD endpoints for the TiKV
+/// SDK, given a naive per-peer candidate list.
+///
+/// The caller (post-join storage setup) builds `candidates` by mapping
+/// every fabric peer to `http://[<mesh_ipv6>]:2379`. That list contains:
+///  - real PD members (good),
+///  - synthesized URLs for TiKV-only peers (bad: no PD listening on 2379),
+///  - possibly real PDs whose WireGuard peer propagation hasn't caught up
+///    on this node yet (typical during rapid joins — the new node
+///    received all peers via the join response, but an existing peer may
+///    not have received the PeerAnnounce broadcast yet).
+///
+/// Passing such a list straight to `open_tikv` wastes its 10 s
+/// per-endpoint timeout on every bad entry, and in the common case the
+/// SDK picks a bad one first and the whole join fails with
+/// `open_tikv: handshake to [<ip>]:2379 timed out after 10s`
+/// (sifrah/nauka#293).
+///
+/// This helper solves it in two passes:
+///
+/// 1. Find any one reachable endpoint in `candidates` (polling with a
+///    short interval until `max_wait_secs` elapses). As soon as one
+///    responds, query it for the authoritative PD member list via
+///    `/pd/api/v1/members`.
+/// 2. Wait until every member in that authoritative list is also
+///    reachable, up to the remaining deadline. Return whatever subset
+///    became reachable — never less than the one seed endpoint, and
+///    usually the full set.
+///
+/// Returns an empty vec only if no endpoint ever answers within the
+/// deadline. The caller must handle that as a hard error.
+pub fn wait_reachable_pds(candidates: &[String], max_wait_secs: u64) -> Vec<String> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(max_wait_secs);
+
+    // Pass 1: find a single reachable candidate and use it to fetch the
+    // real member list. We loop because a freshly-joined node may need
+    // a few seconds for WG to carry the first packet to even one peer.
+    let mut seed: Option<(String, Vec<String>)> = None;
+    while seed.is_none() && std::time::Instant::now() < deadline {
+        for url in candidates {
+            let client = super::pd_client::PdClient::new(vec![url.clone()]);
+            if !client.ping() {
+                continue;
+            }
+            match client.get_members() {
+                Ok(members) => {
+                    let real: Vec<String> = members
+                        .iter()
+                        .flat_map(|m| m.client_urls.iter().cloned())
+                        .collect();
+                    tracing::debug!(
+                        seed = %url,
+                        members = real.len(),
+                        "wait_reachable_pds: fetched authoritative member list"
+                    );
+                    seed = Some((url.clone(), real));
+                    break;
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        endpoint = %url,
+                        error = %e,
+                        "wait_reachable_pds: ping ok but get_members failed, trying next"
+                    );
+                }
+            }
+        }
+        if seed.is_none() {
+            std::thread::sleep(std::time::Duration::from_secs(1));
+        }
+    }
+
+    let (seed_url, real_endpoints) = match seed {
+        Some(s) => s,
+        None => {
+            tracing::warn!(
+                candidates_count = candidates.len(),
+                "wait_reachable_pds: no PD endpoint answered within deadline"
+            );
+            return Vec::new();
+        }
+    };
+
+    // Pass 2: wait for every real member to be reachable. The seed is
+    // already known-good, so we add it straight to the reachable set.
+    let mut pending: Vec<String> = real_endpoints
+        .iter()
+        .filter(|e| *e != &seed_url)
+        .cloned()
+        .collect();
+    let mut reachable: Vec<String> = vec![seed_url];
+
+    while !pending.is_empty() && std::time::Instant::now() < deadline {
+        pending.retain(|url: &String| {
+            let client = super::pd_client::PdClient::new(vec![url.clone()]);
+            if client.ping() {
+                reachable.push(url.clone());
+                false
+            } else {
+                true
+            }
+        });
+        if !pending.is_empty() && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_secs(1));
+        }
+    }
+
+    if !pending.is_empty() {
+        tracing::warn!(
+            unreachable = ?pending,
+            reachable_count = reachable.len(),
+            "wait_reachable_pds: deadline reached, proceeding with reachable subset"
+        );
+    }
+    reachable
+}
+
 /// Wait for mesh connectivity to a PD endpoint (HTTP health check).
 fn wait_mesh_connectivity(pd_url: &str, timeout_secs: u64) -> Result<(), NaukaError> {
     let client = super::pd_client::PdClient::new(vec![pd_url.to_string()]);

--- a/layers/hypervisor/src/handlers.rs
+++ b/layers/hypervisor/src/handlers.rs
@@ -735,47 +735,29 @@ async fn handle_join(req: OperationRequest) -> anyhow::Result<OperationResponse>
         )?;
     }
 
-    // Fetch region storage config from distributed KV and setup locally
-    if network_mode == fabric::NetworkMode::WireGuard {
-        steps.set("Setting up storage");
-        let state = fabric::state::FabricState::load(&db)
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?
-            .ok_or_else(|| anyhow::anyhow!("state missing after join"))?;
-        let pd_endpoints: Vec<String> = state
-            .peers
-            .peers
-            .iter()
-            .map(|p| format!("http://[{}]:{}", p.mesh_ipv6, controlplane::PD_CLIENT_PORT))
-            .collect();
-        let pd_refs: Vec<&str> = pd_endpoints.iter().map(|s| s.as_str()).collect();
-
-        let region_config = storage::ops::fetch_region_config(&pd_refs, region)
-            .await?
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "no storage backend configured for region '{region}'.\n\n\
-                     An S3 backend must be registered before nodes can join this region.\n\
-                     On the init node, re-initialize with storage flags:\n\n\
-                     \x20 nauka hypervisor init --region {region} \\\n\
-                     \x20   --s3-endpoint <URL> --s3-bucket <BUCKET> \\\n\
-                     \x20   --s3-access-key <KEY> --s3-secret-key <SECRET>"
-                )
-            })?;
-
-        storage::ops::setup_region(&db, region_config).await?;
-        steps.inc();
-    }
-
-    // Self-announce to all peers (ensures they know about us even if the
-    // peering server's announce arrived before their listener was ready).
+    // Self-announce to all peers BEFORE storage setup.
     //
-    // IMPORTANT (#282): this MUST run BEFORE `announce::install_service`.
-    // That call does `systemctl enable --now`, which spawns the forge
-    // service, which opens `bootstrap.skv` and holds its flock. If we
-    // re-open the DB here after that, we lose the race and the whole
-    // join exits 1 despite being semantically successful. Reuse the
-    // already-open `db` handle.
+    // Why first: the peering server on the accepting node broadcasts our
+    // PeerAnnounce to every existing peer, but that is best-effort — if
+    // any recipient's announce listener is busy or the TCP connect fails,
+    // that recipient never learns about us and its WireGuard config stays
+    // without our public key. Packets we send to it over wg0 then get
+    // dropped, which manifests later as `open_tikv: handshake timed out`
+    // if that recipient happens to be the PD we (or the SDK) picks for
+    // the storage step (sifrah/nauka#293).
+    //
+    // Doing the self-announce here, before storage setup, makes the join
+    // establish bidirectional WireGuard peerage with every peer directly
+    // — one TCP dial per peer, not relying on the accepting node's
+    // broadcast — so that by the time `open_tikv` runs, the joining node
+    // can actually reach every PD member.
+    //
+    // IMPORTANT (#282): this step must still run BEFORE
+    // `announce::install_service`. That call does `systemctl enable --now`,
+    // which spawns the forge service, which opens `bootstrap.skv` and
+    // holds its flock. If we re-open the DB here after that, we lose
+    // the race and the whole join exits 1 despite being semantically
+    // successful. Reuse the already-open `db` handle.
     steps.set("Announcing to peers");
     {
         let state = fabric::state::FabricState::load(&db)
@@ -804,6 +786,53 @@ async fn handle_join(req: OperationRequest) -> anyhow::Result<OperationResponse>
         }
     }
     steps.inc();
+
+    // Fetch region storage config from distributed KV and setup locally
+    if network_mode == fabric::NetworkMode::WireGuard {
+        steps.set("Setting up storage");
+        let state = fabric::state::FabricState::load(&db)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?
+            .ok_or_else(|| anyhow::anyhow!("state missing after join"))?;
+        let pd_endpoints: Vec<String> = state
+            .peers
+            .peers
+            .iter()
+            .map(|p| format!("http://[{}]:{}", p.mesh_ipv6, controlplane::PD_CLIENT_PORT))
+            .collect();
+
+        // sifrah/nauka#293 — filter to currently-reachable PD endpoints
+        // before handing the list to the TiKV SDK. Without this, the
+        // SDK wastes its 10s handshake timeout on peers whose WG
+        // propagation is still in flight, or on synthesized PD URLs
+        // for TiKV-only peers that don't run PD at all. The helper
+        // queries the first reachable PD for the authoritative member
+        // list, so synthesized phantoms are dropped fast.
+        let reachable_pds = controlplane::ops::wait_reachable_pds(&pd_endpoints, 30);
+        if reachable_pds.is_empty() {
+            return Err(anyhow::anyhow!(
+                "no reachable PD endpoints after 30s (checked {})",
+                pd_endpoints.len()
+            ));
+        }
+        let pd_refs: Vec<&str> = reachable_pds.iter().map(|s| s.as_str()).collect();
+
+        let region_config = storage::ops::fetch_region_config(&pd_refs, region)
+            .await?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no storage backend configured for region '{region}'.\n\n\
+                     An S3 backend must be registered before nodes can join this region.\n\
+                     On the init node, re-initialize with storage flags:\n\n\
+                     \x20 nauka hypervisor init --region {region} \\\n\
+                     \x20   --s3-endpoint <URL> --s3-bucket <BUCKET> \\\n\
+                     \x20   --s3-access-key <KEY> --s3-secret-key <SECRET>"
+                )
+            })?;
+
+        storage::ops::setup_region(&db, region_config).await?;
+        steps.inc();
+    }
 
     // Install persistent announce listener AFTER self-announce, so the
     // forge/announce systemd unit doesn't grab `bootstrap.skv`'s flock


### PR DESCRIPTION
Closes #293.

## Summary
Joining a 4th+ node into a 3-PD cluster sporadically failed with \`open_tikv: handshake to [<pd>]:2379 timed out after 10s\`. Two compound causes:

**1. Self-announce was after storage setup.** The joining node's direct \`PeerAnnounce\` broadcast to every peer ran *after* \`fetch_region_config\` → \`open_tikv\`. If the accepting node's best-effort broadcast had missed a peer (announce listener busy — see also #295), that peer never added us to its WireGuard config and our packets to it were silently dropped at its wg0. The storage step then picked that peer and hung 10 s per attempt. **Fix: move self-announce BEFORE storage setup** so bidirectional WireGuard peerage is established with every peer by the time \`open_tikv\` runs.

**2. Phantom PD URLs in the endpoint list.** \`handlers.rs\` builds the PD endpoint list naively by mapping every fabric peer to \`http://[<mesh_ipv6>]:2379\`. That list contains synthesized URLs for TiKV-only peers, which have nothing listening on 2379 — a guaranteed 10 s timeout every time the SDK picks one. **Fix: add \`controlplane::ops::wait_reachable_pds\`** which:
  1. Finds any reachable candidate in the naive list.
  2. Queries it for the authoritative member list via \`/pd/api/v1/members\`.
  3. Waits for every real member to become reachable, up to a 30 s deadline.
  4. Returns the verified subset for \`fetch_region_config\` → \`open_tikv\`.

## Files changed
- \`layers/hypervisor/src/controlplane/ops.rs\` — new \`wait_reachable_pds\` helper with two-pass strategy
- \`layers/hypervisor/src/handlers.rs\` — reorder join steps (self-announce → storage setup), call \`wait_reachable_pds\` before \`fetch_region_config\`

## Test plan
- [x] \`cargo build --release --target x86_64-unknown-linux-musl --bin nauka\`
- [x] \`cargo test -p nauka-hypervisor --lib\` (137 passed)
- [x] Live test against a 7-node cluster on Hetzner: a fresh join that had been failing at 187 s with \`open_tikv: handshake timed out\` now completes in 45 s
- [x] Logs confirm: self-announce reports 7 successes (including all 3 real PDs) **before** storage setup, and \`wait_reachable_pds\` correctly identifies and filters phantom PD URLs from TiKV-only peers

## Notes / follow-ups
- The #295 flock issue on the announce listener can still cause a peer to miss a broadcast. This PR mitigates the symptom (direct self-announce closes the gap for each joiner), but #295 should still be fixed so the persistent listener doesn't fall behind under load.
- This change keeps the #282 ordering constraint: self-announce still runs before \`announce::install_service\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)