### PR TITLE
fix(#295): release bootstrap.skv flock before cp-status PD round trips

### DIFF
--- a/layers/hypervisor/src/handlers.rs
+++ b/layers/hypervisor/src/handlers.rs
@@ -1127,16 +1127,31 @@ async fn handle_backup_list() -> anyhow::Result<OperationResponse> {
 }
 
 async fn handle_cp_status() -> anyhow::Result<OperationResponse> {
-    let db = open_db().await?;
-    let state = fabric::state::FabricState::load(&db)
-        .await
-        .map_err(|e| anyhow::anyhow!("{e}"))?
-        .ok_or_else(|| {
-            anyhow::anyhow!("cluster not initialized. Run 'nauka hypervisor init' first.")
-        })?;
+    // sifrah/nauka#295 — release the bootstrap.skv flock BEFORE making any
+    // PD HTTP round trips. Holding the flock across the (potentially slow)
+    // `get_members`/`get_stores`/`get_region_stats` calls blocks every
+    // other local CLI that needs to open the same DB, including the
+    // persistent announce listener — which then drops incoming peer
+    // announces and cascades into `open_tikv` failures on freshly-joining
+    // nodes (the symptom that made #293 so hard to reproduce cleanly).
+    // Scope the DB tightly: open, read the one field we need, shut down.
+    let mesh_ipv6 = {
+        let db = open_db().await?;
+        let state = fabric::state::FabricState::load(&db)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?
+            .ok_or_else(|| {
+                anyhow::anyhow!("cluster not initialized. Run 'nauka hypervisor init' first.")
+            })?;
+        let ip = state.hypervisor.mesh_ipv6;
+        db.shutdown().await.ok();
+        ip
+    };
 
-    let mesh_ipv6 = state.hypervisor.mesh_ipv6;
-    let client = controlplane::pd_client::PdClient::from_mesh(&mesh_ipv6);
+    // Tighter per-request timeout than the default 10s — cp-status is
+    // an operator-facing read path and should fail fast if PD is stuck
+    // rather than hold the terminal for 30 s across three endpoints.
+    let client = controlplane::pd_client::PdClient::from_mesh(&mesh_ipv6).with_timeout(5);
 
     // --- PD Members ---
     let members_result = client.get_members();


### PR DESCRIPTION
Closes #295.

## Summary
\`handle_cp_status\` opened \`EmbeddedDb\` at the top of the handler and held the handle alive across three PD HTTP calls (\`get_members\`, \`get_stores\`, \`get_region_stats\`). The handle keeps an exclusive flock on \`/var/lib/nauka/bootstrap.skv/LOCK\` for its entire lifetime, so any other CLI or service that tries to open the same DB during those up-to-30 s of HTTP fails with \`Database ... is already locked by another process\`.

In practice this cascaded into two observed failures:
- Concurrent \`cp-status\` / \`doctor\` / \`status\` invocations aborting on the second call.
- The persistent \`nauka-announce\` listener dropping incoming \`PeerAnnounce\` messages, leaving WireGuard peerage broken on the recipient, which then manifested as \`open_tikv: handshake timed out\` on joining nodes — exactly the fallout that made #293 so hard to reproduce cleanly.

## Fix
- Scope the DB open tightly: read \`mesh_ipv6\` in a block, \`db.shutdown().await.ok()\` immediately, then do the PD HTTP work outside the scope. This matches the pattern already used by \`handle_backup\` (the only other handler that needed to touch both local DB and a remote HTTP surface, in sifrah/nauka#282's aftermath).
- Tighten the per-request PD client timeout from the default 10 s to 5 s. \`cp-status\` is an operator-facing read path, not a health check for internal reconciliation — it should fail fast instead of hanging the terminal for 30 s across three endpoints if PD is stuck.

## Files changed
- \`layers/hypervisor/src/handlers.rs\` — scope DB in \`handle_cp_status\`, tighten PdClient timeout

## Test plan
- [x] \`cargo build --release --target x86_64-unknown-linux-musl --bin nauka\`
- [x] \`cargo test -p nauka-hypervisor --lib\` (137 passed)
- [x] Live on a 9-node Hetzner cluster: two \`cp-status\` invocations ~200 ms apart both return the full PD / TiKV / region tables. Before the fix, the second one died on the flock error.

## Follow-ups
- Other handlers in \`handlers.rs\` that hold \`open_db()\` across long-running work (HTTP / systemctl / waits) likely have the same class of bug. Out of scope for this PR — file per-handler issues if/when they bite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)