### PR TITLE
fix(#299): hypervisor daemon owns the bootstrap DB, CLI forwards via UDS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,37 +10,43 @@ Open-source platform that turns bare-metal servers into a programmable cloud.
 
 ## Repository Structure
 - `layers/core` — `nauka-core`: Resource framework, typed IDs, crypto, addressing, API gen, UI, config (no I/O, no async)
-- `layers/state` — `nauka-state`: Embedded persistence (redb), typed tables, TTL, CAS, watch
-- `layers/hypervisor` — `nauka-hypervisor`: WireGuard mesh (fabric), peering protocol, service lifecycle, handlers
+- `layers/state` — `nauka-state`: SurrealDB-backed persistence (`EmbeddedDb` wraps SurrealKV for local bootstrap state, TiKV for cluster state)
+- `layers/hypervisor` — `nauka-hypervisor`: WireGuard mesh (fabric), peering protocol, hypervisor daemon, service lifecycle, handlers
 - `bin/nauka` — CLI binary that composes all layers (zero logic)
 - `docs/` — Starlight documentation site (deployed to GitHub Pages)
 
 ## Key Modules (layers/hypervisor/src/)
 - `fabric/mesh.rs` — Mesh + hypervisor identity, create_mesh(), create_hypervisor()
 - `fabric/peer.rs` — Peer management, PeerList, PeerStatus
-- `fabric/ops.rs` — High-level orchestration: init, join, status, start, stop, leave
+- `fabric/ops.rs` — High-level orchestration: init, join, status, start, stop, leave, plus `status_view`/`list_view`/`get_view` JSON views
 - `fabric/peering.rs` — TCP peering protocol types (JoinRequest, JoinResponse, PeerAnnounce)
-- `fabric/peering_server.rs` — TCP listener for join requests
+- `fabric/peering_server.rs` — TCP listener for join requests (runs inside the daemon)
 - `fabric/peering_client.rs` — TCP client for join flow
+- `fabric/announce.rs` — Announce listener + broadcast helpers (runs inside the daemon)
+- `fabric/daemon.rs` — `nauka.service` entry point: owns the `EmbeddedDb` handle, spawns peering/announce/health/reconcile tasks, hosts the control socket, handles SIGTERM shutdown
+- `fabric/control/` — Unix-socket protocol + server + client (`ControlRequest`/`ControlResponse`, `forward_or_fallback`)
 - `fabric/wg.rs` — WireGuard interface management (nauka0)
 - `fabric/service.rs` — systemd service management (wg-quick@nauka0)
-- `fabric/state.rs` — FabricState persistence (redb)
-- `handlers.rs` — ResourceDef + thin handlers (delegate to fabric::ops)
+- `fabric/state.rs` — FabricState persistence + `write_lock` for cross-task serialisation of state mutations
+- `handlers.rs` — ResourceDef + thin handlers (forward to daemon via control socket, fall back to direct DB access)
 
 ## Architecture
-- Nauka is a CLI orchestrator, NOT a daemon. Configures systemd services, then exits.
+- Every deployed node runs a long-lived `nauka.service` (the hypervisor daemon). The daemon opens `bootstrap.skv` once at startup and holds the handle for its lifetime, hosting the peering TCP listener, the announce listener, the WireGuard health loop, the mesh reconciler, and the operator Unix control socket all in one tokio runtime. SurrealDB's internal concurrency handles multi-reader/multi-writer inside the shared handle; the daemon is the *only* process holding the SurrealKV flock.
+- Operator CLI commands (`status`, `list`, `get`, `cp-status`, `drain`, `enable`, `update`) forward through `/run/nauka/ctl.sock` (`~/.nauka/ctl.sock` in CLI mode) when the daemon is up, and fall back to opening `bootstrap.skv` directly when it is not — so bootstrap, recovery, and test harnesses keep working with no daemon installed.
+- One-shot CLI commands still run as standalone processes: `init` and `join` open the DB, set state up, release the handle, then `daemon::install_service()` starts the daemon. `leave` sends `ControlRequest::Shutdown`, waits for the daemon to exit, then tears the rest of the state down and uninstalls the unit.
 - Every server is a hypervisor. The mesh connects them.
 - ResourceDef generates both CLI commands (clap) and REST API routes (axum) from one definition.
 - IPv6-native: each mesh gets a ULA /48, each node a /128.
 
 ## CLI
-- `nauka hypervisor init` — create a new mesh
-- `nauka hypervisor join` — join an existing mesh
-- `nauka hypervisor status` — show status
-- `nauka hypervisor start/stop` — manage WireGuard service
-- `nauka hypervisor leave` — leave the mesh
-- `nauka hypervisor peering` — start peering listener
-- `nauka hypervisor list/get` — list/get hypervisors
+- `nauka hypervisor init` — create a new mesh, install `nauka.service`
+- `nauka hypervisor join` — join an existing mesh, install `nauka.service`
+- `nauka hypervisor status` — show status (forwards to daemon via UDS if up)
+- `nauka hypervisor start/stop` — manage all local services (wg, daemon, PD, TiKV, storage)
+- `nauka hypervisor leave` — stop daemon, tear down, uninstall unit
+- `nauka hypervisor list/get` — list/get hypervisors (forwards to daemon)
+- `nauka hypervisor cp-status` — control plane status (forwards for `mesh_ipv6`, then HTTP locally)
+- `nauka hypervisor daemon` — `ExecStart` of `nauka.service` (invoked by systemd, not directly)
 
 ## Conventions
 - serde Serialize/Deserialize on all public types

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,6 +2795,7 @@ name = "nauka-hypervisor-e2e"
 version = "0.1.0"
 dependencies = [
  "axum 0.8.8",
+ "base64 0.22.1",
  "http 1.4.0",
  "nauka-core",
  "nauka-hypervisor",

--- a/layers/core/src/process.rs
+++ b/layers/core/src/process.rs
@@ -1,7 +1,7 @@
 //! Process utilities — paths, directories, run-mode detection.
 //!
-//! No daemon, no fork, no PID file. Nauka is a CLI orchestrator,
-//! not a daemon. WireGuard runs in the kernel.
+//! Run-mode-aware helpers for both CLI invocations and the long-lived
+//! hypervisor daemon (`nauka.service`). WireGuard runs in the kernel.
 //!
 //! # Run modes
 //!
@@ -40,9 +40,21 @@ pub fn ensure_nauka_dir() -> Result<(), NaukaError> {
     Ok(())
 }
 
-/// Default control socket path (for future API server).
+/// Path of the hypervisor daemon's Unix control socket.
+///
+/// - CLI mode → `$HOME/.nauka/ctl.sock`
+/// - Service mode → `/run/nauka/ctl.sock`
+///
+/// The parent directory is **not** created by this function. In service
+/// mode it is populated by systemd via `RuntimeDirectory=nauka` on
+/// `nauka.service`; in CLI mode [`ensure_nauka_dir`] / the daemon
+/// creates `~/.nauka` before binding.
 pub fn socket_path() -> PathBuf {
-    nauka_dir().join("control.sock")
+    if is_service_mode() {
+        PathBuf::from("/run/nauka/ctl.sock")
+    } else {
+        nauka_dir().join("ctl.sock")
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -138,9 +150,16 @@ mod tests {
     }
 
     #[test]
-    fn socket_path_in_dir() {
+    fn socket_path_run_mode_aware() {
         let p = socket_path();
-        assert!(p.to_str().unwrap().contains(".nauka/control.sock"));
+        // In test environment we run as non-root so we land in CLI mode.
+        // The service-mode branch is exercised manually via Hetzner smoke
+        // tests; asserting on it here would require faking geteuid().
+        if is_service_mode() {
+            assert_eq!(p, PathBuf::from("/run/nauka/ctl.sock"));
+        } else {
+            assert!(p.to_str().unwrap().ends_with(".nauka/ctl.sock"));
+        }
     }
 
     #[test]

--- a/layers/hypervisor/src/fabric/announce.rs
+++ b/layers/hypervisor/src/fabric/announce.rs
@@ -9,8 +9,9 @@
 //! Announcements are best-effort: if a peer is unreachable, we skip it
 //! and rely on the next health check or manual sync.
 
-use std::future::Future;
 use std::time::Duration;
+
+use tokio::sync::watch;
 
 use nauka_core::error::NaukaError;
 use nauka_state::EmbeddedDb;
@@ -261,12 +262,17 @@ pub async fn broadcast_state_change(
 /// 2. Update WireGuard config
 /// 3. Persist state
 ///
-/// Opens DB per-request to avoid lock contention.
-pub async fn listen<F, Fut>(db_opener: F, bind_addr: std::net::SocketAddr) -> Result<(), NaukaError>
-where
-    F: Fn() -> Fut,
-    Fut: Future<Output = Result<EmbeddedDb, NaukaError>>,
-{
+/// The caller supplies a long-lived [`EmbeddedDb`] handle; each incoming
+/// message is serviced in a freshly spawned task with a clone of that
+/// handle, so concurrent announces run in parallel against the same
+/// underlying `Datastore` with no flock contention.
+///
+/// Exits when `shutdown` transitions to `true`.
+pub async fn listen(
+    db: EmbeddedDb,
+    bind_addr: std::net::SocketAddr,
+    mut shutdown: watch::Receiver<bool>,
+) -> Result<(), NaukaError> {
     let listener = tokio::net::TcpListener::bind(bind_addr)
         .await
         .map_err(|e| NaukaError::internal(format!("failed to bind announce port: {e}")))?;
@@ -277,43 +283,51 @@ where
     tracing::info!(addr = %bind_addr, "announce listener started (TLS)");
 
     loop {
-        match listener.accept().await {
-            Ok((tcp_stream, peer_addr)) => {
-                // TLS handshake
-                let mut stream = match tls_acceptor.accept(tcp_stream).await {
-                    Ok(s) => s,
-                    Err(e) => {
-                        tracing::warn!(peer = %peer_addr, error = %e, "announce TLS handshake failed");
-                        continue;
-                    }
-                };
+        if *shutdown.borrow() {
+            break;
+        }
 
-                let db = match db_opener().await {
-                    Ok(db) => db,
-                    Err(e) => {
-                        tracing::warn!(error = %e, "announce: failed to open DB");
-                        continue;
-                    }
-                };
+        tokio::select! {
+            biased;
+            _ = shutdown.changed() => {
+                if *shutdown.borrow() {
+                    tracing::info!("announce listener shutting down");
+                    break;
+                }
+            }
+            accept_result = listener.accept() => {
+                match accept_result {
+                    Ok((tcp_stream, peer_addr)) => {
+                        let tls_acceptor = tls_acceptor.clone();
+                        let db = db.clone();
+                        tokio::spawn(async move {
+                            let mut stream = match tls_acceptor.accept(tcp_stream).await {
+                                Ok(s) => s,
+                                Err(e) => {
+                                    tracing::warn!(peer = %peer_addr, error = %e, "announce TLS handshake failed");
+                                    return;
+                                }
+                            };
 
-                match handle_message(&mut stream, &db).await {
-                    Ok(msg) => {
-                        tracing::info!(from = %peer_addr, result = %msg, "announce handled");
+                            match handle_message(&mut stream, &db).await {
+                                Ok(msg) => {
+                                    tracing::info!(from = %peer_addr, result = %msg, "announce handled");
+                                }
+                                Err(e) => {
+                                    tracing::warn!(from = %peer_addr, error = %e, "announce failed");
+                                }
+                            }
+                        });
                     }
                     Err(e) => {
-                        tracing::warn!(from = %peer_addr, error = %e, "announce failed");
+                        tracing::warn!(error = %e, "announce accept error");
                     }
                 }
-
-                // Release the SurrealKV flock before the next accept opens a
-                // new handle, so announce/peering/health runs don't contend.
-                let _ = db.shutdown().await;
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "announce accept error");
             }
         }
     }
+
+    Ok(())
 }
 
 /// Handle an incoming announce message (add or remove).

--- a/layers/hypervisor/src/fabric/announce.rs
+++ b/layers/hypervisor/src/fabric/announce.rs
@@ -567,98 +567,12 @@ async fn handle_peer_announce(
     Ok(peer_name)
 }
 
-// ═══════════════════════════════════════════════════
-// Announce listener systemd service
-// ═══════════════════════════════════════════════════
-
-const ANNOUNCE_SERVICE: &str = "nauka-announce";
-const ANNOUNCE_UNIT_PATH: &str = "/etc/systemd/system/nauka-announce.service";
-
-/// Generate the systemd unit for the persistent announce listener.
-fn generate_announce_unit(port: u16) -> String {
-    let announce_port = port + ANNOUNCE_PORT_OFFSET;
-    format!(
-        r#"[Unit]
-Description=Nauka Peer Announce Listener
-After=network-online.target nauka-wg.service
-Wants=network-online.target
-Requires=nauka-wg.service
-
-[Service]
-Type=simple
-ExecStart=/usr/local/bin/nauka hypervisor announce-listen --port {announce_port}
-Restart=on-failure
-RestartSec=5
-
-[Install]
-WantedBy=multi-user.target
-"#
-    )
-}
-
-/// Install and start the announce listener service.
-pub fn install_service(wg_port: u16) -> Result<(), NaukaError> {
-    std::fs::write(ANNOUNCE_UNIT_PATH, generate_announce_unit(wg_port))
-        .map_err(NaukaError::from)?;
-    run_systemctl(&["daemon-reload"])?;
-    run_systemctl(&["enable", "--now", ANNOUNCE_SERVICE])?;
-    Ok(())
-}
-
-/// Start the announce listener service.
-pub fn start_service() -> Result<(), NaukaError> {
-    if !is_service_installed() {
-        return Ok(());
-    }
-    run_systemctl(&["start", ANNOUNCE_SERVICE])
-}
-
-/// Stop the announce listener service.
-pub fn stop_service() -> Result<(), NaukaError> {
-    if !is_service_installed() {
-        return Ok(());
-    }
-    let _ = run_systemctl(&["stop", ANNOUNCE_SERVICE]);
-    Ok(())
-}
-
-/// Uninstall the announce listener service.
-pub fn uninstall_service() -> Result<(), NaukaError> {
-    let _ = run_systemctl(&["disable", "--now", ANNOUNCE_SERVICE]);
-    let _ = std::fs::remove_file(ANNOUNCE_UNIT_PATH);
-    let _ = run_systemctl(&["daemon-reload"]);
-    Ok(())
-}
-
-/// Check if the service is installed.
-pub fn is_service_installed() -> bool {
-    std::path::Path::new(ANNOUNCE_UNIT_PATH).exists()
-}
-
-/// Check if the service is active.
-pub fn is_service_active() -> bool {
-    std::process::Command::new("systemctl")
-        .args(["is-active", "--quiet", ANNOUNCE_SERVICE])
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
-}
-
-fn run_systemctl(args: &[&str]) -> Result<(), NaukaError> {
-    let output = std::process::Command::new("systemctl")
-        .args(args)
-        .output()
-        .map_err(|e| NaukaError::internal(format!("systemctl failed: {e}")))?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(NaukaError::internal(format!(
-            "systemctl {} failed: {}",
-            args.join(" "),
-            stderr.trim()
-        )));
-    }
-    Ok(())
-}
+// The `nauka-announce.service` systemd unit that used to live here
+// has been superseded by `nauka.service` (see `fabric::daemon`).
+// The new daemon hosts the announce listener in-process alongside
+// the peering listener, health loop, and reconciler — all sharing
+// one `EmbeddedDb` handle. `fabric::daemon::install_service` migrates
+// any leftover `nauka-announce.service` unit during upgrade.
 
 #[cfg(test)]
 mod tests {

--- a/layers/hypervisor/src/fabric/control/client.rs
+++ b/layers/hypervisor/src/fabric/control/client.rs
@@ -147,7 +147,7 @@ where
 /// otherwise. Used by the CLI to decide whether to print "daemon
 /// running" vs "daemon not installed" hints.
 pub async fn is_daemon_up() -> bool {
-    matches!(send(&ControlRequest::Ping).await, Ok(_))
+    send(&ControlRequest::Ping).await.is_ok()
 }
 
 #[cfg(test)]

--- a/layers/hypervisor/src/fabric/control/client.rs
+++ b/layers/hypervisor/src/fabric/control/client.rs
@@ -1,0 +1,195 @@
+//! Control socket client — used by every operator-facing CLI handler.
+//!
+//! The operator runs `nauka hypervisor status` (or `list`, `get`,
+//! `cp-status`, …) in a terminal. In the new daemon model the daemon
+//! holds the flock, so every read path that used to `open_default()`
+//! must route through the Unix socket when the daemon is up — and
+//! seamlessly fall back to a direct DB open when it is not (first-time
+//! bootstrap, test harness, recovery).
+//!
+//! [`forward_or_fallback`] is the single helper every handler calls.
+//! It also decouples CLI and daemon: if the binary is upgraded on disk
+//! but the running daemon is still the previous version, the CLI still
+//! talks to it over the same wire protocol.
+
+use std::future::Future;
+use std::time::Duration;
+
+use tokio::net::UnixStream;
+
+use super::protocol::{socket_path, ControlRequest, ControlResponse};
+use crate::fabric::peering_server::{read_json, write_json};
+
+/// Errors returned by [`forward_or_fallback`]. Only `SocketMissing`
+/// and `ConnectRefused` trigger the fallback path — everything else
+/// surfaces to the caller as an error.
+#[derive(Debug)]
+pub enum ClientError {
+    /// The socket file does not exist. Daemon is not running (or has
+    /// not been installed yet, which is the case during `init`).
+    SocketMissing,
+    /// The socket file exists but connecting to it failed — most
+    /// commonly `ECONNREFUSED` after a daemon crash left a stale path.
+    ConnectRefused(std::io::Error),
+    /// Transport error while talking to the daemon (read/write failed).
+    Transport(String),
+    /// The daemon answered with `ok == false`.
+    Daemon(String),
+    /// Response payload did not deserialise into the expected type.
+    BadPayload(String),
+}
+
+impl std::fmt::Display for ClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ClientError::SocketMissing => write!(f, "daemon socket not present"),
+            ClientError::ConnectRefused(e) => write!(f, "daemon socket refused connection: {e}"),
+            ClientError::Transport(m) => write!(f, "daemon transport: {m}"),
+            ClientError::Daemon(m) => write!(f, "daemon error: {m}"),
+            ClientError::BadPayload(m) => write!(f, "daemon payload: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for ClientError {}
+
+/// How long we wait for the daemon to accept + answer a request
+/// before giving up and surfacing a transport error. The daemon
+/// should respond in the low-ms range for every supported request;
+/// 5 s matches the Nauka "fast timeout" convention for operator
+/// commands.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Send a single request to the daemon and parse the response.
+///
+/// Returns the raw `serde_json::Value` so callers can project it into
+/// whatever concrete type they want. Returns [`ClientError::SocketMissing`]
+/// / [`ClientError::ConnectRefused`] when the daemon isn't up —
+/// callers typically route that to the fallback path.
+pub async fn send(req: &ControlRequest) -> Result<serde_json::Value, ClientError> {
+    let path = socket_path();
+    if !path.exists() {
+        return Err(ClientError::SocketMissing);
+    }
+
+    let connect = UnixStream::connect(&path);
+    let mut stream = match tokio::time::timeout(REQUEST_TIMEOUT, connect).await {
+        Ok(Ok(s)) => s,
+        Ok(Err(e)) => {
+            // Classify ECONNREFUSED / ENOENT as "daemon not up" so the
+            // fallback path still kicks in even if a stale socket file
+            // lingered.
+            if e.kind() == std::io::ErrorKind::ConnectionRefused
+                || e.kind() == std::io::ErrorKind::NotFound
+            {
+                return Err(ClientError::ConnectRefused(e));
+            }
+            return Err(ClientError::Transport(format!("connect: {e}")));
+        }
+        Err(_) => return Err(ClientError::Transport("connect timeout".into())),
+    };
+
+    let io = async {
+        write_json(&mut stream, req)
+            .await
+            .map_err(|e| ClientError::Transport(format!("write: {e}")))?;
+        let resp: ControlResponse = read_json(&mut stream)
+            .await
+            .map_err(|e| ClientError::Transport(format!("read: {e}")))?;
+        Ok::<_, ClientError>(resp)
+    };
+
+    let resp = match tokio::time::timeout(REQUEST_TIMEOUT, io).await {
+        Ok(res) => res?,
+        Err(_) => return Err(ClientError::Transport("request timeout".into())),
+    };
+
+    if !resp.ok {
+        return Err(ClientError::Daemon(
+            resp.error.unwrap_or_else(|| "unknown error".into()),
+        ));
+    }
+
+    Ok(resp.data)
+}
+
+/// Try to forward the operation over the control socket. If the
+/// daemon is not running, invoke `fallback` instead. Transport,
+/// daemon, and payload errors are all propagated as `anyhow::Error`
+/// so CLI handlers keep their existing error shape.
+///
+/// `decode` converts the raw JSON value returned by the daemon (or
+/// produced by the fallback path) into the CLI handler's strongly
+/// typed return value. `fallback` is invoked **lazily** — if the
+/// daemon handles the request, `fallback` never runs and the caller
+/// never opens the DB.
+pub async fn forward_or_fallback<T, FbFut, DecFn>(
+    req: ControlRequest,
+    fallback: impl FnOnce() -> FbFut,
+    decode: DecFn,
+) -> anyhow::Result<T>
+where
+    FbFut: Future<Output = anyhow::Result<serde_json::Value>>,
+    DecFn: FnOnce(serde_json::Value) -> anyhow::Result<T>,
+{
+    match send(&req).await {
+        Ok(value) => decode(value),
+        Err(ClientError::SocketMissing) | Err(ClientError::ConnectRefused(_)) => {
+            let value = fallback().await?;
+            decode(value)
+        }
+        Err(other) => Err(anyhow::anyhow!("{other}")),
+    }
+}
+
+/// Best-effort liveness probe. Returns `true` if a daemon answered a
+/// [`ControlRequest::Ping`] within the request timeout, `false`
+/// otherwise. Used by the CLI to decide whether to print "daemon
+/// running" vs "daemon not installed" hints.
+pub async fn is_daemon_up() -> bool {
+    matches!(send(&ControlRequest::Ping).await, Ok(_))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn send_returns_socket_missing_when_path_absent() {
+        // Override: in CLI mode socket_path() points at ~/.nauka/ctl.sock.
+        // In the test environment we're not root and there's no daemon, so
+        // the path usually doesn't exist. Just confirm we get the expected
+        // error class.
+        let path = socket_path();
+        if path.exists() {
+            // If a real daemon is up on this test host, skip.
+            return;
+        }
+        let result = send(&ControlRequest::Ping).await;
+        assert!(matches!(
+            result,
+            Err(ClientError::SocketMissing) | Err(ClientError::ConnectRefused(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn forward_or_fallback_runs_fallback_when_daemon_missing() {
+        let path = socket_path();
+        if path.exists() {
+            return;
+        }
+        let called = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let flag = called.clone();
+        let result: anyhow::Result<i32> = forward_or_fallback(
+            ControlRequest::Ping,
+            || async move {
+                flag.store(true, std::sync::atomic::Ordering::SeqCst);
+                Ok(serde_json::json!(42))
+            },
+            |v| Ok(v.as_i64().unwrap() as i32),
+        )
+        .await;
+        assert_eq!(result.unwrap(), 42);
+        assert!(called.load(std::sync::atomic::Ordering::SeqCst));
+    }
+}

--- a/layers/hypervisor/src/fabric/control/mod.rs
+++ b/layers/hypervisor/src/fabric/control/mod.rs
@@ -1,0 +1,24 @@
+//! Hypervisor daemon control socket — local Unix-domain IPC.
+//!
+//! Every deployed node runs a long-lived `nauka.service` process that
+//! owns the bootstrap DB handle. Operator CLI commands (`status`,
+//! `list`, `get`, `cp-status`, `drain`, …) forward their operation over
+//! this Unix socket instead of opening `bootstrap.skv` directly — so
+//! the daemon's flock never contends with an ad-hoc CLI.
+//!
+//! Protocol: length-prefixed JSON (reusing the `read_json` /
+//! `write_json` helpers from `peering_server`), one request + one
+//! response per connection. Not versioned — same binary on both ends.
+//!
+//! The CLI fallback behaviour (open `bootstrap.skv` directly when no
+//! daemon is running) lives in [`client::forward_or_fallback`]. That
+//! path is important for bootstrapping (`init` creates the DB before
+//! installing the daemon), recovery, and test harnesses.
+
+pub mod client;
+pub mod protocol;
+pub mod server;
+
+pub use client::{forward_or_fallback, ClientError};
+pub use protocol::{socket_path, ControlRequest, ControlResponse};
+pub use server::run as run_control_server;

--- a/layers/hypervisor/src/fabric/control/mod.rs
+++ b/layers/hypervisor/src/fabric/control/mod.rs
@@ -19,6 +19,6 @@ pub mod client;
 pub mod protocol;
 pub mod server;
 
-pub use client::{forward_or_fallback, ClientError};
+pub use client::{forward_or_fallback, is_daemon_up, send, ClientError};
 pub use protocol::{socket_path, ControlRequest, ControlResponse};
 pub use server::run as run_control_server;

--- a/layers/hypervisor/src/fabric/control/protocol.rs
+++ b/layers/hypervisor/src/fabric/control/protocol.rs
@@ -1,0 +1,150 @@
+//! Wire protocol for the hypervisor daemon control socket.
+//!
+//! One request → one response, length-prefixed JSON. No streaming, no
+//! subscriptions. Adding a new operation is a matter of adding a new
+//! variant to [`ControlRequest`] plus a match arm in
+//! [`super::server::dispatch`].
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Path of the hypervisor daemon's control socket.
+///
+/// Proxies to [`nauka_core::process::socket_path`] so CLI and daemon
+/// agree on the same run-mode-aware location.
+pub fn socket_path() -> PathBuf {
+    nauka_core::process::socket_path()
+}
+
+/// Every operation the CLI can ask the daemon to perform on its
+/// behalf. Variants are ordered roughly from trivial (liveness check)
+/// to impactful (shutdown).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum ControlRequest {
+    /// Zero-arg liveness probe. The client uses it to decide whether
+    /// to forward or fall back to a direct `EmbeddedDb` open.
+    Ping,
+    /// `nauka hypervisor status` — local hypervisor + WG + CP summary.
+    Status,
+    /// `nauka hypervisor list` — hypervisor row + every peer row.
+    List,
+    /// `nauka hypervisor get <name>` — single hypervisor lookup.
+    Get { name: String },
+    /// `nauka hypervisor cp-status` — asks the daemon for the current
+    /// `mesh_ipv6`, then the CLI does its own PD HTTP round trips
+    /// against it. Not a full "forward everything" path because the
+    /// formatting is terminal-side.
+    MeshIpv6,
+    /// `nauka hypervisor drain` — flip this node to draining + broadcast.
+    Drain,
+    /// `nauka hypervisor enable` — flip this node back to available + broadcast.
+    Enable,
+    /// `nauka hypervisor update --ipv6-block ... --ipv4-public ... --name ...`.
+    Update {
+        ipv6_block: Option<String>,
+        ipv4_public: Option<String>,
+        name: Option<String>,
+    },
+    /// `nauka hypervisor leave` — tells the daemon to shut itself down
+    /// cleanly so the CLI can finish tearing state down without the
+    /// daemon racing it on the flock.
+    Shutdown,
+}
+
+/// Response envelope. `ok == true` means the operation ran and
+/// `data` is valid; `ok == false` means `error` carries a human
+/// message and `data` is `null`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ControlResponse {
+    pub ok: bool,
+    pub data: serde_json::Value,
+    pub error: Option<String>,
+}
+
+impl ControlResponse {
+    pub fn ok(data: serde_json::Value) -> Self {
+        Self {
+            ok: true,
+            data,
+            error: None,
+        }
+    }
+
+    pub fn err(msg: impl Into<String>) -> Self {
+        Self {
+            ok: false,
+            data: serde_json::Value::Null,
+            error: Some(msg.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_roundtrip_ping() {
+        let req = ControlRequest::Ping;
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"op\":\"ping\""));
+        let back: ControlRequest = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, ControlRequest::Ping));
+    }
+
+    #[test]
+    fn request_roundtrip_get() {
+        let req = ControlRequest::Get {
+            name: "node-1".into(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"op\":\"get\""));
+        assert!(json.contains("\"name\":\"node-1\""));
+        let back: ControlRequest = serde_json::from_str(&json).unwrap();
+        match back {
+            ControlRequest::Get { name } => assert_eq!(name, "node-1"),
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn request_roundtrip_update() {
+        let req = ControlRequest::Update {
+            ipv6_block: Some("2a01:4f8:c012:abcd::/64".into()),
+            ipv4_public: None,
+            name: Some("renamed".into()),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let back: ControlRequest = serde_json::from_str(&json).unwrap();
+        match back {
+            ControlRequest::Update {
+                ipv6_block,
+                ipv4_public,
+                name,
+            } => {
+                assert_eq!(ipv6_block.as_deref(), Some("2a01:4f8:c012:abcd::/64"));
+                assert_eq!(ipv4_public, None);
+                assert_eq!(name.as_deref(), Some("renamed"));
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn response_ok() {
+        let resp = ControlResponse::ok(serde_json::json!({"foo": 1}));
+        assert!(resp.ok);
+        assert_eq!(resp.data["foo"], 1);
+        assert!(resp.error.is_none());
+    }
+
+    #[test]
+    fn response_err() {
+        let resp = ControlResponse::err("boom");
+        assert!(!resp.ok);
+        assert_eq!(resp.error.as_deref(), Some("boom"));
+        assert!(resp.data.is_null());
+    }
+}

--- a/layers/hypervisor/src/fabric/control/server.rs
+++ b/layers/hypervisor/src/fabric/control/server.rs
@@ -1,0 +1,224 @@
+//! Control socket server — runs inside the hypervisor daemon.
+//!
+//! Binds to [`super::protocol::socket_path`], spawns a fresh task per
+//! incoming connection, dispatches each [`ControlRequest`] against the
+//! daemon's long-lived [`EmbeddedDb`] handle, and writes back a
+//! [`ControlResponse`]. No state is kept across connections.
+
+use std::path::Path;
+
+use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::watch;
+
+use nauka_core::error::NaukaError;
+use nauka_state::EmbeddedDb;
+
+use super::protocol::{socket_path, ControlRequest, ControlResponse};
+use crate::fabric::ops;
+use crate::fabric::peering_server::{read_json, write_json};
+use crate::fabric::state::FabricState;
+
+/// Run the control socket accept loop.
+///
+/// Returns when `shutdown` transitions to `true`. The socket file is
+/// removed on exit so the next daemon start can rebind without a stale
+/// `Address already in use`.
+///
+/// `shutdown_trigger` is the *sender* side of the same watch channel
+/// the daemon uses for its own shutdown — when a client sends
+/// [`ControlRequest::Shutdown`] we flip it to `true`, which wakes the
+/// daemon's main `shutdown.changed()` future and starts the clean
+/// teardown sequence.
+pub async fn run(
+    db: EmbeddedDb,
+    shutdown_trigger: watch::Sender<bool>,
+    mut shutdown: watch::Receiver<bool>,
+) -> Result<(), NaukaError> {
+    let path = socket_path();
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                NaukaError::internal(format!(
+                    "control socket parent dir {}: {e}",
+                    parent.display()
+                ))
+            })?;
+        }
+    }
+
+    // Clear any stale socket from a previous crash — `bind` refuses to
+    // clobber an existing file, and we don't want operator CLIs to
+    // hang on an orphan path.
+    let _ = std::fs::remove_file(&path);
+
+    let listener = UnixListener::bind(&path)
+        .map_err(|e| NaukaError::internal(format!("bind {}: {e}", path.display())))?;
+
+    set_socket_perms(&path);
+
+    tracing::info!(path = %path.display(), "control socket listening");
+
+    loop {
+        if *shutdown.borrow() {
+            break;
+        }
+
+        tokio::select! {
+            biased;
+            _ = shutdown.changed() => {
+                if *shutdown.borrow() {
+                    tracing::info!("control socket shutting down");
+                    break;
+                }
+            }
+            accept_result = listener.accept() => {
+                match accept_result {
+                    Ok((stream, _addr)) => {
+                        let db = db.clone();
+                        let trigger = shutdown_trigger.clone();
+                        tokio::spawn(async move {
+                            handle_one(stream, db, trigger).await;
+                        });
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "control socket accept error");
+                    }
+                }
+            }
+        }
+    }
+
+    let _ = std::fs::remove_file(&path);
+    Ok(())
+}
+
+/// Chmod the control socket to 0o660 so only root (service mode) or
+/// the owner (CLI mode) can talk to it. systemd's `RuntimeDirectory`
+/// already locks `/run/nauka` to 0o750 in service mode; this is a
+/// defence-in-depth on the socket file itself.
+fn set_socket_perms(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Err(e) = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o660)) {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "control socket chmod 0660 failed"
+            );
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+}
+
+/// Read one request, dispatch it, write the response. Errors during
+/// read/write are logged and the connection is dropped; the client
+/// will see `EOF` on its read.
+async fn handle_one(mut stream: UnixStream, db: EmbeddedDb, shutdown_trigger: watch::Sender<bool>) {
+    let req: ControlRequest = match read_json(&mut stream).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(error = %e, "control: read request failed");
+            return;
+        }
+    };
+
+    let resp = dispatch(&db, req, &shutdown_trigger).await;
+
+    if let Err(e) = write_json(&mut stream, &resp).await {
+        tracing::warn!(error = %e, "control: write response failed");
+    }
+}
+
+/// Operation dispatch table. Each arm either pulls data out of the
+/// daemon's live `EmbeddedDb` or mutates it (drain, enable, update,
+/// shutdown) and returns a JSON envelope.
+async fn dispatch(
+    db: &EmbeddedDb,
+    req: ControlRequest,
+    shutdown_trigger: &watch::Sender<bool>,
+) -> ControlResponse {
+    match req {
+        ControlRequest::Ping => ControlResponse::ok(serde_json::Value::Null),
+
+        ControlRequest::Status => match ops::status_view(db).await {
+            Ok(v) => ControlResponse::ok(v),
+            Err(e) => ControlResponse::err(e.to_string()),
+        },
+
+        ControlRequest::List => match ops::list_view(db).await {
+            Ok(v) => ControlResponse::ok(v),
+            Err(e) => ControlResponse::err(e.to_string()),
+        },
+
+        ControlRequest::Get { name } => match ops::get_view(db, &name).await {
+            Ok(v) => ControlResponse::ok(v),
+            Err(e) => ControlResponse::err(e.to_string()),
+        },
+
+        ControlRequest::MeshIpv6 => match FabricState::load(db).await {
+            Ok(Some(state)) => {
+                ControlResponse::ok(serde_json::json!(state.hypervisor.mesh_ipv6.to_string()))
+            }
+            Ok(None) => ControlResponse::err("not initialized"),
+            Err(e) => ControlResponse::err(e.to_string()),
+        },
+
+        ControlRequest::Drain => match ops::drain(db).await {
+            Ok(()) => ControlResponse::ok(serde_json::Value::Null),
+            Err(e) => ControlResponse::err(e.to_string()),
+        },
+
+        ControlRequest::Enable => match ops::enable(db).await {
+            Ok(()) => ControlResponse::ok(serde_json::Value::Null),
+            Err(e) => ControlResponse::err(e.to_string()),
+        },
+
+        ControlRequest::Update {
+            ipv6_block,
+            ipv4_public,
+            name,
+        } => {
+            let cfg = ops::UpdateConfig {
+                ipv6_block,
+                ipv4_public,
+                name,
+            };
+            match ops::update(db, &cfg).await {
+                Ok(hv) => ControlResponse::ok(serde_json::json!({
+                    "name": hv.name,
+                    "id": hv.id.as_str(),
+                    "region": hv.region,
+                    "zone": hv.zone,
+                    "mesh_ipv6": hv.mesh_ipv6.to_string(),
+                    "ipv6_block": hv.ipv6_block,
+                    "ipv4_public": hv.ipv4_public,
+                })),
+                Err(e) => ControlResponse::err(e.to_string()),
+            }
+        }
+
+        ControlRequest::Shutdown => {
+            // Flip the daemon's shutdown channel; the accept loop and
+            // every spawned listener is watching it and will exit.
+            // Reply `ok` *before* we close the socket so the client
+            // sees a clean acknowledgement.
+            let _ = shutdown_trigger.send(true);
+            ControlResponse::ok(serde_json::Value::Null)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn set_perms_on_missing_file_is_a_warning_not_panic() {
+        // Best-effort chmod: a missing file must not crash the server.
+        set_socket_perms(std::path::Path::new("/tmp/nauka-does-not-exist"));
+    }
+}

--- a/layers/hypervisor/src/fabric/daemon.rs
+++ b/layers/hypervisor/src/fabric/daemon.rs
@@ -348,6 +348,41 @@ pub fn start_service() -> Result<(), NaukaError> {
     run_systemctl(&["start", DAEMON_SERVICE])
 }
 
+/// Ask the running daemon to shut itself down via the control
+/// socket, then wait up to `timeout` for the socket file to
+/// disappear (which happens when the daemon's main task returns
+/// from `run` and `server::run` deletes the socket path on its way
+/// out).
+///
+/// Returns:
+/// - `Ok(true)` — a daemon was running, accepted the shutdown, and
+///   exited within the timeout.
+/// - `Ok(false)` — no daemon was running.
+/// - `Err(_)` — a daemon was running but either rejected the
+///   request or failed to exit within `timeout`.
+pub async fn request_shutdown_and_wait(timeout: Duration) -> Result<bool, NaukaError> {
+    use super::control;
+
+    match control::send(&control::ControlRequest::Shutdown).await {
+        Ok(_) => {
+            let socket = control::socket_path();
+            let start = std::time::Instant::now();
+            while start.elapsed() < timeout {
+                if !socket.exists() {
+                    return Ok(true);
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            Err(NaukaError::internal(
+                "daemon did not exit within timeout after shutdown request",
+            ))
+        }
+        Err(control::ClientError::SocketMissing)
+        | Err(control::ClientError::ConnectRefused(_)) => Ok(false),
+        Err(e) => Err(NaukaError::internal(format!("daemon shutdown: {e}"))),
+    }
+}
+
 fn run_systemctl(args: &[&str]) -> Result<(), NaukaError> {
     let output = std::process::Command::new("systemctl")
         .args(args)

--- a/layers/hypervisor/src/fabric/daemon.rs
+++ b/layers/hypervisor/src/fabric/daemon.rs
@@ -1,0 +1,400 @@
+//! Hypervisor daemon — long-lived process that owns the local
+//! `bootstrap.skv` handle and hosts every listener/loop that used to
+//! serialise on its OS flock.
+//!
+//! The daemon is installed by `nauka hypervisor init` / `join` as
+//! `nauka.service` on the node (see [`install_service`]). Its
+//! responsibilities are:
+//!
+//! 1. Open `EmbeddedDb` **once** on startup and keep the handle for
+//!    its entire lifetime. Every in-process task (peering, announce,
+//!    health, reconcile, control socket) gets a `.clone()` of the
+//!    handle, so concurrent operations run against one `Datastore`
+//!    with no per-request flock dance.
+//! 2. Run the peering TCP listener on `wg_port + 1`, the announce
+//!    TCP listener on `wg_port + 2`, the WireGuard health loop, the
+//!    periodic mesh reconciliation loop, and the local Unix control
+//!    socket concurrently.
+//! 3. Watch a `tokio::sync::watch::channel<bool>` for SIGTERM /
+//!    SIGINT / `ControlRequest::Shutdown`. On shutdown, every task
+//!    exits cleanly, we drain them, and **then** call
+//!    `EmbeddedDb::shutdown()` so the `LOCK` file is released before
+//!    systemd restarts us.
+
+use std::net::SocketAddr;
+use std::path::Path;
+use std::time::Duration;
+
+use tokio::sync::watch;
+use tokio::task::JoinSet;
+
+use nauka_core::error::NaukaError;
+use nauka_state::EmbeddedDb;
+
+use super::control;
+use super::state::FabricState;
+use super::{announce, health, ops, peering_server};
+
+/// systemd unit name (without the `.service` suffix).
+pub const DAEMON_SERVICE: &str = "nauka";
+
+/// Absolute path of the generated systemd unit.
+pub const DAEMON_UNIT_PATH: &str = "/etc/systemd/system/nauka.service";
+
+/// Legacy announce-listener unit — auto-removed by [`install_service`]
+/// so upgrades from a pre-#299 binary don't leave two services
+/// fighting over the announce port and the bootstrap flock.
+const LEGACY_ANNOUNCE_UNIT_PATH: &str = "/etc/systemd/system/nauka-announce.service";
+const LEGACY_ANNOUNCE_SERVICE: &str = "nauka-announce";
+
+/// How long the main `listen` future will wait between accepts
+/// before surfacing an idle timeout. In the daemon we effectively
+/// never time out — ten years is well inside `tokio::time::Instant`
+/// safety margins and much longer than any realistic uptime.
+const NEVER_IDLE: Duration = Duration::from_secs(60 * 60 * 24 * 365 * 10);
+
+/// Initial delay before the first mesh reconciliation pass — lets
+/// startup joins settle so the reconcile pass has something to do.
+const RECONCILE_WARMUP: Duration = Duration::from_secs(30);
+
+/// Run the hypervisor daemon. Blocks until SIGTERM / SIGINT /
+/// `ControlRequest::Shutdown`, then drains all child tasks and
+/// returns.
+pub async fn run() -> Result<(), NaukaError> {
+    let db = EmbeddedDb::open_default()
+        .await
+        .map_err(|e| NaukaError::internal(format!("daemon: open bootstrap.skv: {e}")))?;
+
+    let state = FabricState::load(&db)
+        .await
+        .map_err(|e| NaukaError::internal(e.to_string()))?
+        .ok_or_else(|| {
+            NaukaError::precondition(
+                "daemon started but no fabric state found. \
+                 Run 'nauka hypervisor init' or 'join' first.",
+            )
+        })?;
+
+    let secret: nauka_core::crypto::MeshSecret = state
+        .secret
+        .parse()
+        .map_err(|e| NaukaError::internal(format!("daemon: invalid secret: {e}")))?;
+    let pin = secret.derive_pin();
+    let wg_port = state.hypervisor.wg_port;
+    let peering_port = wg_port + 1;
+    let announce_port = wg_port + 2;
+
+    tracing::info!(
+        node = %state.hypervisor.name,
+        mesh_ipv6 = %state.hypervisor.mesh_ipv6,
+        peering_port,
+        announce_port,
+        "hypervisor daemon starting"
+    );
+
+    let peering_addr: SocketAddr = format!("[::]:{peering_port}")
+        .parse()
+        .map_err(|_| NaukaError::internal("daemon: invalid peering bind address"))?;
+    let announce_addr: SocketAddr = format!("[::]:{announce_port}")
+        .parse()
+        .map_err(|_| NaukaError::internal("daemon: invalid announce bind address"))?;
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    spawn_signal_handler(shutdown_tx.clone());
+
+    let mut tasks: JoinSet<()> = JoinSet::new();
+
+    // Peering listener — unlimited accepts, no idle timeout.
+    {
+        let db = db.clone();
+        let rx = shutdown_rx.clone();
+        let pin = pin.clone();
+        tasks.spawn(async move {
+            match peering_server::listen(db, pin, peering_addr, NEVER_IDLE, 0, rx).await {
+                Ok(count) => tracing::info!(accepted = count, "peering listener exited"),
+                Err(e) => tracing::warn!(error = %e, "peering listener stopped with error"),
+            }
+        });
+    }
+
+    // Announce listener — shares the same db handle.
+    {
+        let db = db.clone();
+        let rx = shutdown_rx.clone();
+        tasks.spawn(async move {
+            if let Err(e) = announce::listen(db, announce_addr, rx).await {
+                tracing::warn!(error = %e, "announce listener stopped with error");
+            }
+        });
+    }
+
+    // Health loop — refreshes peer reachability from `wg show dump`.
+    {
+        let db = db.clone();
+        let rx = shutdown_rx.clone();
+        tasks.spawn(async move {
+            health::run_loop(
+                db,
+                health::DEFAULT_INTERVAL_SECS,
+                health::DEFAULT_STALE_THRESHOLD_SECS,
+                rx,
+            )
+            .await;
+        });
+    }
+
+    // Periodic mesh reconciliation.
+    {
+        let db = db.clone();
+        let mut rx = shutdown_rx.clone();
+        tasks.spawn(async move {
+            // Skippable warmup: exit immediately if shutdown already fired.
+            tokio::select! {
+                biased;
+                _ = rx.changed() => {
+                    if *rx.borrow() { return; }
+                }
+                _ = tokio::time::sleep(RECONCILE_WARMUP) => {}
+            }
+            let interval = Duration::from_secs(ops::RECONCILE_INTERVAL_SECS);
+            loop {
+                ops::reconcile_mesh(&db, wg_port).await;
+                tokio::select! {
+                    biased;
+                    _ = rx.changed() => {
+                        if *rx.borrow() { break; }
+                    }
+                    _ = tokio::time::sleep(interval) => {}
+                }
+            }
+        });
+    }
+
+    // Control socket — lets the CLI and `leave` talk to us without
+    // touching bootstrap.skv directly.
+    {
+        let db = db.clone();
+        let trigger = shutdown_tx.clone();
+        let rx = shutdown_rx.clone();
+        tasks.spawn(async move {
+            if let Err(e) = control::run_control_server(db, trigger, rx).await {
+                tracing::warn!(error = %e, "control socket stopped with error");
+            }
+        });
+    }
+
+    // Wait for shutdown. The channel fires on SIGTERM/SIGINT or when
+    // any task (the control server, typically) flips it after
+    // receiving `ControlRequest::Shutdown`.
+    let mut wait_rx = shutdown_rx.clone();
+    while !*wait_rx.borrow() {
+        if wait_rx.changed().await.is_err() {
+            // Sender dropped — treat as shutdown.
+            break;
+        }
+    }
+
+    tracing::info!("hypervisor daemon shutting down");
+
+    // Drain spawned tasks — they all watch the same channel and will
+    // exit shortly. Draining ensures every `db` clone is dropped
+    // before we call `shutdown()` on the last one, which matters
+    // because `EmbeddedDb::shutdown` polls the SurrealKV LOCK file
+    // for release and would hang if another clone were still alive.
+    while let Some(res) = tasks.join_next().await {
+        if let Err(e) = res {
+            if !e.is_cancelled() {
+                tracing::warn!(error = %e, "daemon task join error");
+            }
+        }
+    }
+
+    if let Err(e) = db.shutdown().await {
+        tracing::warn!(error = %e, "daemon: EmbeddedDb shutdown failed");
+    }
+
+    tracing::info!("hypervisor daemon stopped");
+    Ok(())
+}
+
+/// Wire SIGTERM and SIGINT onto the shutdown watch channel. Runs as
+/// a detached task — the watch sender is the only state we care
+/// about, so there's nothing to join on.
+fn spawn_signal_handler(tx: watch::Sender<bool>) {
+    tokio::spawn(async move {
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::{signal, SignalKind};
+            let mut sigterm = match signal(SignalKind::terminate()) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(error = %e, "daemon signal handler install failed");
+                    return;
+                }
+            };
+            tokio::select! {
+                _ = sigterm.recv() => tracing::info!("daemon: SIGTERM received"),
+                _ = tokio::signal::ctrl_c() => tracing::info!("daemon: SIGINT received"),
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = tokio::signal::ctrl_c().await;
+        }
+        let _ = tx.send(true);
+    });
+}
+
+// ═══════════════════════════════════════════════════
+// systemd unit generation / install / uninstall
+// ═══════════════════════════════════════════════════
+
+/// Generate the systemd unit for the hypervisor daemon.
+///
+/// - `RuntimeDirectory=nauka` tells systemd to create `/run/nauka`
+///   (mode 0o750 via `RuntimeDirectoryMode`) before `ExecStart` runs,
+///   and to clean it up when the service stops. That's where the
+///   control socket lives.
+/// - `Restart=on-failure` restarts the daemon if it crashes but does
+///   not restart it after a clean `ControlRequest::Shutdown` (exit 0).
+///   This matters during `leave`: the CLI sends Shutdown, the daemon
+///   exits 0, systemd leaves it stopped, and then `uninstall_service`
+///   removes the unit file.
+fn generate_daemon_unit() -> String {
+    r#"[Unit]
+Description=Nauka Hypervisor Daemon
+Documentation=https://github.com/sifrah/nauka
+After=network-online.target nauka-wg.service
+Wants=network-online.target
+Requires=nauka-wg.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/nauka hypervisor daemon
+Restart=on-failure
+RestartSec=5
+RuntimeDirectory=nauka
+RuntimeDirectoryMode=0750
+
+[Install]
+WantedBy=multi-user.target
+"#
+    .to_string()
+}
+
+/// Install and start `nauka.service`.
+///
+/// Also migrates: if the legacy `nauka-announce.service` is present
+/// from a pre-#299 binary, it is stopped, disabled, and removed
+/// before the new unit is written so the two services don't fight
+/// over the announce port (`wg_port + 2`) or the bootstrap flock.
+pub fn install_service() -> Result<(), NaukaError> {
+    migrate_from_announce_service();
+
+    std::fs::write(DAEMON_UNIT_PATH, generate_daemon_unit()).map_err(NaukaError::from)?;
+    run_systemctl(&["daemon-reload"])?;
+    run_systemctl(&["enable", "--now", DAEMON_SERVICE])?;
+    Ok(())
+}
+
+/// Remove any pre-#299 `nauka-announce.service` unit left behind by
+/// an older binary. Called by [`install_service`] before writing the
+/// new unit so the migration is transparent.
+fn migrate_from_announce_service() {
+    if !Path::new(LEGACY_ANNOUNCE_UNIT_PATH).exists() {
+        return;
+    }
+    tracing::info!("migrating legacy nauka-announce.service -> nauka.service");
+    let _ = run_systemctl(&["disable", "--now", LEGACY_ANNOUNCE_SERVICE]);
+    let _ = std::fs::remove_file(LEGACY_ANNOUNCE_UNIT_PATH);
+    let _ = run_systemctl(&["daemon-reload"]);
+}
+
+/// Stop + disable + remove `nauka.service`. Idempotent.
+pub fn uninstall_service() -> Result<(), NaukaError> {
+    let _ = run_systemctl(&["disable", "--now", DAEMON_SERVICE]);
+    let _ = std::fs::remove_file(DAEMON_UNIT_PATH);
+    let _ = run_systemctl(&["daemon-reload"]);
+    Ok(())
+}
+
+/// `true` iff the unit file is present on disk.
+pub fn is_service_installed() -> bool {
+    Path::new(DAEMON_UNIT_PATH).exists()
+}
+
+/// `true` iff `systemctl is-active nauka` returns 0.
+pub fn is_service_active() -> bool {
+    std::process::Command::new("systemctl")
+        .args(["is-active", "--quiet", DAEMON_SERVICE])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Stop the service if it is installed. No-op otherwise.
+pub fn stop_service() -> Result<(), NaukaError> {
+    if !is_service_installed() {
+        return Ok(());
+    }
+    run_systemctl(&["stop", DAEMON_SERVICE])
+}
+
+/// Start the service if it is installed. No-op otherwise.
+pub fn start_service() -> Result<(), NaukaError> {
+    if !is_service_installed() {
+        return Ok(());
+    }
+    run_systemctl(&["start", DAEMON_SERVICE])
+}
+
+fn run_systemctl(args: &[&str]) -> Result<(), NaukaError> {
+    let output = std::process::Command::new("systemctl")
+        .args(args)
+        .output()
+        .map_err(|e| NaukaError::internal(format!("systemctl failed: {e}")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(NaukaError::internal(format!(
+            "systemctl {} failed: {}",
+            args.join(" "),
+            stderr.trim()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_unit_contains_required_sections() {
+        let unit = generate_daemon_unit();
+        assert!(unit.contains("[Unit]"));
+        assert!(unit.contains("[Service]"));
+        assert!(unit.contains("[Install]"));
+        assert!(unit.contains("ExecStart=/usr/local/bin/nauka hypervisor daemon"));
+        assert!(unit.contains("RuntimeDirectory=nauka"));
+        assert!(unit.contains("RuntimeDirectoryMode=0750"));
+        assert!(unit.contains("Requires=nauka-wg.service"));
+    }
+
+    #[test]
+    fn is_installed_returns_false_by_default() {
+        // In test environments the real system unit never exists.
+        if Path::new(DAEMON_UNIT_PATH).exists() {
+            return;
+        }
+        assert!(!is_service_installed());
+    }
+
+    #[test]
+    fn never_idle_is_sane() {
+        // Must be well under i64::MAX seconds so tokio's Instant math
+        // never overflows, but long enough that no realistic uptime
+        // triggers the idle-timeout branch of `peering_server::listen`.
+        assert!(NEVER_IDLE.as_secs() > 60 * 60 * 24 * 365); // > 1 year
+        assert!(NEVER_IDLE.as_secs() < i64::MAX as u64);
+    }
+}

--- a/layers/hypervisor/src/fabric/health.rs
+++ b/layers/hypervisor/src/fabric/health.rs
@@ -4,10 +4,11 @@
 //! - Handshake within threshold → Active
 //! - Handshake older than threshold → Unreachable
 //!
-//! Designed to run as a background tokio task during `peering` or future daemon mode.
+//! Designed to run as a background tokio task inside the hypervisor daemon.
 
-use std::future::Future;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use tokio::sync::watch;
 
 use nauka_core::error::NaukaError;
 use nauka_state::EmbeddedDb;
@@ -150,26 +151,33 @@ pub async fn check_once(
     })
 }
 
-/// Run the health check loop. Blocks until cancelled.
+/// Run the health check loop. Blocks until `shutdown` transitions to `true`.
 ///
-/// Opens a fresh DB connection each sweep to avoid holding the lock.
-pub async fn run_loop<F, Fut>(db_opener: F, interval_secs: u64, stale_threshold_secs: u64)
-where
-    F: Fn() -> Fut,
-    Fut: Future<Output = Result<EmbeddedDb, NaukaError>>,
-{
+/// The caller supplies a long-lived [`EmbeddedDb`] handle — the loop
+/// reuses it every sweep, so there is no per-iteration flock dance.
+pub async fn run_loop(
+    db: EmbeddedDb,
+    interval_secs: u64,
+    stale_threshold_secs: u64,
+    mut shutdown: watch::Receiver<bool>,
+) {
     let interval = Duration::from_secs(interval_secs);
 
     loop {
-        tokio::time::sleep(interval).await;
-
-        let db = match db_opener().await {
-            Ok(db) => db,
-            Err(e) => {
-                tracing::warn!(error = %e, "health check: failed to open DB");
-                continue;
+        tokio::select! {
+            biased;
+            _ = shutdown.changed() => {
+                if *shutdown.borrow() {
+                    tracing::info!("health check loop shutting down");
+                    break;
+                }
             }
-        };
+            _ = tokio::time::sleep(interval) => {}
+        }
+
+        if *shutdown.borrow() {
+            break;
+        }
 
         match check_once(&db, stale_threshold_secs).await {
             Ok(result) => {
@@ -187,10 +195,6 @@ where
                 tracing::warn!(error = %e, "health check failed");
             }
         }
-
-        // Explicit shutdown to release the SurrealKV flock before the next
-        // iteration opens a new handle.
-        let _ = db.shutdown().await;
     }
 }
 

--- a/layers/hypervisor/src/fabric/mod.rs
+++ b/layers/hypervisor/src/fabric/mod.rs
@@ -9,6 +9,7 @@
 
 pub mod announce;
 pub mod backend;
+pub mod control;
 pub mod direct;
 pub mod health;
 pub mod mesh;

--- a/layers/hypervisor/src/fabric/mod.rs
+++ b/layers/hypervisor/src/fabric/mod.rs
@@ -10,6 +10,7 @@
 pub mod announce;
 pub mod backend;
 pub mod control;
+pub mod daemon;
 pub mod direct;
 pub mod health;
 pub mod mesh;

--- a/layers/hypervisor/src/fabric/ops.rs
+++ b/layers/hypervisor/src/fabric/ops.rs
@@ -849,3 +849,165 @@ pub async fn leave(db: &EmbeddedDb) -> Result<(), NaukaError> {
 
     Ok(())
 }
+
+// ═══════════════════════════════════════════════════
+// JSON views — used by both the CLI fallback and the
+// hypervisor daemon control socket (#299).
+// ═══════════════════════════════════════════════════
+
+/// JSON view of `status` — matches the payload that `handle_status`
+/// used to build inline. Lives here so both the CLI (direct path)
+/// and the daemon's control server can call exactly the same code.
+pub async fn status_view(db: &EmbeddedDb) -> Result<serde_json::Value, NaukaError> {
+    let s = status(db).await?;
+
+    let mesh_ip: std::net::Ipv6Addr = s
+        .mesh_ipv6
+        .parse()
+        .map_err(|_| NaukaError::internal(format!("corrupt state: invalid mesh_ipv6 '{}'", s.mesh_ipv6)))?;
+    let cp = crate::controlplane::ops::status(&mesh_ip);
+    let (pd_active, tikv_active, pd_members, tikv_stores, leader) = match cp {
+        Ok(cs) => (
+            cs.pd_active,
+            cs.tikv_active,
+            cs.pd_members,
+            cs.tikv_stores,
+            cs.leader,
+        ),
+        Err(_) => (false, false, 0, 0, None),
+    };
+
+    let state_label = if s.service_active && tikv_active {
+        s.state.clone()
+    } else if s.service_active {
+        "degraded".to_string()
+    } else {
+        "down".to_string()
+    };
+
+    Ok(serde_json::json!({
+        "name": s.hypervisor_name,
+        "id": s.hypervisor_id,
+        "region": s.region,
+        "zone": s.zone,
+        "mesh_ipv6": s.mesh_ipv6,
+        "state": state_label,
+        "wg": if s.service_active { "running" } else { "stopped" },
+        "wg_interface": s.wg_interface_up,
+        "peers": s.peer_count,
+        "wg_port": s.wg_port,
+        "rx_bytes": s.rx_bytes,
+        "tx_bytes": s.tx_bytes,
+        "pd": if pd_active { "running" } else { "stopped" },
+        "tikv": if tikv_active { "running" } else { "stopped" },
+        "pd_members": pd_members,
+        "tikv_stores": tikv_stores,
+        "leader": leader,
+    }))
+}
+
+/// JSON view of `list` — this node + every peer as an array of rows.
+/// Returns `[]` when the node is not initialised (no state on disk).
+pub async fn list_view(db: &EmbeddedDb) -> Result<serde_json::Value, NaukaError> {
+    let state = match FabricState::load(db)
+        .await
+        .map_err(|e| NaukaError::internal(e.to_string()))?
+    {
+        Some(s) => s,
+        None => return Ok(serde_json::json!([])),
+    };
+
+    let backend = super::backend::create_backend(state.network_mode);
+    let self_state = if !backend.is_up() {
+        "down"
+    } else if state.node_state == super::state::NodeState::Draining {
+        "draining"
+    } else {
+        "available"
+    };
+
+    let mut items = vec![serde_json::json!({
+        "id": state.hypervisor.id.as_str(),
+        "name": state.hypervisor.name,
+        "region": state.hypervisor.region,
+        "zone": state.hypervisor.zone,
+        "state": self_state,
+        "cpu": "0/0",
+        "memory": "0/0",
+        "vms": 0,
+    })];
+
+    for peer in &state.peers.peers {
+        items.push(serde_json::json!({
+            "id": peer.id.as_str(),
+            "name": peer.name,
+            "region": peer.region,
+            "zone": peer.zone,
+            "state": peer_state_label(peer),
+            "cpu": "0/0",
+            "memory": "0/0",
+            "vms": 0,
+        }));
+    }
+
+    Ok(serde_json::json!(items))
+}
+
+/// JSON view of `get <name>` — returns a single hypervisor (either
+/// this node or one of its peers). Errors with "not found" when no
+/// match exists.
+pub async fn get_view(db: &EmbeddedDb, name: &str) -> Result<serde_json::Value, NaukaError> {
+    let state = FabricState::load(db)
+        .await
+        .map_err(|e| NaukaError::internal(e.to_string()))?
+        .ok_or_else(|| NaukaError::precondition("not initialized"))?;
+
+    let backend = super::backend::create_backend(state.network_mode);
+
+    if state.hypervisor.name == name {
+        return Ok(serde_json::json!({
+            "name": state.hypervisor.name,
+            "id": state.hypervisor.id.as_str(),
+            "region": state.hypervisor.region,
+            "zone": state.hypervisor.zone,
+            "mesh_ipv6": state.hypervisor.mesh_ipv6.to_string(),
+            "state": if !backend.is_up() {
+                "down"
+            } else if state.node_state == super::state::NodeState::Draining {
+                "draining"
+            } else {
+                "available"
+            },
+        }));
+    }
+
+    if let Some(peer) = state.peers.find_by_name(name) {
+        return Ok(serde_json::json!({
+            "name": peer.name,
+            "id": peer.id.as_str(),
+            "region": peer.region,
+            "zone": peer.zone,
+            "mesh_ipv6": peer.mesh_ipv6.to_string(),
+            "state": peer_state_label(peer),
+        }));
+    }
+
+    Err(NaukaError::not_found("hypervisor", name))
+}
+
+/// Map peer status to user-facing label. Shared between the live
+/// `list_view` / `get_view` paths and the CLI handlers that used to
+/// carry an inline copy.
+pub(crate) fn peer_state_label(peer: &super::peer::Peer) -> &'static str {
+    match peer.status {
+        super::peer::PeerStatus::Active => {
+            if peer.node_state == super::state::NodeState::Draining {
+                "draining"
+            } else {
+                "available"
+            }
+        }
+        super::peer::PeerStatus::Unreachable => "unreachable",
+        super::peer::PeerStatus::Removed => "removed",
+    }
+}

--- a/layers/hypervisor/src/fabric/ops.rs
+++ b/layers/hypervisor/src/fabric/ops.rs
@@ -13,24 +13,6 @@ use super::service;
 use super::state::FabricState;
 use super::wg;
 
-/// Open the SurrealKV-backed [`EmbeddedDb`] at the run-mode-aware default
-/// path.
-///
-/// Shared helper used by every per-request DB opener in the fabric layer
-/// (peering listener, announce listener, health loop, reconciler). Each
-/// caller opens, does one pass, and drops the handle — the SurrealKV
-/// flock is released between passes so `leave` / external tools can
-/// also touch the file.
-///
-/// Exposed as an `async fn` (not an opaque helper) so listeners that take
-/// an `impl Fn() -> impl Future<Output = Result<EmbeddedDb, NaukaError>>`
-/// opener can pass `open_db` directly.
-pub(crate) async fn open_db() -> Result<EmbeddedDb, NaukaError> {
-    EmbeddedDb::open_default()
-        .await
-        .map_err(|e| NaukaError::internal(e.to_string()))
-}
-
 /// Result of a successful fabric init.
 pub struct InitResult {
     pub mesh: MeshIdentity,
@@ -141,102 +123,6 @@ pub async fn init(
     })
 }
 
-/// Start a peering listener to accept join requests.
-///
-/// Also starts background tasks for:
-/// - Health check loop (monitors peer reachability via WG handshakes)
-/// - Announce listener (receives peer announcements from other nodes)
-///
-/// Blocks until timeout or Ctrl+C. Opens the DB once and shares the
-/// handle across every listener/loop via `Clone` so no flock dance is
-/// needed.
-///
-/// **Deprecated**: this function is the old `init --peering` entry
-/// point. It is retained through the #299 refactor for the existing
-/// `init --peering` and standalone `hypervisor peering` code paths,
-/// and is removed once the hypervisor daemon subcommand takes over.
-pub async fn listen_for_peers(
-    pin: &str,
-    peering_port: u16,
-    timeout_secs: u64,
-    max_joins: usize,
-) -> Result<usize, NaukaError> {
-    let bind_addr = format!("[::]:{peering_port}")
-        .parse()
-        .map_err(|_| NaukaError::internal("invalid bind address"))?;
-
-    let timeout = std::time::Duration::from_secs(timeout_secs);
-    let db = open_db().await?;
-
-    // P2/#281: only spawn the long-running background helpers (health
-    // loop, announce listener, periodic mesh reconciliation) in the
-    // explicit unlimited-accept mode (`max_joins == 0`), which is what
-    // `hypervisor init --peering` uses for a bootstrap-then-daemon
-    // flow. In one-shot mode the main listener exits after max_joins
-    // and the process shuts down — there's no point keeping background
-    // helpers alive.
-    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
-
-    if max_joins == 0 {
-        // Start health check loop in background
-        let health_db = db.clone();
-        let health_rx = shutdown_rx.clone();
-        tokio::spawn(async move {
-            super::health::run_loop(
-                health_db,
-                super::health::DEFAULT_INTERVAL_SECS,
-                super::health::DEFAULT_STALE_THRESHOLD_SECS,
-                health_rx,
-            )
-            .await;
-        });
-
-        // Start announce listener in background (peering_port + 1 = announce port)
-        let announce_port = peering_port + 1;
-        let announce_addr: std::net::SocketAddr = format!("[::]:{announce_port}")
-            .parse()
-            .map_err(|_| NaukaError::internal("invalid announce bind address"))?;
-        let announce_db = db.clone();
-        let announce_rx = shutdown_rx.clone();
-        tokio::spawn(async move {
-            if let Err(e) = super::announce::listen(announce_db, announce_addr, announce_rx).await
-            {
-                tracing::warn!(error = %e, "announce listener stopped");
-            }
-        });
-
-        // Start periodic mesh reconciliation in background.
-        let reconcile_wg_port = peering_port - 1; // wg_port = peering_port - 1
-        let reconcile_db = db.clone();
-        let mut reconcile_rx = shutdown_rx.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_secs(30)).await;
-            loop {
-                tokio::select! {
-                    biased;
-                    _ = reconcile_rx.changed() => {
-                        if *reconcile_rx.borrow() { break; }
-                    }
-                    _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
-                        reconcile_mesh(&reconcile_db, reconcile_wg_port).await;
-                    }
-                }
-            }
-        });
-    }
-
-    // Main peering listener (blocks until `max_joins` is reached or
-    // the idle timeout elapses).
-    super::peering_server::listen(
-        db.clone(),
-        pin.to_string(),
-        bind_addr,
-        timeout,
-        max_joins,
-        shutdown_rx,
-    )
-    .await
-}
 
 /// Reconciliation interval in seconds (matches the sleep in the spawned task).
 pub(crate) const RECONCILE_INTERVAL_SECS: u64 = 30;

--- a/layers/hypervisor/src/fabric/ops.rs
+++ b/layers/hypervisor/src/fabric/ops.rs
@@ -147,7 +147,14 @@ pub async fn init(
 /// - Health check loop (monitors peer reachability via WG handshakes)
 /// - Announce listener (receives peer announcements from other nodes)
 ///
-/// Blocks until timeout or Ctrl+C. Opens DB per-request (no long-lived lock).
+/// Blocks until timeout or Ctrl+C. Opens the DB once and shares the
+/// handle across every listener/loop via `Clone` so no flock dance is
+/// needed.
+///
+/// **Deprecated**: this function is the old `init --peering` entry
+/// point. It is retained through the #299 refactor for the existing
+/// `init --peering` and standalone `hypervisor peering` code paths,
+/// and is removed once the hypervisor daemon subcommand takes over.
 pub async fn listen_for_peers(
     pin: &str,
     peering_port: u16,
@@ -159,26 +166,27 @@ pub async fn listen_for_peers(
         .map_err(|_| NaukaError::internal("invalid bind address"))?;
 
     let timeout = std::time::Duration::from_secs(timeout_secs);
+    let db = open_db().await?;
 
     // P2/#281: only spawn the long-running background helpers (health
     // loop, announce listener, periodic mesh reconciliation) in the
     // explicit unlimited-accept mode (`max_joins == 0`), which is what
     // `hypervisor init --peering` uses for a bootstrap-then-daemon
-    // flow. In one-shot mode (`max_joins > 0`, the new default for
-    // standalone `nauka hypervisor peering`) we skip them entirely so
-    // the process can exit cleanly after the listen loop returns — a
-    // detached `tokio::spawn` keeps the runtime alive indefinitely
-    // otherwise, which is exactly how #281 manifested. The helpers
-    // are also redundant in that mode because `nauka-announce` is
-    // already installed as a systemd service by `init` / `join` and
-    // runs continuously in the background.
+    // flow. In one-shot mode the main listener exits after max_joins
+    // and the process shuts down — there's no point keeping background
+    // helpers alive.
+    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
     if max_joins == 0 {
         // Start health check loop in background
+        let health_db = db.clone();
+        let health_rx = shutdown_rx.clone();
         tokio::spawn(async move {
             super::health::run_loop(
-                open_db,
+                health_db,
                 super::health::DEFAULT_INTERVAL_SECS,
                 super::health::DEFAULT_STALE_THRESHOLD_SECS,
+                health_rx,
             )
             .await;
         });
@@ -188,37 +196,50 @@ pub async fn listen_for_peers(
         let announce_addr: std::net::SocketAddr = format!("[::]:{announce_port}")
             .parse()
             .map_err(|_| NaukaError::internal("invalid announce bind address"))?;
+        let announce_db = db.clone();
+        let announce_rx = shutdown_rx.clone();
         tokio::spawn(async move {
-            if let Err(e) = super::announce::listen(open_db, announce_addr).await {
+            if let Err(e) = super::announce::listen(announce_db, announce_addr, announce_rx).await
+            {
                 tracing::warn!(error = %e, "announce listener stopped");
             }
         });
 
         // Start periodic mesh reconciliation in background.
-        // Every 30s, re-read the full peer list and announce every peer to every
-        // other peer. This is idempotent (known peers are skipped) and guarantees
-        // full mesh convergence even after concurrent joins.
         let reconcile_wg_port = peering_port - 1; // wg_port = peering_port - 1
+        let reconcile_db = db.clone();
+        let mut reconcile_rx = shutdown_rx.clone();
         tokio::spawn(async move {
-            // Initial delay — let the first joins settle
             tokio::time::sleep(std::time::Duration::from_secs(30)).await;
             loop {
-                reconcile_mesh(reconcile_wg_port).await;
-                tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                tokio::select! {
+                    biased;
+                    _ = reconcile_rx.changed() => {
+                        if *reconcile_rx.borrow() { break; }
+                    }
+                    _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+                        reconcile_mesh(&reconcile_db, reconcile_wg_port).await;
+                    }
+                }
             }
         });
     }
 
     // Main peering listener (blocks until `max_joins` is reached or
-    // the idle timeout elapses). P2/#281: the previous hard-coded
-    // `0` here meant "accept forever", turning every `nauka hypervisor
-    // peering` invocation into a long-lived daemon that had to be
-    // killed manually.
-    super::peering_server::listen(open_db, pin, bind_addr, timeout, max_joins).await
+    // the idle timeout elapses).
+    super::peering_server::listen(
+        db.clone(),
+        pin.to_string(),
+        bind_addr,
+        timeout,
+        max_joins,
+        shutdown_rx,
+    )
+    .await
 }
 
 /// Reconciliation interval in seconds (matches the sleep in the spawned task).
-const RECONCILE_INTERVAL_SECS: u64 = 30;
+pub(crate) const RECONCILE_INTERVAL_SECS: u64 = 30;
 
 /// Periodic mesh reconciliation.
 ///
@@ -228,12 +249,8 @@ const RECONCILE_INTERVAL_SECS: u64 = 30;
 /// to the join rate (O(new × n)) instead of the total mesh size (O(n²)).
 ///
 /// Idempotent — known peers are skipped by the announce handler.
-async fn reconcile_mesh(wg_port: u16) {
-    let db = match open_db().await {
-        Ok(db) => db,
-        Err(_) => return,
-    };
-    let state = match FabricState::load(&db).await.ok().flatten() {
+pub(crate) async fn reconcile_mesh(db: &EmbeddedDb, wg_port: u16) {
+    let state = match FabricState::load(db).await.ok().flatten() {
         Some(s) => s,
         None => return,
     };

--- a/layers/hypervisor/src/fabric/peering_server.rs
+++ b/layers/hypervisor/src/fabric/peering_server.rs
@@ -1,16 +1,22 @@
 //! Peering TCP server — accepts join requests from new nodes.
 //!
-//! Opens the DB per-request (no long-lived lock).
+//! The listener borrows a long-lived [`EmbeddedDb`] handle from its
+//! caller (the hypervisor daemon, or `listen_for_peers` during
+//! `init --peering`) and clones it into a per-connection `tokio::spawn`
+//! for every incoming join. SurrealDB itself is thread-safe, so
+//! concurrent joins run truly in parallel against the same underlying
+//! `Datastore` — no OS-level flock serialisation.
 
 use std::collections::HashMap;
-use std::future::Future;
 use std::net::{IpAddr, SocketAddr};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
+use tokio::sync::watch;
 use tokio_rustls::TlsAcceptor;
 
 use nauka_core::error::NaukaError;
@@ -45,7 +51,6 @@ impl PinRateLimiter {
     fn record_failure(&mut self, ip: IpAddr) {
         let entry = self.failures.entry(ip).or_insert((0, Instant::now()));
         if entry.1.elapsed() >= PIN_BLOCK_DURATION {
-            // Reset after block period
             *entry = (1, Instant::now());
         } else {
             entry.0 += 1;
@@ -62,100 +67,121 @@ use super::peering::{JoinRequest, JoinResponse, PeerInfo};
 use super::service;
 use super::state::FabricState;
 
-/// Start a peering listener. Opens the DB per-request to avoid holding the lock.
-pub async fn listen<F, Fut>(
-    db_opener: F,
-    pin: &str,
+/// Run the peering listener on `bind_addr`.
+///
+/// Accepts TLS-wrapped join requests and services each one in a freshly
+/// spawned task. The supplied `db` handle is cloned into every spawn so
+/// concurrent joins share the same underlying `Surreal<Db>` (and
+/// therefore never contend on the SurrealKV `LOCK`).
+///
+/// Termination rules:
+/// - If `max_joins > 0`, the accept loop stops once `max_joins`
+///   handlers have returned `Ok(_)`. Spawned handlers that are still
+///   running are left to finish on their own.
+/// - If no connection is accepted for `timeout`, the accept loop exits.
+/// - If `shutdown` transitions to `true`, the accept loop exits
+///   immediately.
+///
+/// Returns the number of successfully accepted joins.
+pub async fn listen(
+    db: EmbeddedDb,
+    pin: String,
     bind_addr: SocketAddr,
     timeout: Duration,
     max_joins: usize,
-) -> Result<usize, NaukaError>
-where
-    F: Fn() -> Fut,
-    Fut: Future<Output = Result<EmbeddedDb, NaukaError>>,
-{
+    mut shutdown: watch::Receiver<bool>,
+) -> Result<usize, NaukaError> {
     let listener = TcpListener::bind(bind_addr)
         .await
         .map_err(|e| NaukaError::internal(format!("failed to bind peering port: {e}")))?;
 
-    // TLS setup
     let tls_config = super::tls::server_config()?;
     let tls_acceptor = TlsAcceptor::from(tls_config);
 
     tracing::info!(addr = %bind_addr, "peering listener started (TLS)");
 
-    let mut accepted = 0;
     let rate_limiter = Arc::new(Mutex::new(PinRateLimiter::new()));
+    let accepted = Arc::new(AtomicUsize::new(0));
+    let pin = Arc::new(pin);
 
     loop {
-        let accept = tokio::time::timeout(timeout, listener.accept()).await;
+        if max_joins > 0 && accepted.load(Ordering::Acquire) >= max_joins {
+            break;
+        }
+        if *shutdown.borrow() {
+            break;
+        }
 
-        match accept {
-            Ok(Ok((tcp_stream, peer_addr))) => {
-                // Check rate limit before processing
-                {
-                    let rl = rate_limiter.lock().unwrap_or_else(|e| e.into_inner());
-                    if rl.is_blocked(&peer_addr.ip()) {
-                        tracing::warn!(peer = %peer_addr, "blocked (too many failed PIN attempts)");
-                        continue;
-                    }
+        tokio::select! {
+            biased;
+            _ = shutdown.changed() => {
+                if *shutdown.borrow() {
+                    tracing::info!("peering listener shutting down");
+                    break;
                 }
-
-                // TLS handshake
-                let mut stream = match tls_acceptor.accept(tcp_stream).await {
-                    Ok(s) => s,
-                    Err(e) => {
-                        tracing::warn!(peer = %peer_addr, error = %e, "TLS handshake failed");
-                        continue;
-                    }
-                };
-
-                tracing::info!(peer = %peer_addr, "incoming join request (TLS)");
-
-                let db = match db_opener().await {
-                    Ok(db) => db,
-                    Err(e) => {
-                        tracing::warn!(error = %e, "failed to open DB for join");
-                        continue;
-                    }
-                };
-
-                match handle_join(&mut stream, &db, pin, peer_addr).await {
-                    Ok(peer_name) => {
-                        rate_limiter
-                            .lock()
-                            .unwrap_or_else(|e| e.into_inner())
-                            .record_success(&peer_addr.ip());
-                        tracing::info!(peer = %peer_addr, name = %peer_name, "join accepted");
-                        accepted += 1;
-                        // Best-effort shutdown to release the SurrealKV flock
-                        // before the next accept opens a new handle.
-                        let _ = db.shutdown().await;
-                        if max_joins > 0 && accepted >= max_joins {
-                            break;
+            }
+            accept_result = tokio::time::timeout(timeout, listener.accept()) => {
+                match accept_result {
+                    Ok(Ok((tcp_stream, peer_addr))) => {
+                        // Cheap per-IP rate-limit check before paying
+                        // for the TLS handshake.
+                        {
+                            let rl = rate_limiter.lock().unwrap_or_else(|e| e.into_inner());
+                            if rl.is_blocked(&peer_addr.ip()) {
+                                tracing::warn!(peer = %peer_addr, "blocked (too many failed PIN attempts)");
+                                continue;
+                            }
                         }
+
+                        let db = db.clone();
+                        let pin = pin.clone();
+                        let tls_acceptor = tls_acceptor.clone();
+                        let rate_limiter = rate_limiter.clone();
+                        let accepted = accepted.clone();
+
+                        tokio::spawn(async move {
+                            let mut stream = match tls_acceptor.accept(tcp_stream).await {
+                                Ok(s) => s,
+                                Err(e) => {
+                                    tracing::warn!(peer = %peer_addr, error = %e, "TLS handshake failed");
+                                    return;
+                                }
+                            };
+
+                            tracing::info!(peer = %peer_addr, "incoming join request (TLS)");
+
+                            match handle_join(&mut stream, &db, pin.as_str(), peer_addr).await {
+                                Ok(peer_name) => {
+                                    rate_limiter
+                                        .lock()
+                                        .unwrap_or_else(|e| e.into_inner())
+                                        .record_success(&peer_addr.ip());
+                                    accepted.fetch_add(1, Ordering::AcqRel);
+                                    tracing::info!(peer = %peer_addr, name = %peer_name, "join accepted");
+                                }
+                                Err(e) => {
+                                    rate_limiter
+                                        .lock()
+                                        .unwrap_or_else(|e| e.into_inner())
+                                        .record_failure(peer_addr.ip());
+                                    tracing::warn!(peer = %peer_addr, error = %e, "join rejected");
+                                }
+                            }
+                        });
                     }
-                    Err(e) => {
-                        rate_limiter
-                            .lock()
-                            .unwrap_or_else(|e| e.into_inner())
-                            .record_failure(peer_addr.ip());
-                        tracing::warn!(peer = %peer_addr, error = %e, "join rejected");
-                        let _ = db.shutdown().await;
+                    Ok(Err(e)) => {
+                        tracing::warn!(error = %e, "accept error");
+                    }
+                    Err(_) => {
+                        tracing::info!("peering listener idle timeout");
+                        break;
                     }
                 }
-            }
-            Ok(Err(e)) => {
-                tracing::warn!(error = %e, "accept error");
-            }
-            Err(_) => {
-                tracing::info!("peering listener timeout");
-                break;
             }
         }
     }
 
-    Ok(accepted)
+    Ok(accepted.load(Ordering::Acquire))
 }
 
 /// Handle a single join request on a stream.

--- a/layers/hypervisor/src/fabric/peering_server.rs
+++ b/layers/hypervisor/src/fabric/peering_server.rs
@@ -69,6 +69,25 @@ use super::state::FabricState;
 
 /// Run the peering listener on `bind_addr`.
 ///
+/// Convenience wrapper that binds a `TcpListener` and forwards to
+/// [`serve`]. Integration tests that need to pick the bound port
+/// before driving clients can skip the bind and call `serve` directly.
+pub async fn listen(
+    db: EmbeddedDb,
+    pin: String,
+    bind_addr: SocketAddr,
+    timeout: Duration,
+    max_joins: usize,
+    shutdown: watch::Receiver<bool>,
+) -> Result<usize, NaukaError> {
+    let listener = TcpListener::bind(bind_addr)
+        .await
+        .map_err(|e| NaukaError::internal(format!("failed to bind peering port: {e}")))?;
+    serve(listener, db, pin, timeout, max_joins, shutdown).await
+}
+
+/// Run the peering accept loop against a pre-bound `TcpListener`.
+///
 /// Accepts TLS-wrapped join requests and services each one in a freshly
 /// spawned task. The supplied `db` handle is cloned into every spawn so
 /// concurrent joins share the same underlying `Surreal<Db>` (and
@@ -83,21 +102,21 @@ use super::state::FabricState;
 ///   immediately.
 ///
 /// Returns the number of successfully accepted joins.
-pub async fn listen(
+pub async fn serve(
+    listener: TcpListener,
     db: EmbeddedDb,
     pin: String,
-    bind_addr: SocketAddr,
     timeout: Duration,
     max_joins: usize,
     mut shutdown: watch::Receiver<bool>,
 ) -> Result<usize, NaukaError> {
-    let listener = TcpListener::bind(bind_addr)
-        .await
-        .map_err(|e| NaukaError::internal(format!("failed to bind peering port: {e}")))?;
-
     let tls_config = super::tls::server_config()?;
     let tls_acceptor = TlsAcceptor::from(tls_config);
 
+    let bind_addr = listener
+        .local_addr()
+        .map(|a| a.to_string())
+        .unwrap_or_else(|_| "<unknown>".to_string());
     tracing::info!(addr = %bind_addr, "peering listener started (TLS)");
 
     let rate_limiter = Arc::new(Mutex::new(PinRateLimiter::new()));
@@ -226,6 +245,25 @@ async fn handle_join(
         return Err(NaukaError::permission_denied("invalid PIN"));
     }
 
+    // Derive the new peer's mesh IPv6 *before* taking the write lock
+    // so the base64 decode error (if any) surfaces without ever
+    // touching the shared state.
+    let pub_bytes = base64::engine::general_purpose::STANDARD
+        .decode(&req.wg_public_key)
+        .map_err(|e| NaukaError::validation(format!("invalid WireGuard key: {e}")))?;
+
+    // ─── Critical section: serialise load+modify+save against
+    // every other concurrent state mutator in this process.
+    // Without this, two `handle_join` tasks running in parallel
+    // both load a snapshot with the same `peers` vec, each add
+    // their new peer locally, each save back — and the last
+    // writer wins, silently dropping every earlier join. The
+    // pre-#299 OS flock hid this by serialising at the process
+    // level; with one shared `EmbeddedDb` handle the race is
+    // live, which is exactly what the `parallel_join` regression
+    // test exercises.
+    let write_guard = super::state::write_lock().lock().await;
+
     let mut state = FabricState::load(db)
         .await
         .map_err(|e| NaukaError::internal(e.to_string()))?
@@ -266,12 +304,7 @@ async fn handle_join(
         self_info,
         state.max_pd_members,
     );
-    write_json(stream, &resp).await?;
 
-    // Derive the new peer's mesh IPv6
-    let pub_bytes = base64::engine::general_purpose::STANDARD
-        .decode(&req.wg_public_key)
-        .map_err(|e| NaukaError::validation(format!("invalid WireGuard key: {e}")))?;
     let peer_ipv6 = nauka_core::addressing::derive_node_address(&state.mesh.prefix, &pub_bytes);
 
     // Build announce info before consuming req fields
@@ -288,6 +321,8 @@ async fn handle_join(
     // Skip if exact same key already exists (duplicate join)
     if state.peers.find_by_key(&req.wg_public_key).is_some() {
         tracing::info!(peer = %req.name, "duplicate join, same key already known");
+        drop(write_guard);
+        write_json(stream, &resp).await?;
         return Ok(req.name);
     }
 
@@ -300,11 +335,11 @@ async fn handle_join(
     // Add peer + save + update WG
     let new_peer = Peer::new(
         req.name.clone(),
-        req.region,
-        req.zone,
-        req.wg_public_key,
+        req.region.clone(),
+        req.zone.clone(),
+        req.wg_public_key.clone(),
         req.wg_port,
-        req.endpoint,
+        req.endpoint.clone(),
         peer_ipv6,
     );
     state
@@ -312,16 +347,18 @@ async fn handle_join(
         .add(new_peer)
         .map_err(|e| NaukaError::internal(format!("peer add failed: {e}")))?;
 
-    // Save state FIRST — state is the source of truth.
-    // If the process crashes after this point, WireGuard will be reconciled
-    // from state on the next `wg-quick up` / service restart.
+    // Save state FIRST — state is the source of truth. If the
+    // process crashes after this point, WireGuard will be
+    // reconciled from state on the next `wg-quick up` / service
+    // restart.
     state
         .save(db)
         .await
         .map_err(|e| NaukaError::internal(e.to_string()))?;
 
-    // Update WireGuard config. If this fails, state is still correct and
-    // WG will catch up on next restart — log a warning but don't fail the join.
+    // Update WireGuard config. If this fails, state is still
+    // correct and WG will catch up on next restart — log a
+    // warning but don't fail the join.
     let peers_for_wg: Vec<_> = state
         .peers
         .peers
@@ -358,11 +395,14 @@ async fn handle_join(
         .cloned()
         .collect();
 
+    // Release the write lock before the async response write + the
+    // spawned broadcast. The next joiner can proceed immediately.
+    drop(write_guard);
+
+    write_json(stream, &resp).await?;
+
     if !announce_targets.is_empty() {
         tokio::spawn(async move {
-            // Best-effort immediate announce — some peers may not have their
-            // listener yet. The periodic reconciliation loop in ops.rs
-            // guarantees eventual convergence.
             let (ok, fail) = super::announce::broadcast_new_peer(
                 &new_peer_info,
                 &announcer_name,

--- a/layers/hypervisor/src/fabric/state.rs
+++ b/layers/hypervisor/src/fabric/state.rs
@@ -11,13 +11,50 @@
 
 use std::fmt;
 use std::net::Ipv6Addr;
+use std::sync::OnceLock;
 
 use nauka_state::EmbeddedDb;
 use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
 
 use super::backend::NetworkMode;
 use super::mesh::{HypervisorIdentity, MeshIdentity};
 use super::peer::PeerList;
+
+/// Process-global async mutex guarding every read-modify-write of the
+/// single-blob `fabric:state` record.
+///
+/// Why this exists: `FabricState` persists as one JSON blob written by
+/// `UPSERT fabric:state CONTENT $data`. Concurrent callers that
+/// `load`-mutate-`save` against the same record race each other — the
+/// last writer wins and every earlier change is silently lost. Before
+/// #299 this was hidden by the OS flock on `bootstrap.skv/LOCK`, which
+/// serialised *all* access across processes. With #299 the flock is
+/// held for the daemon's entire lifetime and concurrent in-process
+/// tasks share one `EmbeddedDb` clone, so the lost-update race
+/// surfaces — notably on parallel `hypervisor join` requests handled
+/// by the peering listener.
+///
+/// Every state mutator (`peering_server::handle_join`, the announce
+/// `handle_peer_*` handlers, `ops::drain` / `ops::enable` /
+/// `ops::update`, CLI `leave`) acquires this lock for the duration of
+/// its load-modify-save block via [`write_lock`]. Holding the lock
+/// across an async write is cheap because the critical section is
+/// milliseconds — the lock is only here to serialise the coarse blob
+/// writes, not to gate long I/O.
+///
+/// Phase 3 codegen (sifrah/nauka#225 ff) retires the single-blob
+/// storage in favour of SCHEMAFULL rows under the `mesh` /
+/// `hypervisor` / `peer` tables, at which point this lock can go away
+/// and be replaced with per-row transactions.
+static WRITE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+/// Accessor for the fabric-state write lock. Lazy-initialised on
+/// first call so tests and unit bench harnesses don't pay for the
+/// mutex until they actually mutate state.
+pub fn write_lock() -> &'static Mutex<()> {
+    WRITE_LOCK.get_or_init(|| Mutex::new(()))
+}
 
 /// Scheduling state of a node (maintenance mode).
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/layers/hypervisor/src/fabric/wireguard/service.rs
+++ b/layers/hypervisor/src/fabric/wireguard/service.rs
@@ -216,7 +216,27 @@ pub fn uninstall() -> Result<(), NaukaError> {
     Ok(())
 }
 
-/// Update the WireGuard config (e.g., when a peer joins) and reload.
+/// Update the WireGuard config (e.g., when a peer joins) and apply it
+/// to the running interface without tearing it down.
+///
+/// Writes the full wg-quick-format config (with `[Interface].Address`)
+/// to `WG_CONF_FILE`, then hot-applies the peer diff via
+/// `wg-quick strip | wg syncconf nauka0 /dev/stdin`. The `strip` stage
+/// is load-bearing: `wg syncconf` only understands the pure wg subset
+/// (PublicKey, AllowedIPs, etc.) and errors out with
+/// `Line unrecognized: Address=...` if handed a wg-quick config
+/// directly. Before this fix, the failed `wg syncconf` fell back to
+/// `systemctl restart nauka-wg.service`, which cascaded through
+/// `Requires=nauka-wg.service` on `nauka.service` / `nauka-pd` /
+/// `nauka-tikv` and bounced the entire control plane for every
+/// single peer add — visible during #299 Hetzner validation as the
+/// hypervisor daemon deactivating the instant a join arrived.
+///
+/// If the hot-apply fails for any reason, we log a warning and
+/// return `Ok(())`: the updated config is persisted on disk and the
+/// next `wg-quick up` (service restart, reboot, or operator-driven
+/// reconciliation) will pick it up. Never cascade-restart systemd —
+/// the recovery path is more disruptive than the original failure.
 pub fn update_config(
     private_key: &str,
     listen_port: u16,
@@ -232,15 +252,117 @@ pub fn update_config(
         let _ = std::fs::set_permissions(WG_CONF_FILE, std::fs::Permissions::from_mode(0o600));
     }
 
-    // wg syncconf applies changes without tearing down the interface
-    let output = Command::new("wg")
-        .args(["syncconf", "nauka0", WG_CONF_FILE])
+    // Hot-apply: `wg-quick strip <conf>` → pipe → `wg syncconf nauka0 /dev/stdin`.
+    // The strip stage drops `Address`, `MTU`, `PreUp`, etc., leaving
+    // only the directives `wg syncconf` understands.
+    match syncconf_via_strip() {
+        Ok(()) => {}
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "wg syncconf hot-apply failed; config persisted for next wg-quick up"
+            );
+        }
+    }
+
+    // `wg syncconf` updates WireGuard's internal peer table but does
+    // **not** touch the kernel routing table. `wg-quick up` normally
+    // installs an `ip -6 route add <AllowedIPs> dev nauka0` for every
+    // peer on top of the syncconf — without those routes the kernel
+    // has no reason to steer a peer's mesh IPv6 via `nauka0`, so
+    // traffic gets default-routed out `eth0` and never enters the
+    // tunnel. Symptom during #299 Hetzner validation: a joining node
+    // got its WG handshake through but `ping`/`curl` to the acceptor's
+    // mesh IPv6 timed out because the return packet left via the
+    // public interface.
+    //
+    // Install each peer's `AllowedIPs` as a `/128` route on `nauka0`.
+    // Idempotent: `ip -6 route add` returns `RTNETLINK: File exists`
+    // when the route is already present, which we treat as success.
+    install_peer_routes(peers);
+
+    Ok(())
+}
+
+/// Install a `/128` route on `nauka0` for every peer in the slice.
+///
+/// `ip -6 route add <ipv6>/128 dev nauka0` — idempotent: the
+/// `File exists` failure mode is ignored. Failures to spawn `ip`
+/// are logged but do not surface as errors because the config file
+/// on disk will be reloaded on the next `wg-quick up`.
+fn install_peer_routes(peers: &[(String, String, std::net::Ipv6Addr, Option<String>)]) {
+    for (_pub, _keepalive, mesh_ipv6, _endpoint) in peers {
+        let dst = format!("{mesh_ipv6}/128");
+        match Command::new("ip")
+            .args(["-6", "route", "add", &dst, "dev", "nauka0"])
+            .output()
+        {
+            Ok(output) if output.status.success() => {}
+            Ok(output) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                // Already-installed routes look like "File exists"
+                // from ip/route2, or rtnetlink error 17. Swallow those.
+                if !stderr.contains("File exists") && !stderr.contains("exists") {
+                    tracing::warn!(
+                        dst = %dst,
+                        stderr = %stderr.trim(),
+                        "ip -6 route add failed"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(dst = %dst, error = %e, "ip -6 route add spawn failed");
+            }
+        }
+    }
+}
+
+/// Run `wg-quick strip <conf>` and pipe its stdout into
+/// `wg syncconf nauka0 /dev/stdin`.
+///
+/// Returns `Err` only when the strip step spawned successfully but
+/// wrote an error, or when either subprocess exited non-zero. The
+/// caller logs and swallows — we never want a syncconf failure to
+/// cascade into a systemd restart.
+fn syncconf_via_strip() -> Result<(), NaukaError> {
+    use std::io::Write;
+
+    let strip = Command::new("wg-quick")
+        .args(["strip", WG_CONF_FILE])
         .output()
-        .map_err(|e| NaukaError::internal(format!("wg syncconf failed: {e}")))?;
+        .map_err(|e| NaukaError::internal(format!("wg-quick strip spawn: {e}")))?;
+
+    if !strip.status.success() {
+        return Err(NaukaError::internal(format!(
+            "wg-quick strip: {}",
+            String::from_utf8_lossy(&strip.stderr).trim()
+        )));
+    }
+
+    let mut child = Command::new("wg")
+        .args(["syncconf", "nauka0", "/dev/stdin"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| NaukaError::internal(format!("wg syncconf spawn: {e}")))?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(&strip.stdout)
+            .map_err(|e| NaukaError::internal(format!("wg syncconf stdin write: {e}")))?;
+        // drop stdin → EOF
+    }
+
+    let output = child
+        .wait_with_output()
+        .map_err(|e| NaukaError::internal(format!("wg syncconf wait: {e}")))?;
 
     if !output.status.success() {
-        // Fallback: restart the service
-        let _ = run_systemctl(&["restart", SERVICE_NAME]);
+        return Err(NaukaError::internal(format!(
+            "wg syncconf: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
     }
 
     Ok(())

--- a/layers/hypervisor/src/handlers.rs
+++ b/layers/hypervisor/src/handlers.rs
@@ -246,6 +246,11 @@ pub fn resource_def() -> ResourceDef {
                 FieldDef::integer("port", "Announce listen port").with_default("51822"),
             ))
         })
+        .action(
+            "daemon",
+            "Run the hypervisor daemon (installed as nauka.service)",
+        )
+        .op(|op| op.with_output(OutputKind::None))
         // Future
         .action("drain", "Evacuate all VMs before maintenance")
         .op(|op| op.with_confirm())
@@ -299,6 +304,7 @@ pub fn handler() -> HandlerFn {
                 "upgrade" => handle_upgrade().await,
                 "doctor" => handle_doctor().await,
                 "announce-listen" => handle_announce_listen(req).await,
+                "daemon" => handle_daemon().await,
                 "drain" => handle_drain().await,
                 "enable" => handle_enable().await,
                 other => Ok(OperationResponse::Message(format!("unknown: {other}"))),
@@ -1014,6 +1020,11 @@ async fn handle_enable() -> anyhow::Result<OperationResponse> {
     Ok(OperationResponse::Message(
         "node set to available — ready for VM scheduling.".into(),
     ))
+}
+
+async fn handle_daemon() -> anyhow::Result<OperationResponse> {
+    fabric::daemon::run().await?;
+    Ok(OperationResponse::None)
 }
 
 async fn handle_announce_listen(req: OperationRequest) -> anyhow::Result<OperationResponse> {

--- a/layers/hypervisor/src/handlers.rs
+++ b/layers/hypervisor/src/handlers.rs
@@ -190,23 +190,6 @@ pub fn resource_def() -> ResourceDef {
         .op(|op| op.with_example("nauka hypervisor list"))
         .get()
         .op(|op| op.with_example("nauka hypervisor get HYPERVISOR-1"))
-        .action("peering", "Start peering listener to accept new nodes")
-        .op(|op| {
-            op.with_arg(OperationArg::optional(
-                "timeout",
-                FieldDef::integer("timeout", "Listener idle timeout in seconds").with_default("300"),
-            ))
-            .with_arg(OperationArg::optional(
-                "max-joins",
-                FieldDef::integer(
-                    "max-joins",
-                    "Number of joins to accept before exiting (0 = unlimited)",
-                )
-                .with_default("1"),
-            ))
-            .with_example("nauka hypervisor peering")
-            .with_example("nauka hypervisor peering --max-joins 3 --timeout 600")
-        })
         .action("backup", "Create a backup of PD and TiKV data to S3")
         .op(|op| {
             op.with_arg(OperationArg::optional(
@@ -239,13 +222,6 @@ pub fn resource_def() -> ResourceDef {
                 .with_example("nauka hypervisor upgrade")
         })
         .action("doctor", "Diagnose hypervisor health")
-        .action("announce-listen", "Run the announce listener (internal)")
-        .op(|op| {
-            op.with_arg(OperationArg::optional(
-                "port",
-                FieldDef::integer("port", "Announce listen port").with_default("51822"),
-            ))
-        })
         .action(
             "daemon",
             "Run the hypervisor daemon (installed as nauka.service)",
@@ -296,14 +272,12 @@ pub fn handler() -> HandlerFn {
                 "list" => handle_list().await,
                 "get" => handle_get(req).await,
                 "join" => handle_join(req).await,
-                "peering" => handle_peering(req).await,
                 "backup" => handle_backup(req).await,
                 "backup-list" => handle_backup_list().await,
                 "cp-status" => handle_cp_status().await,
                 "upgrade-check" => handle_upgrade_check().await,
                 "upgrade" => handle_upgrade().await,
                 "doctor" => handle_doctor().await,
-                "announce-listen" => handle_announce_listen(req).await,
                 "daemon" => handle_daemon().await,
                 "drain" => handle_drain().await,
                 "enable" => handle_enable().await,
@@ -867,130 +841,70 @@ async fn handle_join(req: OperationRequest) -> anyhow::Result<OperationResponse>
     })))
 }
 
-async fn handle_peering(req: OperationRequest) -> anyhow::Result<OperationResponse> {
-    // P2/#281: default to accepting ONE join then exiting. The
-    // operator-intuitive model is "run this, wait for a join, get
-    // your shell back". Unlimited-accept mode is still available via
-    // `--max-joins 0` for scripted bulk-join workflows. Default idle
-    // timeout is also dropped from 1 h to 5 min so a forgotten
-    // listener cleans up quickly instead of parking resources.
-    let timeout_secs: u64 = req
-        .fields
-        .get("timeout")
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(300);
-    let max_joins: usize = req
-        .fields
-        .get("max-joins")
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(1);
-
-    let db = open_db().await?;
-    let state = fabric::state::FabricState::load(&db)
-        .await
-        .map_err(|e| anyhow::anyhow!("{e}"))?
-        .ok_or_else(|| anyhow::anyhow!("not initialized. Run 'nauka hypervisor init' first."))?;
-
-    // Derive PIN from secret
-    let secret: nauka_core::crypto::MeshSecret = state.secret.parse()?;
-    let pin = secret.derive_pin();
-    let peering_port = state.hypervisor.wg_port + 1;
-
-    // Explicitly shut down so the SurrealKV flock is released before the
-    // listener's per-request opens.
-    db.shutdown().await?;
-
-    eprintln!();
-    eprintln!("  Peering active on port {peering_port}");
-    eprintln!("  PIN: {pin}");
-    if max_joins > 0 {
-        eprintln!(
-            "  Accepting up to {max_joins} join{} (idle timeout {timeout_secs}s)",
-            if max_joins == 1 { "" } else { "s" }
-        );
-    } else {
-        eprintln!("  Accepting unlimited joins (idle timeout {timeout_secs}s)");
-    }
-    eprintln!();
-    eprintln!("  Nodes can join with:");
-    eprintln!("    nauka hypervisor join --target <this-ip>:{peering_port} --pin {pin}");
-    eprintln!();
-
-    let accepted =
-        fabric::ops::listen_for_peers(&pin, peering_port, timeout_secs, max_joins).await?;
-
-    Ok(OperationResponse::Message(format!(
-        "{accepted} node(s) joined."
-    )))
-}
-
 async fn handle_update(req: OperationRequest) -> anyhow::Result<OperationResponse> {
-    let db = open_db().await?;
-
     let ipv6_block = req.fields.get("ipv6-block").cloned();
     let ipv4_public = req.fields.get("ipv4-public").cloned();
     let name = req.fields.get("name").cloned();
 
-    let cfg = fabric::ops::UpdateConfig {
-        ipv6_block,
-        ipv4_public,
-        name,
+    let req = fabric::control::ControlRequest::Update {
+        ipv6_block: ipv6_block.clone(),
+        ipv4_public: ipv4_public.clone(),
+        name: name.clone(),
     };
 
-    let hv = fabric::ops::update(&db, &cfg).await?;
+    let value = fabric::control::forward_or_fallback(
+        req,
+        || async move {
+            let db = open_db().await?;
+            let cfg = fabric::ops::UpdateConfig {
+                ipv6_block,
+                ipv4_public,
+                name,
+            };
+            let hv = fabric::ops::update(&db, &cfg).await?;
+            Ok(serde_json::json!({
+                "name": hv.name,
+                "id": hv.id.as_str(),
+                "region": hv.region,
+                "zone": hv.zone,
+                "mesh_ipv6": hv.mesh_ipv6.to_string(),
+                "ipv6_block": hv.ipv6_block,
+                "ipv4_public": hv.ipv4_public,
+            }))
+        },
+        Ok,
+    )
+    .await?;
 
-    Ok(OperationResponse::Resource(serde_json::json!({
-        "name": hv.name,
-        "id": hv.id.as_str(),
-        "region": hv.region,
-        "zone": hv.zone,
-        "mesh_ipv6": hv.mesh_ipv6.to_string(),
-        "ipv6_block": hv.ipv6_block,
-        "ipv4_public": hv.ipv4_public,
-        "state": "available",
-    })))
+    // The control-server response shape matches the fallback JSON
+    // above but does not include the synthetic "state" field — add
+    // it here so CLI output stays identical regardless of which path
+    // served the request.
+    let mut value = value;
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert(
+            "state".to_string(),
+            serde_json::Value::String("available".to_string()),
+        );
+    }
+
+    Ok(OperationResponse::Resource(value))
 }
 
 async fn handle_status() -> anyhow::Result<OperationResponse> {
-    let db = open_db().await?;
-    let s = fabric::ops::status(&db).await?;
+    let value = fabric::control::forward_or_fallback(
+        fabric::control::ControlRequest::Status,
+        || async {
+            let db = open_db().await?;
+            fabric::ops::status_view(&db)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))
+        },
+        Ok,
+    )
+    .await?;
 
-    // Control plane status (best-effort — may not be installed yet)
-    let mesh_ip: std::net::Ipv6Addr = s
-        .mesh_ipv6
-        .parse()
-        .map_err(|_| anyhow::anyhow!("corrupt state: invalid mesh_ipv6 '{}'", s.mesh_ipv6))?;
-    let cp = controlplane::ops::status(&mesh_ip);
-    let (pd_active, tikv_active, pd_members, tikv_stores, leader) = match cp {
-        Ok(cs) => (
-            cs.pd_active,
-            cs.tikv_active,
-            cs.pd_members,
-            cs.tikv_stores,
-            cs.leader,
-        ),
-        Err(_) => (false, false, 0, 0, None),
-    };
-
-    Ok(OperationResponse::Resource(serde_json::json!({
-        "name": s.hypervisor_name,
-        "id": s.hypervisor_id,
-        "region": s.region,
-        "zone": s.zone,
-        "mesh_ipv6": s.mesh_ipv6,
-        "state": if s.service_active && tikv_active { &s.state } else if s.service_active { "degraded" } else { "down" },
-        "wg": if s.service_active { "running" } else { "stopped" },
-        "wg_interface": s.wg_interface_up,
-        "peers": s.peer_count,
-        "wg_port": s.wg_port,
-        "rx_bytes": s.rx_bytes,
-        "tx_bytes": s.tx_bytes,
-        "pd": if pd_active { "running" } else { "stopped" },
-        "tikv": if tikv_active { "running" } else { "stopped" },
-        "pd_members": pd_members,
-        "tikv_stores": tikv_stores,
-        "leader": leader,
-    })))
+    Ok(OperationResponse::Resource(value))
 }
 
 async fn handle_start() -> anyhow::Result<OperationResponse> {
@@ -1007,16 +921,32 @@ async fn handle_start() -> anyhow::Result<OperationResponse> {
 }
 
 async fn handle_drain() -> anyhow::Result<OperationResponse> {
-    let db = open_db().await?;
-    fabric::ops::drain(&db).await?;
+    fabric::control::forward_or_fallback(
+        fabric::control::ControlRequest::Drain,
+        || async {
+            let db = open_db().await?;
+            fabric::ops::drain(&db).await?;
+            Ok(serde_json::Value::Null)
+        },
+        |_| Ok(()),
+    )
+    .await?;
     Ok(OperationResponse::Message(
         "node set to draining — no new VMs will be scheduled.".into(),
     ))
 }
 
 async fn handle_enable() -> anyhow::Result<OperationResponse> {
-    let db = open_db().await?;
-    fabric::ops::enable(&db).await?;
+    fabric::control::forward_or_fallback(
+        fabric::control::ControlRequest::Enable,
+        || async {
+            let db = open_db().await?;
+            fabric::ops::enable(&db).await?;
+            Ok(serde_json::Value::Null)
+        },
+        |_| Ok(()),
+    )
+    .await?;
     Ok(OperationResponse::Message(
         "node set to available — ready for VM scheduling.".into(),
     ))
@@ -1024,36 +954,6 @@ async fn handle_enable() -> anyhow::Result<OperationResponse> {
 
 async fn handle_daemon() -> anyhow::Result<OperationResponse> {
     fabric::daemon::run().await?;
-    Ok(OperationResponse::None)
-}
-
-async fn handle_announce_listen(req: OperationRequest) -> anyhow::Result<OperationResponse> {
-    let port: u16 = req
-        .fields
-        .get("port")
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(51822);
-
-    let bind_addr: std::net::SocketAddr = format!("[::]:{port}")
-        .parse()
-        .map_err(|_| anyhow::anyhow!("invalid port"))?;
-
-    // Open the DB once and hold the handle for the lifetime of the
-    // listener — SurrealDB's `Surreal<Db>` is thread-safe and every
-    // spawned announce-handler task clones the same underlying
-    // `Datastore`, so concurrent announces never contend on the
-    // SurrealKV `LOCK`. The `Ctrl+C` shutdown below drops the handle
-    // cleanly before the process exits.
-    let db = open_db().await?;
-    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
-
-    tokio::spawn(async move {
-        let _ = tokio::signal::ctrl_c().await;
-        let _ = shutdown_tx.send(true);
-    });
-
-    fabric::announce::listen(db, bind_addr, shutdown_rx).await?;
-
     Ok(OperationResponse::None)
 }
 
@@ -1143,26 +1043,36 @@ async fn handle_backup_list() -> anyhow::Result<OperationResponse> {
 }
 
 async fn handle_cp_status() -> anyhow::Result<OperationResponse> {
-    // sifrah/nauka#295 — release the bootstrap.skv flock BEFORE making any
-    // PD HTTP round trips. Holding the flock across the (potentially slow)
-    // `get_members`/`get_stores`/`get_region_stats` calls blocks every
-    // other local CLI that needs to open the same DB, including the
-    // persistent announce listener — which then drops incoming peer
-    // announces and cascades into `open_tikv` failures on freshly-joining
-    // nodes (the symptom that made #293 so hard to reproduce cleanly).
-    // Scope the DB tightly: open, read the one field we need, shut down.
-    let mesh_ipv6 = {
-        let db = open_db().await?;
-        let state = fabric::state::FabricState::load(&db)
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?
-            .ok_or_else(|| {
-                anyhow::anyhow!("cluster not initialized. Run 'nauka hypervisor init' first.")
-            })?;
-        let ip = state.hypervisor.mesh_ipv6;
-        db.shutdown().await.ok();
-        ip
-    };
+    // #299: ask the daemon for mesh_ipv6 over the control socket so
+    // we never touch bootstrap.skv while the daemon holds it. When
+    // there is no daemon (init hasn't finished yet, recovery, test
+    // harness) we fall back to a direct open + immediate shutdown —
+    // which is still safe because nothing else is holding the flock
+    // in that case.
+    let mesh_ipv6_str: String = fabric::control::forward_or_fallback(
+        fabric::control::ControlRequest::MeshIpv6,
+        || async {
+            let db = open_db().await?;
+            let state = fabric::state::FabricState::load(&db)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .ok_or_else(|| {
+                    anyhow::anyhow!("cluster not initialized. Run 'nauka hypervisor init' first.")
+                })?;
+            let ip = state.hypervisor.mesh_ipv6.to_string();
+            db.shutdown().await.ok();
+            Ok(serde_json::json!(ip))
+        },
+        |v| {
+            v.as_str()
+                .map(|s| s.to_string())
+                .ok_or_else(|| anyhow::anyhow!("mesh_ipv6: expected string"))
+        },
+    )
+    .await?;
+    let mesh_ipv6: std::net::Ipv6Addr = mesh_ipv6_str
+        .parse()
+        .map_err(|_| anyhow::anyhow!("corrupt mesh_ipv6: {mesh_ipv6_str}"))?;
 
     // Tighter per-request timeout than the default 10s — cp-status is
     // an operator-facing read path and should fail fast if PD is stuck
@@ -1559,48 +1469,19 @@ async fn handle_leave() -> anyhow::Result<OperationResponse> {
 }
 
 async fn handle_list() -> anyhow::Result<OperationResponse> {
-    let db = open_db().await?;
-    let state = match fabric::state::FabricState::load(&db)
-        .await
-        .map_err(|e| anyhow::anyhow!("{e}"))?
-    {
-        Some(s) => s,
-        None => return Ok(OperationResponse::ResourceList(vec![])),
-    };
+    let value = fabric::control::forward_or_fallback(
+        fabric::control::ControlRequest::List,
+        || async {
+            let db = open_db().await?;
+            fabric::ops::list_view(&db)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))
+        },
+        Ok,
+    )
+    .await?;
 
-    let backend = fabric::backend::create_backend(state.network_mode);
-    let self_state = if !backend.is_up() {
-        "down"
-    } else if state.node_state == fabric::state::NodeState::Draining {
-        "draining"
-    } else {
-        "available"
-    };
-
-    let mut items = vec![serde_json::json!({
-        "id": state.hypervisor.id.as_str(),
-        "name": state.hypervisor.name,
-        "region": state.hypervisor.region,
-        "zone": state.hypervisor.zone,
-        "state": self_state,
-        "cpu": "0/0",
-        "memory": "0/0",
-        "vms": 0,
-    })];
-
-    for peer in &state.peers.peers {
-        items.push(serde_json::json!({
-            "id": peer.id.as_str(),
-            "name": peer.name,
-            "region": peer.region,
-            "zone": peer.zone,
-            "state": peer_state_label(peer),
-            "cpu": "0/0",
-            "memory": "0/0",
-            "vms": 0,
-        }));
-    }
-
+    let items: Vec<serde_json::Value> = value.as_array().cloned().unwrap_or_default();
     Ok(OperationResponse::ResourceList(items))
 }
 
@@ -1608,52 +1489,21 @@ async fn handle_get(req: OperationRequest) -> anyhow::Result<OperationResponse> 
     let name = req
         .name
         .ok_or_else(|| anyhow::anyhow!("missing hypervisor name"))?;
-    let db = open_db().await?;
-    let state = fabric::state::FabricState::load(&db)
-        .await
-        .map_err(|e| anyhow::anyhow!("{e}"))?
-        .ok_or_else(|| anyhow::anyhow!("not initialized"))?;
+    let name_for_fallback = name.clone();
 
-    let backend = fabric::backend::create_backend(state.network_mode);
+    let value = fabric::control::forward_or_fallback(
+        fabric::control::ControlRequest::Get { name },
+        || async move {
+            let db = open_db().await?;
+            fabric::ops::get_view(&db, &name_for_fallback)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))
+        },
+        Ok,
+    )
+    .await?;
 
-    if state.hypervisor.name == name {
-        return Ok(OperationResponse::Resource(serde_json::json!({
-            "name": state.hypervisor.name,
-            "id": state.hypervisor.id.as_str(),
-            "region": state.hypervisor.region,
-            "zone": state.hypervisor.zone,
-            "mesh_ipv6": state.hypervisor.mesh_ipv6.to_string(),
-            "state": if !backend.is_up() { "down" } else if state.node_state == fabric::state::NodeState::Draining { "draining" } else { "available" },
-        })));
-    }
-
-    if let Some(peer) = state.peers.find_by_name(&name) {
-        return Ok(OperationResponse::Resource(serde_json::json!({
-            "name": peer.name,
-            "id": peer.id.as_str(),
-            "region": peer.region,
-            "zone": peer.zone,
-            "mesh_ipv6": peer.mesh_ipv6.to_string(),
-            "state": peer_state_label(peer),
-        })));
-    }
-
-    anyhow::bail!("hypervisor '{name}' not found")
-}
-
-/// Map peer status to user-facing label.
-fn peer_state_label(peer: &fabric::peer::Peer) -> &'static str {
-    match peer.status {
-        fabric::peer::PeerStatus::Active => {
-            if peer.node_state == fabric::state::NodeState::Draining {
-                "draining"
-            } else {
-                "available"
-            }
-        }
-        fabric::peer::PeerStatus::Unreachable => "unreachable",
-        fabric::peer::PeerStatus::Removed => "removed",
-    }
+    Ok(OperationResponse::Resource(value))
 }
 
 async fn open_db() -> anyhow::Result<EmbeddedDb> {

--- a/layers/hypervisor/src/handlers.rs
+++ b/layers/hypervisor/src/handlers.rs
@@ -1027,16 +1027,21 @@ async fn handle_announce_listen(req: OperationRequest) -> anyhow::Result<Operati
         .parse()
         .map_err(|_| anyhow::anyhow!("invalid port"))?;
 
-    // Async opener: each request gets a fresh EmbeddedDb handle so the
-    // SurrealKV flock is only held for the duration of one announce.
-    let db_opener = || async {
-        EmbeddedDb::open_default()
-            .await
-            .map_err(|e| nauka_core::error::NaukaError::internal(e.to_string()))
-    };
+    // Open the DB once and hold the handle for the lifetime of the
+    // listener — SurrealDB's `Surreal<Db>` is thread-safe and every
+    // spawned announce-handler task clones the same underlying
+    // `Datastore`, so concurrent announces never contend on the
+    // SurrealKV `LOCK`. The `Ctrl+C` shutdown below drops the handle
+    // cleanly before the process exits.
+    let db = open_db().await?;
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
-    // This blocks forever (until killed by systemd)
-    fabric::announce::listen(db_opener, bind_addr).await?;
+    tokio::spawn(async move {
+        let _ = tokio::signal::ctrl_c().await;
+        let _ = shutdown_tx.send(true);
+    });
+
+    fabric::announce::listen(db, bind_addr, shutdown_rx).await?;
 
     Ok(OperationResponse::None)
 }

--- a/layers/hypervisor/src/handlers.rs
+++ b/layers/hypervisor/src/handlers.rs
@@ -92,13 +92,6 @@ pub fn resource_def() -> ResourceDef {
                 FieldDef::string("ipv4-public", "Public IPv4 address of this server"),
             ))
             .with_arg(OperationArg::optional(
-                "peering",
-                FieldDef::flag(
-                    "peering",
-                    "Start peering listener after init (accepts joins)",
-                ),
-            ))
-            .with_arg(OperationArg::optional(
                 "max-pd-members",
                 FieldDef::integer(
                     "max-pd-members",
@@ -367,11 +360,14 @@ async fn handle_init(req: OperationRequest) -> anyhow::Result<OperationResponse>
                 .unwrap_or_else(|| "node".to_string())
         });
 
-    let peering = req
-        .fields
-        .get("peering")
-        .map(|s| s == "true")
-        .unwrap_or(false);
+    // #299: the old `--peering` flag used to keep an ephemeral
+    // listener running inline after `init`. The hypervisor daemon
+    // now takes over that role (installed at the end of this
+    // handler) and listens continuously, gated by the PIN and
+    // per-IP rate-limited, so the flag is no longer meaningful.
+    // We silently ignore any `peering` field that may still show
+    // up from scripted callers or stale docs.
+    let _ = req.fields.get("peering");
 
     let max_pd_members: usize = req
         .fields
@@ -536,15 +532,23 @@ async fn handle_init(req: OperationRequest) -> anyhow::Result<OperationResponse>
         steps.inc();
     }
 
-    // Non-critical steps — warn but don't rollback
-    if !peering {
-        if let Err(e) = fabric::announce::install_service(port) {
-            tracing::warn!(error = %e, "announce service install failed");
-        }
-    }
-
     // Suppress unused variable warnings
     let _ = (fabric_initialized, storage_initialized);
+
+    // Release our in-process flock BEFORE installing the daemon: the
+    // daemon opens `bootstrap.skv` on startup and would otherwise
+    // race us. `shutdown()` polls the LOCK file for release so the
+    // next open is guaranteed to succeed. From this point on, the
+    // daemon owns the handle.
+    db.shutdown().await.ok();
+
+    // Install and start `nauka.service`. The daemon hosts the
+    // peering TCP listener on `port + 1`, the announce listener on
+    // `port + 2`, the health loop, the mesh reconciler, and the
+    // operator control socket — all under one long-lived process.
+    if let Err(e) = fabric::daemon::install_service() {
+        tracing::warn!(error = %e, "hypervisor daemon install failed");
+    }
 
     steps.finish("Hypervisor initialized");
     eprintln!();
@@ -555,42 +559,12 @@ async fn handle_init(req: OperationRequest) -> anyhow::Result<OperationResponse>
     eprintln!("  address  {}", result.hypervisor.mesh_ipv6);
     eprintln!("  pin      {}", result.pin);
     eprintln!();
-
-    if peering {
-        let peering_port = port + 1;
-        eprintln!("  Peering active on port {peering_port}");
-        eprintln!("  Nodes can join with:");
-        eprintln!(
-            "    nauka hypervisor join --target <this-ip>:{peering_port} --pin {}",
-            result.pin
-        );
-        eprintln!();
-        eprintln!("  Waiting for joins... (Ctrl+C to stop)");
-        eprintln!();
-
-        // Block here listening for joins (DB opened per-request, no lock held).
-        // P2/#281: `init --peering` is the bootstrap-then-accept-unlimited-
-        // joins flow, so we explicitly request unlimited mode (0) with the
-        // legacy 1-hour idle timeout. The standalone `nauka hypervisor
-        // peering` command defaults to 1-join-then-exit instead.
-        let accepted = fabric::ops::listen_for_peers(&result.pin, peering_port, 3600, 0).await?;
-
-        eprintln!("  {} node(s) joined.", accepted);
-
-        // Peering session ended — install announce service for persistent listening
-        if let Err(e) = fabric::announce::install_service(port) {
-            tracing::warn!(error = %e, "announce service install failed");
-        }
-    } else {
-        eprintln!("  To accept joins on this node:");
-        eprintln!("    nauka hypervisor peering");
-        eprintln!();
-        eprintln!("  Or from another node:");
-        eprintln!(
-            "    nauka hypervisor join --target <this-ip> --pin {}",
-            result.pin
-        );
-    }
+    eprintln!("  Daemon running. Nodes can join with:");
+    eprintln!(
+        "    nauka hypervisor join --target <this-ip> --pin {}",
+        result.pin
+    );
+    eprintln!();
 
     Ok(OperationResponse::Resource(serde_json::json!({
         "name": result.hypervisor.name,
@@ -814,11 +788,17 @@ async fn handle_join(req: OperationRequest) -> anyhow::Result<OperationResponse>
         steps.inc();
     }
 
-    // Install persistent announce listener AFTER self-announce, so the
-    // forge/announce systemd unit doesn't grab `bootstrap.skv`'s flock
-    // while we're still holding it in-process (see #282).
-    if let Err(e) = fabric::announce::install_service(port) {
-        tracing::warn!(error = %e, "announce service install failed");
+    // Release our in-process flock BEFORE installing the hypervisor
+    // daemon. The daemon opens `bootstrap.skv` as soon as
+    // `systemctl --now` starts it, and would otherwise race our
+    // handle. `EmbeddedDb::shutdown` polls the LOCK file for release,
+    // guaranteeing the daemon's open will succeed on first try.
+    // (Supersedes #282 which worked around this by carefully
+    // ordering self-announce before the announce-service install.)
+    db.shutdown().await.ok();
+
+    if let Err(e) = fabric::daemon::install_service() {
+        tracing::warn!(error = %e, "hypervisor daemon install failed");
     }
 
     steps.finish("Joined cluster");
@@ -908,14 +888,28 @@ async fn handle_status() -> anyhow::Result<OperationResponse> {
 }
 
 async fn handle_start() -> anyhow::Result<OperationResponse> {
+    // If the daemon is running, stop it briefly so we can open the
+    // DB directly for the boot-up checks. We restart it at the end.
+    let daemon_was_installed = fabric::daemon::is_service_installed();
+    let daemon_was_active = fabric::daemon::is_service_active();
+    if daemon_was_active {
+        let _ = fabric::daemon::stop_service();
+        // Give systemd a moment to actually release the LOCK.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+
     let db = open_db().await?;
     fabric::ops::start(&db).await?;
-    let _ = fabric::announce::start_service();
     if let Err(e) = controlplane::ops::start() {
         eprintln!("  Warning: control plane: {e}");
     }
     if let Err(e) = storage::ops::start_all(&db).await {
         eprintln!("  Warning: storage: {e}");
+    }
+    db.shutdown().await.ok();
+
+    if daemon_was_installed {
+        let _ = fabric::daemon::start_service();
     }
     Ok(OperationResponse::Message("all services started.".into()))
 }
@@ -1413,15 +1407,31 @@ async fn handle_doctor() -> anyhow::Result<OperationResponse> {
 }
 
 async fn handle_stop() -> anyhow::Result<OperationResponse> {
+    // Stop the daemon first so we can open the DB without flock
+    // contention for the rest of the teardown.
+    let _ = fabric::daemon::request_shutdown_and_wait(std::time::Duration::from_secs(5)).await;
+    let _ = fabric::daemon::stop_service();
+
     let db = open_db().await?;
     let _ = storage::ops::stop_all(&db).await;
     let _ = controlplane::ops::stop();
-    let _ = fabric::announce::stop_service();
     fabric::ops::stop(&db).await?;
     Ok(OperationResponse::Message("all services stopped.".into()))
 }
 
 async fn handle_leave() -> anyhow::Result<OperationResponse> {
+    let steps = ui::Steps::new(5);
+
+    // 1. Stop the daemon if it's running so the bootstrap.skv flock
+    //    is free before we open the DB directly for teardown.
+    steps.set("Stopping daemon");
+    if let Err(e) =
+        fabric::daemon::request_shutdown_and_wait(std::time::Duration::from_secs(10)).await
+    {
+        tracing::warn!(error = %e, "daemon shutdown request failed, continuing");
+    }
+    steps.inc();
+
     let db = open_db().await?;
     // Get mesh IPv6 for TiKV deregistration before leaving
     let mesh_ipv6 = fabric::state::FabricState::load(&db)
@@ -1430,38 +1440,35 @@ async fn handle_leave() -> anyhow::Result<OperationResponse> {
         .flatten()
         .map(|s| s.hypervisor.mesh_ipv6);
 
-    let steps = ui::Steps::new(4);
-
-    // Storage first (stop ZeroFS instances)
+    // 2. Storage (stop ZeroFS instances)
     steps.set("Stopping storage");
     let _ = storage::ops::leave();
     steps.inc();
 
-    // Controlplane (deregister TiKV store, then uninstall). The
-    // `leave_with_mesh` variant reads peer state via its own
-    // short-lived EmbeddedDb handle, so release ours first to avoid
-    // flock contention on the SurrealKV store directory.
+    // 3. Controlplane (deregister TiKV store, then uninstall). The
+    //    `leave_with_mesh` variant reads peer state via its own
+    //    short-lived EmbeddedDb handle — safe now that our daemon is
+    //    no longer holding the flock.
     steps.set("Leaving control plane");
     if let Some(ipv6) = mesh_ipv6 {
-        // Temporarily release our handle during the TiKV deregistration
-        // step; `leave_with_mesh` opens its own EmbeddedDb for peer
-        // lookups via `FabricState::load`.
-        //
-        // We recreate the handle afterwards for the remaining steps.
         let _ = controlplane::ops::leave_with_mesh(&ipv6).await;
     } else {
         let _ = controlplane::ops::leave();
     }
     steps.inc();
 
-    // Notify peers + tear down mesh
+    // 4. Notify peers + tear down mesh
     steps.set("Notifying peers");
-    let _ = fabric::announce::uninstall_service();
     fabric::ops::leave(&db).await?;
     steps.inc();
 
-    // Final cleanup
+    // Release our DB handle before uninstalling the daemon unit, so
+    // `daemon-reload` doesn't race anything still holding `LOCK`.
+    db.shutdown().await.ok();
+
+    // 5. Final cleanup: remove the daemon systemd unit.
     steps.set("Removing services");
+    let _ = fabric::daemon::uninstall_service();
     steps.inc();
 
     steps.finish("Left the cluster");

--- a/layers/hypervisor/tests/e2e/Cargo.toml
+++ b/layers/hypervisor/tests/e2e/Cargo.toml
@@ -8,6 +8,10 @@ publish = false
 name = "peering"
 path = "peering_test.rs"
 
+[[test]]
+name = "parallel_join"
+path = "parallel_join_test.rs"
+
 [dependencies]
 nauka-core = { path = "../../../core" }
 nauka-state = { path = "../../../state" }
@@ -20,3 +24,4 @@ axum = "0.8"
 http = "1"
 tower = "0.5"
 serde_json = "1"
+base64 = "0.22"

--- a/layers/hypervisor/tests/e2e/parallel_join_test.rs
+++ b/layers/hypervisor/tests/e2e/parallel_join_test.rs
@@ -1,0 +1,221 @@
+//! Integration test for #299 — parallel joins against a shared
+//! `EmbeddedDb` handle, plus concurrent read access.
+//!
+//! This is the regression test the issue's acceptance criteria asks
+//! for. It exercises the post-#299 invariants:
+//!
+//! 1. Multiple `peering_client::join` calls running concurrently all
+//!    succeed *and* every one shows up in the final state.
+//!    Before #299 this was the "1-of-N-joins-succeeds-TLS-reset-on-
+//!    the-rest" failure mode — the listener was strictly serial,
+//!    every joiner past the first hit the per-request bootstrap.skv
+//!    flock on the accept path, and the `load → modify → save` race
+//!    on the single-blob `fabric:state` record silently dropped
+//!    updates.
+//! 2. While parallel joins are in flight, concurrent `status_view`
+//!    reads against the same `EmbeddedDb` handle never fail with
+//!    "Database ... is already locked". This is the in-process
+//!    analogue of the `cp-status` / `status` operator command
+//!    running while the daemon is accepting joins.
+//!
+//! We do **not** install `nauka.service` here — that would require
+//! root and systemd. Instead we run the individual listeners
+//! directly against a temp `EmbeddedDb`, which is exactly the shape
+//! `fabric::daemon::run` has on a real node minus the process
+//! isolation and systemd integration.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use nauka_hypervisor::fabric::backend::NetworkMode;
+use nauka_hypervisor::fabric::mesh;
+use nauka_hypervisor::fabric::peer::PeerList;
+use nauka_hypervisor::fabric::peering::JoinRequest;
+use nauka_hypervisor::fabric::peering_client;
+use nauka_hypervisor::fabric::peering_server;
+use nauka_hypervisor::fabric::state::FabricState;
+use nauka_state::EmbeddedDb;
+
+/// Number of joiners we drive at once. Matches the issue's
+/// "5 joiners concurrent" scenario but stays small enough for a
+/// unit test.
+const CONCURRENCY: usize = 4;
+
+async fn temp_db() -> (tempfile::TempDir, EmbeddedDb) {
+    let dir = tempfile::tempdir().unwrap();
+    let db = EmbeddedDb::open(&dir.path().join("test.skv"))
+        .await
+        .unwrap();
+    (dir, db)
+}
+
+async fn init_bootstrap_node(db: &EmbeddedDb) -> String {
+    let (mesh_id, secret) = mesh::create_mesh();
+    let hv = mesh::create_hypervisor(&mesh::CreateHypervisorConfig {
+        name: "bootstrap",
+        region: "eu",
+        zone: "test",
+        port: 51820,
+        endpoint: None,
+        fabric_interface: "",
+        mesh_prefix: &mesh_id.prefix,
+        ipv6_block: None,
+        ipv4_public: None,
+    })
+    .unwrap();
+
+    let pin = secret.derive_pin();
+
+    let state = FabricState {
+        mesh: mesh_id,
+        hypervisor: hv,
+        secret: secret.to_string(),
+        peers: PeerList::new(),
+        network_mode: NetworkMode::Mock,
+        node_state: nauka_hypervisor::fabric::NodeState::default(),
+        max_pd_members: 3,
+    };
+    state.save(db).await.unwrap();
+
+    pin
+}
+
+/// Build a throwaway 32-byte base64-encoded WireGuard key. Different
+/// each call so every joiner claims a distinct peer identity.
+fn fake_wg_key(seed: u64) -> String {
+    use base64::Engine as _;
+    let mut bytes = [0u8; 32];
+    for (i, b) in bytes.iter_mut().enumerate() {
+        *b = ((seed.wrapping_mul(31337).wrapping_add(i as u64)) & 0xff) as u8;
+    }
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+#[tokio::test]
+async fn parallel_joins_plus_concurrent_state_reads() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let (_dir, db) = temp_db().await;
+    let pin = init_bootstrap_node(&db).await;
+
+    // Bind first, then pass the listener into `serve` so the test
+    // can read back the allocated port.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let peering_addr = listener.local_addr().unwrap();
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+    // Spawn the peering server against the pre-bound listener. The
+    // server shares the same `db` handle we use for status reads.
+    let server_db = db.clone();
+    let server_pin = pin.clone();
+    let server = tokio::spawn(async move {
+        peering_server::serve(
+            listener,
+            server_db,
+            server_pin,
+            Duration::from_secs(30),
+            0, // unlimited accepts
+            shutdown_rx,
+        )
+        .await
+    });
+
+    // ── Parallel joiners ──
+    let mut join_handles = Vec::with_capacity(CONCURRENCY);
+    for i in 0..CONCURRENCY {
+        let target = peering_addr.to_string();
+        let pin = pin.clone();
+        let wg_key = fake_wg_key(i as u64);
+        let name = format!("joiner-{i}");
+        join_handles.push(tokio::spawn(async move {
+            let req = JoinRequest {
+                name,
+                region: "eu".into(),
+                zone: "test".into(),
+                wg_public_key: wg_key,
+                wg_port: 51820 + i as u16 + 1,
+                endpoint: Some(format!("127.0.0.1:{}", 51820 + i as u16 + 1)),
+                pin: Some(pin),
+                trace_id: Some(format!("parallel_test_{i}")),
+            };
+            peering_client::join(&target, req).await
+        }));
+    }
+
+    // ── Concurrent state reads against the same db clone ──
+    //
+    // The acceptance criterion from #299: while parallel joins are
+    // in flight, a concurrent reader must never fail with "Database
+    // ... is already locked". We drive 8 tasks each doing 5 tight
+    // `FabricState::load` calls against the shared handle. None is
+    // allowed to error out.
+    //
+    // We deliberately use `FabricState::load` rather than the
+    // full `status_view` because the latter also pokes PD over
+    // HTTP, and in a test without a real cluster those calls would
+    // saturate the runtime with curl timeouts. The DB-flock
+    // contention we care about is 100% in `FabricState::load`.
+    let read_errors: Arc<std::sync::Mutex<Vec<String>>> = Arc::new(Default::default());
+    let mut read_handles = Vec::new();
+    for _ in 0..8 {
+        let db = db.clone();
+        let errors = read_errors.clone();
+        read_handles.push(tokio::spawn(async move {
+            for _ in 0..5 {
+                match FabricState::load(&db).await {
+                    Ok(_) => tokio::time::sleep(Duration::from_millis(5)).await,
+                    Err(e) => {
+                        errors.lock().unwrap().push(e.to_string());
+                        return;
+                    }
+                }
+            }
+        }));
+    }
+
+    // Wait for joiners.
+    let mut ok = 0usize;
+    let mut errors = Vec::new();
+    for h in join_handles {
+        match h.await.expect("join task panicked") {
+            Ok(_) => ok += 1,
+            Err(e) => errors.push(e.to_string()),
+        }
+    }
+    assert_eq!(
+        ok, CONCURRENCY,
+        "expected all {CONCURRENCY} joins to succeed; errors = {errors:?}"
+    );
+
+    // Wait for concurrent readers and check they never saw a lock
+    // error.
+    for h in read_handles {
+        h.await.unwrap();
+    }
+    let errs = read_errors.lock().unwrap();
+    assert!(
+        errs.is_empty(),
+        "concurrent FabricState::load calls should never fail while joins are in flight, but: {errs:?}"
+    );
+    drop(errs);
+
+    // State reflects all joiners — proves the write_lock around
+    // `handle_join` prevents the load→modify→save race that
+    // silently dropped updates before #299.
+    let state = FabricState::load(&db).await.unwrap().unwrap();
+    assert_eq!(
+        state.peers.len(),
+        CONCURRENCY,
+        "expected {CONCURRENCY} peers in state, got {}",
+        state.peers.len()
+    );
+
+    // Shut the listener down cleanly so its db clone is released
+    // before we call `db.shutdown()` on our last clone.
+    shutdown_tx.send(true).unwrap();
+    let accepted = server.await.unwrap().unwrap();
+    assert_eq!(accepted, CONCURRENCY);
+
+    db.shutdown().await.unwrap();
+}

--- a/layers/hypervisor/tests/e2e/parallel_join_test.rs
+++ b/layers/hypervisor/tests/e2e/parallel_join_test.rs
@@ -189,16 +189,16 @@ async fn parallel_joins_plus_concurrent_state_reads() {
     );
 
     // Wait for concurrent readers and check they never saw a lock
-    // error.
+    // error. Snapshot the errors into an owned Vec before any await
+    // so the std Mutex guard doesn't live across an await point.
     for h in read_handles {
         h.await.unwrap();
     }
-    let errs = read_errors.lock().unwrap();
+    let errs: Vec<String> = read_errors.lock().unwrap().clone();
     assert!(
         errs.is_empty(),
         "concurrent FabricState::load calls should never fail while joins are in flight, but: {errs:?}"
     );
-    drop(errs);
 
     // State reflects all joiners — proves the write_lock around
     // `handle_join` prevents the load→modify→save race that


### PR DESCRIPTION
## Summary

Closes #299 by moving the local bootstrap state out of "every CLI opens its own flock-held handle" and into "one long-lived daemon owns the handle; everyone else forwards over a Unix socket or falls back to direct access when no daemon is running".

- **Peering, announce, health, reconcile** listeners no longer take a `db_opener` closure — they accept a long-lived `EmbeddedDb` handle by value, clone it into a per-connection `tokio::spawn`, and share one `Datastore` with SurrealDB's internal concurrency. Shutdown is driven by a `watch::Receiver<bool>`.
- **New `fabric/daemon.rs`** runs `nauka.service`: opens `bootstrap.skv` once, spawns every listener + loop + the control socket, waits for SIGTERM / SIGINT / `ControlRequest::Shutdown`, drains all children, then calls `EmbeddedDb::shutdown()` on the last clone.
- **New `fabric/control/`** module (`protocol.rs` + `server.rs` + `client.rs`) is the Unix-socket plumbing. The daemon hosts the server at `/run/nauka/ctl.sock` (`~/.nauka/ctl.sock` in CLI mode). Operator handlers (`status`, `list`, `get`, `cp-status`, `drain`, `enable`, `update`) use `forward_or_fallback` — forward to the daemon when it's up, fall back to opening the DB directly when it isn't. `leave` sends `ControlRequest::Shutdown` before tearing down local state.
- **`init` / `join`** install `nauka.service` as their last step, after `db.shutdown().await` on the in-process handle. `install_service` auto-migrates any legacy `nauka-announce.service` left from a pre-#299 binary (stop → disable → remove → daemon-reload).
- **Removed**: `nauka hypervisor peering`, `nauka hypervisor announce-listen`, the `init --peering` flag, `fabric::announce::install_service`/`start_service`/`stop_service`/…, `fabric::ops::listen_for_peers`, `fabric::ops::open_db` helper — all superseded by the daemon.
- **Lost-update race fix**: `handle_join` used to `load → mutate → save` without cross-task coordination. Before #299 the OS flock hid this by serialising at the process level; after #299 it's live, and the new regression test catches it. Fix: a process-global `tokio::sync::Mutex` in `fabric::state::write_lock`, acquired by `handle_join` for the duration of its load-modify-save-WG-update critical section.

### Commits

1. `refactor(#299): peering/announce/health listeners own a shared EmbeddedDb` — signatures take `EmbeddedDb` by value, spawn per connection, watch-channel shutdown.
2. `feat(#299): add fabric/control Unix-socket protocol + views` — new `fabric/control/` module + `ops::{status,list,get}_view` helpers.
3. `feat(#299): add hypervisor daemon + nauka.service` — `fabric/daemon.rs`, new `nauka hypervisor daemon` subcommand, systemd unit generation + install/uninstall helpers + legacy migration.
4. `feat(#299): forward operator handlers through the control socket` — handlers.rs rewires status/list/get/cp-status/drain/enable/update via `forward_or_fallback`. Removes `handle_peering`, `handle_announce_listen`.
5. `refactor(#299): init/join/leave install nauka.service, retire legacy path` — init/join wrap up with `daemon::install_service`, leave sends `ControlRequest::Shutdown`, start/stop bracket their direct-DB work with `daemon::stop_service`/`start_service`. Deletes `listen_for_peers`, `announce::install_service`, `ops::open_db`.
6. `test(#299): regression test for parallel joins + concurrent state reads` — `parallel_join_test` drives 4 parallel joiners + 8 parallel `FabricState::load` readers against one shared handle, asserts every join lands and no reader sees a flock error. Adds the `write_lock` fix.
7. `docs(#299): CLAUDE.md — daemon-owned bootstrap DB + control socket` — drops the "not a daemon" bullet, updates the module map, fixes the stale "redb" mention.
8. `test(#299): snapshot read_errors to avoid holding std Mutex across await` — trivial clippy followup.

## Test plan

- [x] `cargo build` — clean across the workspace
- [x] `cargo test` — 710 tests pass; includes the new `parallel_join_test::parallel_joins_plus_concurrent_state_reads` which drives 4 concurrent joins + 8 concurrent readers and asserts no flock errors
- [x] `cargo clippy --all-targets` — 0 warnings
- [ ] Hetzner acceptance criteria (manual, not automated): 8-node cluster, parallel joins against `nauka.service` on node-1, cp-status on a second shell never hits "already locked", no orphan `nauka` processes holding the flock, immediate re-join of a 9th node works without manual cleanup
- [ ] Upgrade path (manual): deploy the new binary on a node where `nauka-announce.service` is still installed from a previous release; on next `init`/`join`/`daemon::install_service` call the legacy unit should be stopped, disabled, and removed before `nauka.service` takes over

🤖 Generated with [Claude Code](https://claude.com/claude-code)