### PR TITLE
fix(#312): Database::query() propagates per-statement SurQL errors

### DIFF
--- a/layers/hypervisor/definition.surql
+++ b/layers/hypervisor/definition.surql
@@ -1,24 +1,24 @@
 -- Mesh identity and configuration (local to this node)
-DEFINE TABLE mesh SCHEMAFULL;
-DEFINE FIELD interface_name ON mesh TYPE string;
-DEFINE FIELD listen_port    ON mesh TYPE int;
-DEFINE FIELD mesh_id        ON mesh TYPE string;
-DEFINE FIELD private_key    ON mesh TYPE string;
-DEFINE FIELD ca_cert        ON mesh TYPE option<string>;
-DEFINE FIELD ca_key         ON mesh TYPE option<string>;
-DEFINE FIELD tls_cert       ON mesh TYPE option<string>;
-DEFINE FIELD tls_key        ON mesh TYPE option<string>;
-DEFINE FIELD created_at     ON mesh TYPE datetime DEFAULT time::now();
+DEFINE TABLE IF NOT EXISTS mesh SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS interface_name ON mesh TYPE string;
+DEFINE FIELD IF NOT EXISTS listen_port    ON mesh TYPE int;
+DEFINE FIELD IF NOT EXISTS mesh_id        ON mesh TYPE string;
+DEFINE FIELD IF NOT EXISTS private_key    ON mesh TYPE string;
+DEFINE FIELD IF NOT EXISTS ca_cert        ON mesh TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS ca_key         ON mesh TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS tls_cert       ON mesh TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS tls_key        ON mesh TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS created_at     ON mesh TYPE datetime DEFAULT time::now();
 
 -- Mesh hypervisors (replicated via Raft consensus)
-DEFINE TABLE hypervisor SCHEMAFULL;
-DEFINE FIELD public_key     ON hypervisor TYPE string;
-DEFINE FIELD node_id        ON hypervisor TYPE int;
-DEFINE FIELD address        ON hypervisor TYPE string;
-DEFINE FIELD endpoint       ON hypervisor TYPE option<string>;
-DEFINE FIELD allowed_ips    ON hypervisor TYPE array<string>;
-DEFINE FIELD keepalive      ON hypervisor TYPE option<int>;
-DEFINE FIELD raft_addr      ON hypervisor TYPE string;
-DEFINE FIELD joined_at      ON hypervisor TYPE datetime DEFAULT time::now();
+DEFINE TABLE IF NOT EXISTS hypervisor SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS public_key     ON hypervisor TYPE string;
+DEFINE FIELD IF NOT EXISTS node_id        ON hypervisor TYPE int;
+DEFINE FIELD IF NOT EXISTS address        ON hypervisor TYPE string;
+DEFINE FIELD IF NOT EXISTS endpoint       ON hypervisor TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS allowed_ips    ON hypervisor TYPE array<string>;
+DEFINE FIELD IF NOT EXISTS keepalive      ON hypervisor TYPE option<int>;
+DEFINE FIELD IF NOT EXISTS raft_addr      ON hypervisor TYPE string;
+DEFINE FIELD IF NOT EXISTS joined_at      ON hypervisor TYPE datetime DEFAULT time::now();
 
-DEFINE INDEX hypervisor_pubkey ON hypervisor FIELDS public_key UNIQUE;
+DEFINE INDEX IF NOT EXISTS hypervisor_pubkey ON hypervisor FIELDS public_key UNIQUE;

--- a/layers/state/definition.surql
+++ b/layers/state/definition.surql
@@ -1,19 +1,19 @@
 -- Raft consensus state (local to each node)
-DEFINE TABLE _raft_meta SCHEMAFULL;
-DEFINE FIELD hypervisor ON _raft_meta TYPE int;
-DEFINE FIELD vote       ON _raft_meta TYPE option<string>;
-DEFINE FIELD committed  ON _raft_meta TYPE option<string>;
-DEFINE FIELD purged     ON _raft_meta TYPE option<string>;
+DEFINE TABLE IF NOT EXISTS _raft_meta SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS hypervisor ON _raft_meta TYPE int;
+DEFINE FIELD IF NOT EXISTS vote       ON _raft_meta TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS committed  ON _raft_meta TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS purged     ON _raft_meta TYPE option<string>;
 
-DEFINE TABLE _raft_log SCHEMAFULL;
-DEFINE FIELD hypervisor ON _raft_log TYPE int;
-DEFINE FIELD log_index  ON _raft_log TYPE int;
-DEFINE FIELD entry      ON _raft_log TYPE string;
-DEFINE INDEX raft_log_idx ON _raft_log FIELDS hypervisor, log_index UNIQUE;
+DEFINE TABLE IF NOT EXISTS _raft_log SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS hypervisor ON _raft_log TYPE int;
+DEFINE FIELD IF NOT EXISTS log_index  ON _raft_log TYPE int;
+DEFINE FIELD IF NOT EXISTS entry      ON _raft_log TYPE string;
+DEFINE INDEX IF NOT EXISTS raft_log_idx ON _raft_log FIELDS hypervisor, log_index UNIQUE;
 
-DEFINE TABLE _raft_snapshot SCHEMAFULL;
-DEFINE FIELD hypervisor      ON _raft_snapshot TYPE int;
-DEFINE FIELD snapshot_id     ON _raft_snapshot TYPE string;
-DEFINE FIELD last_applied    ON _raft_snapshot TYPE option<string>;
-DEFINE FIELD last_membership ON _raft_snapshot TYPE string;
-DEFINE FIELD data            ON _raft_snapshot TYPE string;
+DEFINE TABLE IF NOT EXISTS _raft_snapshot SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS hypervisor      ON _raft_snapshot TYPE int;
+DEFINE FIELD IF NOT EXISTS snapshot_id     ON _raft_snapshot TYPE string;
+DEFINE FIELD IF NOT EXISTS last_applied    ON _raft_snapshot TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS last_membership ON _raft_snapshot TYPE string;
+DEFINE FIELD IF NOT EXISTS data            ON _raft_snapshot TYPE string;

--- a/layers/state/src/db.rs
+++ b/layers/state/src/db.rs
@@ -24,7 +24,7 @@ impl Database {
     }
 
     pub async fn query(&self, surql: &str) -> Result<(), StateError> {
-        self.db.query(surql).await?;
+        self.db.query(surql).await?.check()?;
         Ok(())
     }
 
@@ -38,5 +38,54 @@ impl Database {
 
     pub fn inner(&self) -> &Surreal<surrealdb::engine::local::Db> {
         &self.db
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn open_tmp() -> (Database, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        let db = Database::open(Some(path.to_str().unwrap())).await.unwrap();
+        (db, dir)
+    }
+
+    #[tokio::test]
+    async fn query_propagates_schema_violation() {
+        let (db, _dir) = open_tmp().await;
+        db.query(
+            "DEFINE TABLE t SCHEMAFULL; \
+             DEFINE FIELD name ON t TYPE string; \
+             DEFINE INDEX t_name ON t FIELDS name UNIQUE;",
+        )
+        .await
+        .unwrap();
+
+        db.query("CREATE t SET name = 'foo'").await.unwrap();
+        let result = db.query("CREATE t SET name = 'foo'").await;
+        assert!(
+            result.is_err(),
+            "expected unique-constraint error, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn query_propagates_missing_required_field() {
+        let (db, _dir) = open_tmp().await;
+        db.query(
+            "DEFINE TABLE t SCHEMAFULL; \
+             DEFINE FIELD name ON t TYPE string;",
+        )
+        .await
+        .unwrap();
+
+        // Missing required `name` field
+        let result = db.query("CREATE t SET other = 'x'").await;
+        assert!(
+            result.is_err(),
+            "expected schema-violation error, got: {result:?}"
+        );
     }
 }


### PR DESCRIPTION
Closes #312.

## Summary

- `Database::query()` now calls `.check()` on the SurrealDB `Response`, so per-statement errors (schema violations, UNIQUE index conflicts, missing required fields) surface instead of being silently swallowed.
- Schema definitions switched to `DEFINE ... IF NOT EXISTS` so `load_schemas` is idempotent across CLI invocations — required because the stricter `query()` now errors on duplicate `DEFINE TABLE`.
- 2 regression tests in `db.rs`: unique-constraint violation, missing required field.

## Why the schema change

The first Hetzner run of this PR failed on `nauka mesh down` with `The table '_raft_meta' already exists`. Root cause: `bin/nauka/src/main.rs:28` calls `load_schemas` on every command, and `DEFINE TABLE` is not idempotent in SurrealDB 3. The old `query()` hid this for every user. Fixing it without making the schema idempotent would break every CLI invocation after the first. `IF NOT EXISTS` is the supported idempotent form.

## Test plan

- [x] `cargo test` — 8/8 pass (6 existing + 2 new regression tests)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Hetzner 2-node via `tests/test-issue-305.sh` — init + join + `mesh down` + `mesh up` + voter promotion all green

## Known follow-ups (not in scope)

`state_machine::apply` (`layers/state/src/raft/state_machine.rs:262`) and `install_snapshot` (`:308`) still log-and-continue on per-statement errors. Their behavior is unchanged by this PR — but now they log _real_ errors instead of silence. Proper handling (cluster-wide divergence protection) belongs to #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)