### PR TITLE
test(#311): end-to-end integration tests for Raft write replication

### DIFF
--- a/layers/state/src/raft/mod.rs
+++ b/layers/state/src/raft/mod.rs
@@ -109,7 +109,11 @@ impl RaftNode {
             .client_write(SurqlCommand { query })
             .await
             .map_err(|e| StateError::Raft(format!("client_write: {e}")))?;
-        Ok(resp.response().clone())
+        let response = resp.response().clone();
+        if let Some(ref err) = response.error {
+            return Err(StateError::Raft(format!("state machine: {err}")));
+        }
+        Ok(response)
     }
 
     pub async fn start_server(&self, bind_addr: String) -> tokio::task::JoinHandle<()> {

--- a/layers/state/src/raft/state_machine.rs
+++ b/layers/state/src/raft/state_machine.rs
@@ -258,15 +258,15 @@ where
                 }
                 EntryPayload::Normal(cmd) => {
                     eprintln!("  sm: apply query: {}", cmd.query);
-                    inner.data.applied_queries.push(cmd.query.clone());
                     match self.db.query(&cmd.query).await {
                         Ok(_) => {
                             eprintln!("  sm: query OK");
+                            inner.data.applied_queries.push(cmd.query.clone());
                             SurqlResponse::ok()
                         }
                         Err(e) => {
                             eprintln!("  sm: query FAILED: {e}");
-                            SurqlResponse::none()
+                            SurqlResponse::err(e.to_string())
                         }
                     }
                 }

--- a/layers/state/src/raft/types.rs
+++ b/layers/state/src/raft/types.rs
@@ -23,14 +23,29 @@ impl fmt::Display for SurqlCommand {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SurqlResponse {
     pub success: bool,
+    #[serde(default)]
+    pub error: Option<String>,
 }
 
 impl SurqlResponse {
     pub fn ok() -> Self {
-        Self { success: true }
+        Self {
+            success: true,
+            error: None,
+        }
     }
 
     pub fn none() -> Self {
-        Self { success: false }
+        Self {
+            success: false,
+            error: None,
+        }
+    }
+
+    pub fn err(msg: impl Into<String>) -> Self {
+        Self {
+            success: false,
+            error: Some(msg.into()),
+        }
     }
 }

--- a/layers/state/tests/raft_cluster.rs
+++ b/layers/state/tests/raft_cluster.rs
@@ -1,0 +1,171 @@
+//! End-to-end integration tests for the Raft consensus layer.
+//!
+//! Spins up in-process 3-node clusters over loopback TCP and exercises
+//! `RaftNode::write` — the same path used by the daemon.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use nauka_state::{Database, RaftNode};
+use serde::Deserialize;
+use surrealdb::types::SurrealValue;
+
+const TEST_SCHEMA: &str = "\
+DEFINE TABLE IF NOT EXISTS kv SCHEMAFULL;\
+DEFINE FIELD IF NOT EXISTS key ON kv TYPE string;\
+DEFINE FIELD IF NOT EXISTS value ON kv TYPE string;\
+DEFINE INDEX IF NOT EXISTS kv_key ON kv FIELDS key UNIQUE;\
+";
+
+#[derive(Deserialize, SurrealValue, Debug)]
+struct Kv {
+    #[allow(dead_code)]
+    key: String,
+    value: String,
+}
+
+struct TestNode {
+    raft: Arc<RaftNode>,
+    db: Arc<Database>,
+    addr: String,
+    _dir: tempfile::TempDir,
+}
+
+fn pick_free_port() -> u16 {
+    let l = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    l.local_addr().expect("local_addr").port()
+}
+
+async fn spawn_node(node_id: u64) -> TestNode {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("raft.db");
+    let db = Arc::new(
+        Database::open(Some(path.to_str().unwrap()))
+            .await
+            .expect("open db"),
+    );
+    db.query(nauka_state::SCHEMA).await.expect("raft schema");
+    db.query(TEST_SCHEMA).await.expect("test schema");
+
+    let port = pick_free_port();
+    let addr = format!("127.0.0.1:{port}");
+
+    let raft = Arc::new(
+        RaftNode::new(node_id, db.clone(), None)
+            .await
+            .expect("raft node"),
+    );
+    raft.start_server(addr.clone()).await;
+
+    TestNode {
+        raft,
+        db,
+        addr,
+        _dir: dir,
+    }
+}
+
+async fn add_and_promote(leader: &RaftNode, node_id: u64, addr: &str) {
+    for attempt in 1..=10 {
+        match leader.add_learner(node_id, addr).await {
+            Ok(_) => break,
+            Err(e) if attempt < 10 => {
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                eprintln!("  test: add_learner retry {attempt}: {e}");
+            }
+            Err(e) => panic!("add_learner failed after retries: {e}"),
+        }
+    }
+    for attempt in 1..=10 {
+        match leader.promote_voter(node_id).await {
+            Ok(_) => return,
+            Err(e) if attempt < 10 => {
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                eprintln!("  test: promote_voter retry {attempt}: {e}");
+            }
+            Err(e) => panic!("promote_voter failed after retries: {e}"),
+        }
+    }
+}
+
+async fn poll_kv(db: &Database, key: &str, timeout: Duration) -> Option<Kv> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        let rows: Vec<Kv> = db
+            .query_take(&format!("SELECT key, value FROM kv WHERE key = '{key}'"))
+            .await
+            .unwrap_or_default();
+        if let Some(row) = rows.into_iter().next() {
+            return Some(row);
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    None
+}
+
+#[tokio::test]
+async fn write_replicates_to_all_nodes() {
+    let n1 = spawn_node(1).await;
+    let n2 = spawn_node(2).await;
+    let n3 = spawn_node(3).await;
+
+    n1.raft.init_cluster(&n1.addr).await.expect("init_cluster");
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    add_and_promote(&n1.raft, 2, &n2.addr).await;
+    add_and_promote(&n1.raft, 3, &n3.addr).await;
+
+    n1.raft
+        .write("CREATE kv SET key = 'hello', value = 'world'".into())
+        .await
+        .expect("write");
+
+    for (i, node) in [&n1, &n2, &n3].iter().enumerate() {
+        let row = poll_kv(&node.db, "hello", Duration::from_secs(5))
+            .await
+            .unwrap_or_else(|| panic!("record not replicated to node {}", i + 1));
+        assert_eq!(row.value, "world");
+    }
+}
+
+#[tokio::test]
+async fn invalid_surql_surfaces_error_to_caller() {
+    let n1 = spawn_node(10).await;
+    n1.raft.init_cluster(&n1.addr).await.expect("init_cluster");
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    n1.raft
+        .write("CREATE kv SET key = 'dup', value = '1'".into())
+        .await
+        .expect("first write");
+
+    let result = n1
+        .raft
+        .write("CREATE kv SET key = 'dup', value = '2'".into())
+        .await;
+
+    assert!(
+        result.is_err(),
+        "expected unique-constraint error to surface, got: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn followers_see_writes_committed_before_they_joined() {
+    let n1 = spawn_node(100).await;
+    n1.raft.init_cluster(&n1.addr).await.expect("init_cluster");
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    n1.raft
+        .write("CREATE kv SET key = 'early', value = '1'".into())
+        .await
+        .expect("early write");
+
+    let n2 = spawn_node(200).await;
+    add_and_promote(&n1.raft, 200, &n2.addr).await;
+
+    let row = poll_kv(&n2.db, "early", Duration::from_secs(5))
+        .await
+        .expect("late joiner missed the pre-join write");
+    assert_eq!(row.value, "1");
+}


### PR DESCRIPTION
Closes #311.

**Stacked on #316** (fix/312) — the error-propagation test needs `.check()` in `Database::query()` to actually error on statement failures.

## Summary

- New integration test file `layers/state/tests/raft_cluster.rs` with 3 scenarios against in-process 3-node clusters over loopback TCP
- `SurqlResponse` gains an `error: Option<String>` field; `state_machine::apply` returns `SurqlResponse::err(...)` on DB failure instead of masquerading as a blank response; `RaftNode::write` surfaces the error to the caller
- `applied_queries` is now only appended on successful apply, so snapshot replay doesn't re-run queries that never actually changed any node's DB state

## Tests

- `write_replicates_to_all_nodes` — leader write lands on all 3 follower DBs
- `invalid_surql_surfaces_error_to_caller` — duplicate UNIQUE insert returns Err from `raft.write()` (was silently reported as success)
- `followers_see_writes_committed_before_they_joined` — late joiner catches up via AppendEntries/snapshot

## Test plan

- [x] `cargo test` — 11/11 (6 log_store + 2 db + 3 raft_cluster)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Hetzner 2-node (`tests/test-issue-305.sh`) — init + join + `mesh down` + `mesh up` + voter promotion → PASS

## Notes on the state-machine change

Making `apply` return an error-carrying response is safe because SurrealDB DDL-free CREATE/UPDATE/DELETE statements are deterministic: if they fail on the leader they fail on every follower with the same error, so no state divergence is introduced. Non-deterministic schemas (e.g. `DEFAULT time::now()` on required fields) are a separate concern, outside #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)