### PR TITLE
test(#310): chaos test verifies functional consensus after recovery

### DIFF
--- a/layers/hypervisor/definition.surql
+++ b/layers/hypervisor/definition.surql
@@ -1,24 +1,24 @@
 -- Mesh identity and configuration (local to this node)
-DEFINE TABLE mesh SCHEMAFULL;
-DEFINE FIELD interface_name ON mesh TYPE string;
-DEFINE FIELD listen_port    ON mesh TYPE int;
-DEFINE FIELD mesh_id        ON mesh TYPE string;
-DEFINE FIELD private_key    ON mesh TYPE string;
-DEFINE FIELD ca_cert        ON mesh TYPE option<string>;
-DEFINE FIELD ca_key         ON mesh TYPE option<string>;
-DEFINE FIELD tls_cert       ON mesh TYPE option<string>;
-DEFINE FIELD tls_key        ON mesh TYPE option<string>;
-DEFINE FIELD created_at     ON mesh TYPE datetime DEFAULT time::now();
+DEFINE TABLE IF NOT EXISTS mesh SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS interface_name ON mesh TYPE string;
+DEFINE FIELD IF NOT EXISTS listen_port    ON mesh TYPE int;
+DEFINE FIELD IF NOT EXISTS mesh_id        ON mesh TYPE string;
+DEFINE FIELD IF NOT EXISTS private_key    ON mesh TYPE string;
+DEFINE FIELD IF NOT EXISTS ca_cert        ON mesh TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS ca_key         ON mesh TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS tls_cert       ON mesh TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS tls_key        ON mesh TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS created_at     ON mesh TYPE datetime DEFAULT time::now();
 
 -- Mesh hypervisors (replicated via Raft consensus)
-DEFINE TABLE hypervisor SCHEMAFULL;
-DEFINE FIELD public_key     ON hypervisor TYPE string;
-DEFINE FIELD node_id        ON hypervisor TYPE int;
-DEFINE FIELD address        ON hypervisor TYPE string;
-DEFINE FIELD endpoint       ON hypervisor TYPE option<string>;
-DEFINE FIELD allowed_ips    ON hypervisor TYPE array<string>;
-DEFINE FIELD keepalive      ON hypervisor TYPE option<int>;
-DEFINE FIELD raft_addr      ON hypervisor TYPE string;
-DEFINE FIELD joined_at      ON hypervisor TYPE datetime DEFAULT time::now();
+DEFINE TABLE IF NOT EXISTS hypervisor SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS public_key     ON hypervisor TYPE string;
+DEFINE FIELD IF NOT EXISTS node_id        ON hypervisor TYPE int;
+DEFINE FIELD IF NOT EXISTS address        ON hypervisor TYPE string;
+DEFINE FIELD IF NOT EXISTS endpoint       ON hypervisor TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS allowed_ips    ON hypervisor TYPE array<string>;
+DEFINE FIELD IF NOT EXISTS keepalive      ON hypervisor TYPE option<int>;
+DEFINE FIELD IF NOT EXISTS raft_addr      ON hypervisor TYPE string;
+DEFINE FIELD IF NOT EXISTS joined_at      ON hypervisor TYPE datetime DEFAULT time::now();
 
-DEFINE INDEX hypervisor_pubkey ON hypervisor FIELDS public_key UNIQUE;
+DEFINE INDEX IF NOT EXISTS hypervisor_pubkey ON hypervisor FIELDS public_key UNIQUE;

--- a/layers/hypervisor/src/daemon.rs
+++ b/layers/hypervisor/src/daemon.rs
@@ -195,13 +195,14 @@ pub async fn run_daemon_join(
         .await
         .map_err(|e| MeshError::State(e.to_string()))?;
     let _raft_server = raft_node.start_server(raft_addr).await;
+    let raft = Arc::new(raft_node);
 
     let db2 = db.clone();
     let iface = interface_name.clone();
     let own_pk2 = own_pk.clone();
 
     let listener_handle = tokio::spawn(mesh_listener(
-        None,
+        Some(raft),
         mesh.mesh_id().clone(),
         mesh.keypair().clone(),
         mesh.address().to_string(),
@@ -251,6 +252,7 @@ pub async fn run_daemon_restart(db: Arc<Database>) -> Result<(), MeshError> {
         .await
         .map_err(|e| MeshError::State(e.to_string()))?;
     let _raft_server = raft_node.start_server(raft_addr).await;
+    let raft = Arc::new(raft_node);
 
     let db2 = db.clone();
     let iface = state.interface_name.clone();
@@ -261,7 +263,7 @@ pub async fn run_daemon_restart(db: Arc<Database>) -> Result<(), MeshError> {
     });
 
     let listener_handle = tokio::spawn(mesh_listener(
-        None,
+        Some(raft),
         mesh.mesh_id().clone(),
         mesh.keypair().clone(),
         mesh.address().to_string(),

--- a/layers/state/definition.surql
+++ b/layers/state/definition.surql
@@ -1,19 +1,19 @@
 -- Raft consensus state (local to each node)
-DEFINE TABLE _raft_meta SCHEMAFULL;
-DEFINE FIELD hypervisor ON _raft_meta TYPE int;
-DEFINE FIELD vote       ON _raft_meta TYPE option<string>;
-DEFINE FIELD committed  ON _raft_meta TYPE option<string>;
-DEFINE FIELD purged     ON _raft_meta TYPE option<string>;
+DEFINE TABLE IF NOT EXISTS _raft_meta SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS hypervisor ON _raft_meta TYPE int;
+DEFINE FIELD IF NOT EXISTS vote       ON _raft_meta TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS committed  ON _raft_meta TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS purged     ON _raft_meta TYPE option<string>;
 
-DEFINE TABLE _raft_log SCHEMAFULL;
-DEFINE FIELD hypervisor ON _raft_log TYPE int;
-DEFINE FIELD log_index  ON _raft_log TYPE int;
-DEFINE FIELD entry      ON _raft_log TYPE string;
-DEFINE INDEX raft_log_idx ON _raft_log FIELDS hypervisor, log_index UNIQUE;
+DEFINE TABLE IF NOT EXISTS _raft_log SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS hypervisor ON _raft_log TYPE int;
+DEFINE FIELD IF NOT EXISTS log_index  ON _raft_log TYPE int;
+DEFINE FIELD IF NOT EXISTS entry      ON _raft_log TYPE string;
+DEFINE INDEX IF NOT EXISTS raft_log_idx ON _raft_log FIELDS hypervisor, log_index UNIQUE;
 
-DEFINE TABLE _raft_snapshot SCHEMAFULL;
-DEFINE FIELD hypervisor      ON _raft_snapshot TYPE int;
-DEFINE FIELD snapshot_id     ON _raft_snapshot TYPE string;
-DEFINE FIELD last_applied    ON _raft_snapshot TYPE option<string>;
-DEFINE FIELD last_membership ON _raft_snapshot TYPE string;
-DEFINE FIELD data            ON _raft_snapshot TYPE string;
+DEFINE TABLE IF NOT EXISTS _raft_snapshot SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS hypervisor      ON _raft_snapshot TYPE int;
+DEFINE FIELD IF NOT EXISTS snapshot_id     ON _raft_snapshot TYPE string;
+DEFINE FIELD IF NOT EXISTS last_applied    ON _raft_snapshot TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS last_membership ON _raft_snapshot TYPE string;
+DEFINE FIELD IF NOT EXISTS data            ON _raft_snapshot TYPE string;

--- a/layers/state/src/db.rs
+++ b/layers/state/src/db.rs
@@ -24,7 +24,7 @@ impl Database {
     }
 
     pub async fn query(&self, surql: &str) -> Result<(), StateError> {
-        self.db.query(surql).await?;
+        self.db.query(surql).await?.check()?;
         Ok(())
     }
 
@@ -38,5 +38,54 @@ impl Database {
 
     pub fn inner(&self) -> &Surreal<surrealdb::engine::local::Db> {
         &self.db
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn open_tmp() -> (Database, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        let db = Database::open(Some(path.to_str().unwrap())).await.unwrap();
+        (db, dir)
+    }
+
+    #[tokio::test]
+    async fn query_propagates_schema_violation() {
+        let (db, _dir) = open_tmp().await;
+        db.query(
+            "DEFINE TABLE t SCHEMAFULL; \
+             DEFINE FIELD name ON t TYPE string; \
+             DEFINE INDEX t_name ON t FIELDS name UNIQUE;",
+        )
+        .await
+        .unwrap();
+
+        db.query("CREATE t SET name = 'foo'").await.unwrap();
+        let result = db.query("CREATE t SET name = 'foo'").await;
+        assert!(
+            result.is_err(),
+            "expected unique-constraint error, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn query_propagates_missing_required_field() {
+        let (db, _dir) = open_tmp().await;
+        db.query(
+            "DEFINE TABLE t SCHEMAFULL; \
+             DEFINE FIELD name ON t TYPE string;",
+        )
+        .await
+        .unwrap();
+
+        // Missing required `name` field
+        let result = db.query("CREATE t SET other = 'x'").await;
+        assert!(
+            result.is_err(),
+            "expected schema-violation error, got: {result:?}"
+        );
     }
 }

--- a/layers/state/src/raft/mod.rs
+++ b/layers/state/src/raft/mod.rs
@@ -109,7 +109,11 @@ impl RaftNode {
             .client_write(SurqlCommand { query })
             .await
             .map_err(|e| StateError::Raft(format!("client_write: {e}")))?;
-        Ok(resp.response().clone())
+        let response = resp.response().clone();
+        if let Some(ref err) = response.error {
+            return Err(StateError::Raft(format!("state machine: {err}")));
+        }
+        Ok(response)
     }
 
     pub async fn start_server(&self, bind_addr: String) -> tokio::task::JoinHandle<()> {

--- a/layers/state/src/raft/state_machine.rs
+++ b/layers/state/src/raft/state_machine.rs
@@ -258,15 +258,15 @@ where
                 }
                 EntryPayload::Normal(cmd) => {
                     eprintln!("  sm: apply query: {}", cmd.query);
-                    inner.data.applied_queries.push(cmd.query.clone());
                     match self.db.query(&cmd.query).await {
                         Ok(_) => {
                             eprintln!("  sm: query OK");
+                            inner.data.applied_queries.push(cmd.query.clone());
                             SurqlResponse::ok()
                         }
                         Err(e) => {
                             eprintln!("  sm: query FAILED: {e}");
-                            SurqlResponse::none()
+                            SurqlResponse::err(e.to_string())
                         }
                     }
                 }

--- a/layers/state/src/raft/types.rs
+++ b/layers/state/src/raft/types.rs
@@ -23,14 +23,29 @@ impl fmt::Display for SurqlCommand {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SurqlResponse {
     pub success: bool,
+    #[serde(default)]
+    pub error: Option<String>,
 }
 
 impl SurqlResponse {
     pub fn ok() -> Self {
-        Self { success: true }
+        Self {
+            success: true,
+            error: None,
+        }
     }
 
     pub fn none() -> Self {
-        Self { success: false }
+        Self {
+            success: false,
+            error: None,
+        }
+    }
+
+    pub fn err(msg: impl Into<String>) -> Self {
+        Self {
+            success: false,
+            error: Some(msg.into()),
+        }
     }
 }

--- a/layers/state/tests/raft_cluster.rs
+++ b/layers/state/tests/raft_cluster.rs
@@ -1,0 +1,171 @@
+//! End-to-end integration tests for the Raft consensus layer.
+//!
+//! Spins up in-process 3-node clusters over loopback TCP and exercises
+//! `RaftNode::write` — the same path used by the daemon.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use nauka_state::{Database, RaftNode};
+use serde::Deserialize;
+use surrealdb::types::SurrealValue;
+
+const TEST_SCHEMA: &str = "\
+DEFINE TABLE IF NOT EXISTS kv SCHEMAFULL;\
+DEFINE FIELD IF NOT EXISTS key ON kv TYPE string;\
+DEFINE FIELD IF NOT EXISTS value ON kv TYPE string;\
+DEFINE INDEX IF NOT EXISTS kv_key ON kv FIELDS key UNIQUE;\
+";
+
+#[derive(Deserialize, SurrealValue, Debug)]
+struct Kv {
+    #[allow(dead_code)]
+    key: String,
+    value: String,
+}
+
+struct TestNode {
+    raft: Arc<RaftNode>,
+    db: Arc<Database>,
+    addr: String,
+    _dir: tempfile::TempDir,
+}
+
+fn pick_free_port() -> u16 {
+    let l = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    l.local_addr().expect("local_addr").port()
+}
+
+async fn spawn_node(node_id: u64) -> TestNode {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("raft.db");
+    let db = Arc::new(
+        Database::open(Some(path.to_str().unwrap()))
+            .await
+            .expect("open db"),
+    );
+    db.query(nauka_state::SCHEMA).await.expect("raft schema");
+    db.query(TEST_SCHEMA).await.expect("test schema");
+
+    let port = pick_free_port();
+    let addr = format!("127.0.0.1:{port}");
+
+    let raft = Arc::new(
+        RaftNode::new(node_id, db.clone(), None)
+            .await
+            .expect("raft node"),
+    );
+    raft.start_server(addr.clone()).await;
+
+    TestNode {
+        raft,
+        db,
+        addr,
+        _dir: dir,
+    }
+}
+
+async fn add_and_promote(leader: &RaftNode, node_id: u64, addr: &str) {
+    for attempt in 1..=10 {
+        match leader.add_learner(node_id, addr).await {
+            Ok(_) => break,
+            Err(e) if attempt < 10 => {
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                eprintln!("  test: add_learner retry {attempt}: {e}");
+            }
+            Err(e) => panic!("add_learner failed after retries: {e}"),
+        }
+    }
+    for attempt in 1..=10 {
+        match leader.promote_voter(node_id).await {
+            Ok(_) => return,
+            Err(e) if attempt < 10 => {
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                eprintln!("  test: promote_voter retry {attempt}: {e}");
+            }
+            Err(e) => panic!("promote_voter failed after retries: {e}"),
+        }
+    }
+}
+
+async fn poll_kv(db: &Database, key: &str, timeout: Duration) -> Option<Kv> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        let rows: Vec<Kv> = db
+            .query_take(&format!("SELECT key, value FROM kv WHERE key = '{key}'"))
+            .await
+            .unwrap_or_default();
+        if let Some(row) = rows.into_iter().next() {
+            return Some(row);
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    None
+}
+
+#[tokio::test]
+async fn write_replicates_to_all_nodes() {
+    let n1 = spawn_node(1).await;
+    let n2 = spawn_node(2).await;
+    let n3 = spawn_node(3).await;
+
+    n1.raft.init_cluster(&n1.addr).await.expect("init_cluster");
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    add_and_promote(&n1.raft, 2, &n2.addr).await;
+    add_and_promote(&n1.raft, 3, &n3.addr).await;
+
+    n1.raft
+        .write("CREATE kv SET key = 'hello', value = 'world'".into())
+        .await
+        .expect("write");
+
+    for (i, node) in [&n1, &n2, &n3].iter().enumerate() {
+        let row = poll_kv(&node.db, "hello", Duration::from_secs(5))
+            .await
+            .unwrap_or_else(|| panic!("record not replicated to node {}", i + 1));
+        assert_eq!(row.value, "world");
+    }
+}
+
+#[tokio::test]
+async fn invalid_surql_surfaces_error_to_caller() {
+    let n1 = spawn_node(10).await;
+    n1.raft.init_cluster(&n1.addr).await.expect("init_cluster");
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    n1.raft
+        .write("CREATE kv SET key = 'dup', value = '1'".into())
+        .await
+        .expect("first write");
+
+    let result = n1
+        .raft
+        .write("CREATE kv SET key = 'dup', value = '2'".into())
+        .await;
+
+    assert!(
+        result.is_err(),
+        "expected unique-constraint error to surface, got: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn followers_see_writes_committed_before_they_joined() {
+    let n1 = spawn_node(100).await;
+    n1.raft.init_cluster(&n1.addr).await.expect("init_cluster");
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    n1.raft
+        .write("CREATE kv SET key = 'early', value = '1'".into())
+        .await
+        .expect("early write");
+
+    let n2 = spawn_node(200).await;
+    add_and_promote(&n1.raft, 200, &n2.addr).await;
+
+    let row = poll_kv(&n2.db, "early", Duration::from_secs(5))
+        .await
+        .expect("late joiner missed the pre-join write");
+    assert_eq!(row.value, "1");
+}

--- a/tests/test-chaos-304.sh
+++ b/tests/test-chaos-304.sh
@@ -244,6 +244,62 @@ log "    final alive: $final_alive / $NODE_COUNT"
 [[ $final_alive -eq $NODE_COUNT ]] || die "some nodes died during recovery"
 ok "cluster fully recovered — $final_alive/$NODE_COUNT nodes alive"
 
+# ═══════════════════════════════════════════════════════════════════
+# CHAOS PHASE 4: functional consensus check
+# Prove the cluster can still do Raft writes post-recovery:
+# 1. remove a peer via CLI (issues DELETE hypervisor through Raft)
+# 2. verify every non-victim node's reconciler picks up the change
+# ═══════════════════════════════════════════════════════════════════
+log ""
+log "═══ CHAOS PHASE 4: functional consensus check ═══"
+
+VICTIM_IDX=$((NODE_COUNT - 1))
+VICTIM_IP=${IPS[$VICTIM_IDX]}
+VICTIM_PK=$(ssh_node "$VICTIM_IP" \
+    "grep -hoP 'public key:\s+\K\S+' /tmp/nauka.log /tmp/nauka-restart.log 2>/dev/null | head -1")
+[[ -n $VICTIM_PK ]] || die "could not read victim pubkey"
+log "  victim: node-$((VICTIM_IDX + 1)) ($VICTIM_IP) pk=$VICTIM_PK"
+
+# Raft writes must land on the leader; post-chaos the leader is whichever
+# node won the re-election, not necessarily node-1. Daemons today don't
+# forward to the leader (separate concern), so we try every non-victim
+# node until one — the leader — accepts.
+log "  ▶ nauka mesh peer remove (probing every node for the leader)"
+remove_ok=false
+for i in "${!IPS[@]}"; do
+    [[ $i -eq $VICTIM_IDX ]] && continue
+    ip=${IPS[$i]}
+    wait_port "$ip" 51821 2>/dev/null || continue
+    if ssh_node "$ip" "nauka mesh peer remove --public-key '$VICTIM_PK'" 2>&1 \
+        | tee -a "$RUN_DIR/remove-attempts.log" \
+        | grep -q '^peer removal requested'; then
+        ok "  peer remove accepted by node-$((i + 1)) (leader)"
+        remove_ok=true
+        break
+    fi
+done
+$remove_ok || die "no node accepted the peer-remove — Raft write rejected everywhere"
+
+# Each node's reconciler polls every 5s — give 2 cycles for apply+reconcile
+log "  waiting 12s for Raft apply + reconciler cycle..."
+sleep 12
+
+# Every non-victim node must have dropped the victim from its WG peer list.
+# The victim still sees its old peers — with its own record deleted, its
+# reconciler has nothing to diff against. Skipping the victim is intentional.
+log "  ▶ checking WG peer counts on non-victim nodes"
+expected=$((NODE_COUNT - 2))   # self already excluded; victim now excluded too
+for i in "${!IPS[@]}"; do
+    [[ $i -eq $VICTIM_IDX ]] && continue
+    ip=${IPS[$i]}
+    count=$(ssh_node "$ip" "nauka mesh status 2>/dev/null | grep -c ': Peer {'" \
+        2>/dev/null || echo -1)
+    log "    node-$((i + 1)): $count peers (want $expected)"
+    [[ $count -eq $expected ]] || \
+        die "node-$((i + 1)) still has $count peers after peer-remove (expected $expected)"
+done
+ok "post-recovery Raft write replicated to all $((NODE_COUNT - 1)) non-victim nodes"
+
 # ─── Collect logs ────────────────────────────────────────────────────
 log "▶ collecting logs"
 for i in "${!IPS[@]}"; do


### PR DESCRIPTION
Closes #310.

**Stacked on #317** (feat/311) → #316 (fix/312).

## Summary

- Chaos test grows a Phase 4 that does a real Raft write through the recovered cluster (`nauka mesh peer remove`) and asserts the delete reaches every non-victim node's WireGuard interface.
- One-line daemon fix: `run_daemon_join` and `run_daemon_restart` now hand their `RaftNode` to `mesh_listener` so post-restart daemons can actually service `remove_public_key` (they used to return `no raft`). Joins stay gated on the peering PIN, which restart still doesn't provide, so the peering surface isn't re-opened.

## Why the probe loop

The peer-remove CLI talks to the local daemon, which calls `raft.client_write` — this only succeeds on the leader. openraft returns a "has to forward to" hint on followers, but the daemon doesn't forward today. The test probes each non-victim node until it finds the one that accepts (the leader). Proper leader-aware writes belong to a follow-up issue.

## Test plan

- [x] `cargo test` — 11/11 (6 log_store + 2 db + 3 raft_cluster)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Hetzner 8-node chaos (`tests/test-chaos-304.sh`) — PASS
  - Phase 4 accepted by node-4 (post-restart leader, not node-1)
  - All 7 non-victim nodes' WG peer counts dropped 7 → 6

## Known follow-ups (not in scope)

- Peer-remove CLI / daemon don't forward to the leader (hence the probe loop).
- Victim's WG peer list is stale after its record is deleted — related to #315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)