### PR TITLE
feat(#314): explicit snapshot policy, tracing on build/purge, compaction test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,6 +2445,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2518,6 +2527,8 @@ dependencies = [
  "nauka-state",
  "serde_json",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2705,6 +2716,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4102,6 +4122,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4958,6 +4987,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -5258,6 +5317,12 @@ checksum = "4efba0434d5a0a62d4f22070b44ce055dc18cb64d4fa98276aa523dadfaba0e7"
 dependencies = [
  "anyerror",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vart"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ thiserror = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 surrealdb = { version = "3", default-features = false, features = ["kv-surrealkv"] }

--- a/bin/nauka/Cargo.toml
+++ b/bin/nauka/Cargo.toml
@@ -15,5 +15,7 @@ clap.workspace = true
 anyhow.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 nauka-hypervisor.workspace = true
 nauka-state.workspace = true

--- a/bin/nauka/src/main.rs
+++ b/bin/nauka/src/main.rs
@@ -9,6 +9,15 @@ use nauka_state::Database;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Init tracing. Defaults to `info` level; override via `RUST_LOG`.
+    // Output goes to stderr so it coexists with println! on stdout.
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .init();
+
     let app = Command::new("nauka")
         .about("Nauka — turn dedicated servers into a programmable cloud")
         .version(option_env!("NAUKA_VERSION").unwrap_or(env!("CARGO_PKG_VERSION")))

--- a/layers/hypervisor/definition.surql
+++ b/layers/hypervisor/definition.surql
@@ -1,24 +1,24 @@
 -- Mesh identity and configuration (local to this node)
-DEFINE TABLE mesh SCHEMAFULL;
-DEFINE FIELD interface_name ON mesh TYPE string;
-DEFINE FIELD listen_port    ON mesh TYPE int;
-DEFINE FIELD mesh_id        ON mesh TYPE string;
-DEFINE FIELD private_key    ON mesh TYPE string;
-DEFINE FIELD ca_cert        ON mesh TYPE option<string>;
-DEFINE FIELD ca_key         ON mesh TYPE option<string>;
-DEFINE FIELD tls_cert       ON mesh TYPE option<string>;
-DEFINE FIELD tls_key        ON mesh TYPE option<string>;
-DEFINE FIELD created_at     ON mesh TYPE datetime DEFAULT time::now();
+DEFINE TABLE IF NOT EXISTS mesh SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS interface_name ON mesh TYPE string;
+DEFINE FIELD IF NOT EXISTS listen_port    ON mesh TYPE int;
+DEFINE FIELD IF NOT EXISTS mesh_id        ON mesh TYPE string;
+DEFINE FIELD IF NOT EXISTS private_key    ON mesh TYPE string;
+DEFINE FIELD IF NOT EXISTS ca_cert        ON mesh TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS ca_key         ON mesh TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS tls_cert       ON mesh TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS tls_key        ON mesh TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS created_at     ON mesh TYPE datetime DEFAULT time::now();
 
 -- Mesh hypervisors (replicated via Raft consensus)
-DEFINE TABLE hypervisor SCHEMAFULL;
-DEFINE FIELD public_key     ON hypervisor TYPE string;
-DEFINE FIELD node_id        ON hypervisor TYPE int;
-DEFINE FIELD address        ON hypervisor TYPE string;
-DEFINE FIELD endpoint       ON hypervisor TYPE option<string>;
-DEFINE FIELD allowed_ips    ON hypervisor TYPE array<string>;
-DEFINE FIELD keepalive      ON hypervisor TYPE option<int>;
-DEFINE FIELD raft_addr      ON hypervisor TYPE string;
-DEFINE FIELD joined_at      ON hypervisor TYPE datetime DEFAULT time::now();
+DEFINE TABLE IF NOT EXISTS hypervisor SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS public_key     ON hypervisor TYPE string;
+DEFINE FIELD IF NOT EXISTS node_id        ON hypervisor TYPE int;
+DEFINE FIELD IF NOT EXISTS address        ON hypervisor TYPE string;
+DEFINE FIELD IF NOT EXISTS endpoint       ON hypervisor TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS allowed_ips    ON hypervisor TYPE array<string>;
+DEFINE FIELD IF NOT EXISTS keepalive      ON hypervisor TYPE option<int>;
+DEFINE FIELD IF NOT EXISTS raft_addr      ON hypervisor TYPE string;
+DEFINE FIELD IF NOT EXISTS joined_at      ON hypervisor TYPE datetime DEFAULT time::now();
 
-DEFINE INDEX hypervisor_pubkey ON hypervisor FIELDS public_key UNIQUE;
+DEFINE INDEX IF NOT EXISTS hypervisor_pubkey ON hypervisor FIELDS public_key UNIQUE;

--- a/layers/hypervisor/src/daemon.rs
+++ b/layers/hypervisor/src/daemon.rs
@@ -1,3 +1,4 @@
+use std::str::FromStr;
 use std::sync::Arc;
 
 use nauka_state::{node_id_from_key, Database, RaftNode, TlsConfig};
@@ -161,19 +162,39 @@ pub async fn run_daemon_join(
 
     let tls = build_tls(&state);
 
-    // Save bootstrap hypervisors to local DB so reconciler picks them up
+    // Save bootstrap hypervisors to local DB so reconciler picks them up.
+    // Validate every field before interpolating — the bootstrap server is
+    // trusted by the PIN, but we still refuse to pass un-parseable strings
+    // into SurQL.
     for p in &bootstrap_peers {
+        let canonical_pk = match defguard_wireguard_rs::key::Key::from_str(&p.public_key) {
+            Ok(k) => k.to_string(),
+            Err(_) => {
+                eprintln!("  ! bootstrap peer: invalid public_key, skipping");
+                continue;
+            }
+        };
+        let endpoint: std::net::SocketAddr = match p.endpoint.parse() {
+            Ok(a) => a,
+            Err(_) => {
+                eprintln!("  ! bootstrap peer {canonical_pk}: invalid endpoint, skipping");
+                continue;
+            }
+        };
+        let mesh_addr_mask: defguard_wireguard_rs::net::IpAddrMask = match p.mesh_address.parse() {
+            Ok(m) => m,
+            Err(_) => {
+                eprintln!("  ! bootstrap peer {canonical_pk}: invalid mesh_address, skipping");
+                continue;
+            }
+        };
         let surql = format!(
             "CREATE hypervisor SET \
-             public_key = '{}', node_id = {}, address = '{}', \
-             endpoint = '{}', allowed_ips = ['{}'], keepalive = 25, \
-             raft_addr = '[{}]:4001'",
-            p.public_key,
-            node_id_from_key(&p.public_key) as i64,
-            p.mesh_address,
-            p.endpoint,
-            p.mesh_address,
-            p.mesh_address.split('/').next().unwrap_or(""),
+             public_key = '{canonical_pk}', node_id = {node_id}, address = '{mesh_addr_mask}', \
+             endpoint = '{endpoint}', allowed_ips = ['{mesh_addr_mask}'], keepalive = 25, \
+             raft_addr = '[{ip}]:4001'",
+            node_id = node_id_from_key(&canonical_pk) as i64,
+            ip = mesh_addr_mask.address,
         );
         let _ = db.query(&surql).await;
     }

--- a/layers/hypervisor/src/daemon.rs
+++ b/layers/hypervisor/src/daemon.rs
@@ -195,13 +195,14 @@ pub async fn run_daemon_join(
         .await
         .map_err(|e| MeshError::State(e.to_string()))?;
     let _raft_server = raft_node.start_server(raft_addr).await;
+    let raft = Arc::new(raft_node);
 
     let db2 = db.clone();
     let iface = interface_name.clone();
     let own_pk2 = own_pk.clone();
 
     let listener_handle = tokio::spawn(mesh_listener(
-        None,
+        Some(raft),
         mesh.mesh_id().clone(),
         mesh.keypair().clone(),
         mesh.address().to_string(),
@@ -251,6 +252,7 @@ pub async fn run_daemon_restart(db: Arc<Database>) -> Result<(), MeshError> {
         .await
         .map_err(|e| MeshError::State(e.to_string()))?;
     let _raft_server = raft_node.start_server(raft_addr).await;
+    let raft = Arc::new(raft_node);
 
     let db2 = db.clone();
     let iface = state.interface_name.clone();
@@ -261,7 +263,7 @@ pub async fn run_daemon_restart(db: Arc<Database>) -> Result<(), MeshError> {
     });
 
     let listener_handle = tokio::spawn(mesh_listener(
-        None,
+        Some(raft),
         mesh.mesh_id().clone(),
         mesh.keypair().clone(),
         mesh.address().to_string(),

--- a/layers/hypervisor/src/daemon.rs
+++ b/layers/hypervisor/src/daemon.rs
@@ -1,15 +1,24 @@
+use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use nauka_state::{node_id_from_key, Database, RaftNode, TlsConfig};
+use serde::Deserialize;
+use surrealdb::types::SurrealValue;
 use tokio::signal;
 
 use crate::mesh::{
-    certs, generate_pin, join_mesh, mesh_listener, KeyPair, Mesh, MeshError, MeshId, MeshState,
-    DEFAULT_JOIN_PORT,
+    certs, generate_pin, join_mesh, mesh_listener, whoami, KeyPair, Mesh, MeshError, MeshId,
+    MeshState, DEFAULT_JOIN_PORT,
 };
 
 use crate::mesh::reconciler;
+
+#[derive(Deserialize, SurrealValue)]
+struct EndpointRow {
+    endpoint: Option<String>,
+}
 
 pub struct DaemonConfig {
     pub interface_name: String,
@@ -284,7 +293,7 @@ pub async fn run_daemon_restart(db: Arc<Database>) -> Result<(), MeshError> {
     });
 
     let listener_handle = tokio::spawn(mesh_listener(
-        Some(raft),
+        Some(raft.clone()),
         mesh.mesh_id().clone(),
         mesh.keypair().clone(),
         mesh.address().to_string(),
@@ -296,14 +305,120 @@ pub async fn run_daemon_restart(db: Arc<Database>) -> Result<(), MeshError> {
         state.ca_key,
     ));
 
+    let refresh_handle = tokio::spawn(refresh_own_endpoint(
+        db.clone(),
+        raft.clone(),
+        own_pk.clone(),
+        state.listen_port,
+    ));
+
     println!("\n  ctrl+c to stop\n");
     signal::ctrl_c().await.map_err(|e| MeshError::State(e.to_string()))?;
 
     listener_handle.abort();
     reconciler_handle.abort();
+    refresh_handle.abort();
     mesh.down()?;
     println!("\ndaemon stopped (state preserved)");
     Ok(())
+}
+
+/// Discover our public endpoint via `whoami` to a peer, then, if it differs
+/// from what's currently in the hypervisor table, UPDATE via Raft so every
+/// node's reconciler can refresh its WG peer endpoint for us.
+///
+/// Runs in a background task after `run_daemon_restart` brings Raft up,
+/// because restart is the only flow where our IP might have changed while
+/// peers still hold the old one.
+async fn refresh_own_endpoint(
+    db: Arc<Database>,
+    raft: Arc<RaftNode>,
+    own_pk: String,
+    listen_port: u16,
+) {
+    // Let Raft elect a leader before we try to write.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Find a peer with a known public endpoint.
+    let peer_ip = match pick_peer_ip(&db, &own_pk).await {
+        Ok(Some(ip)) => ip,
+        Ok(None) => {
+            eprintln!("  endpoint refresh: no peer with endpoint yet — skipping");
+            return;
+        }
+        Err(e) => {
+            eprintln!("  endpoint refresh: pick peer failed: {e}");
+            return;
+        }
+    };
+
+    // Ask the peer what IP it sees us on.
+    let observed_ip = match whoami(&peer_ip, DEFAULT_JOIN_PORT).await {
+        Ok(ip) => ip,
+        Err(e) => {
+            eprintln!("  endpoint refresh: whoami {peer_ip} failed: {e}");
+            return;
+        }
+    };
+    let new_endpoint = SocketAddr::new(observed_ip, listen_port).to_string();
+
+    // Compare with the value currently in the table.
+    let current_ep = match read_own_endpoint(&db, &own_pk).await {
+        Ok(ep) => ep,
+        Err(e) => {
+            eprintln!("  endpoint refresh: read own endpoint failed: {e}");
+            return;
+        }
+    };
+    if current_ep.as_deref() == Some(new_endpoint.as_str()) {
+        println!("  endpoint refresh: {new_endpoint} (unchanged)");
+        return;
+    }
+
+    println!(
+        "  endpoint refresh: {:?} -> {new_endpoint}",
+        current_ep.as_deref().unwrap_or("NONE")
+    );
+    let surql = format!(
+        "UPDATE hypervisor SET endpoint = '{new_endpoint}' WHERE public_key = '{own_pk}'"
+    );
+    match raft.write(surql).await {
+        Ok(_) => println!("  endpoint refresh: propagated via Raft"),
+        Err(e) => eprintln!("  endpoint refresh: raft write failed: {e}"),
+    }
+}
+
+async fn pick_peer_ip(db: &Database, own_pk: &str) -> Result<Option<String>, MeshError> {
+    #[derive(Deserialize, SurrealValue)]
+    struct PeerRow {
+        public_key: String,
+        endpoint: Option<String>,
+    }
+    let peers: Vec<PeerRow> = db
+        .query_take("SELECT public_key, endpoint FROM hypervisor")
+        .await
+        .map_err(|e| MeshError::State(e.to_string()))?;
+    for p in peers {
+        if p.public_key == own_pk {
+            continue;
+        }
+        if let Some(ep) = p.endpoint {
+            if let Ok(sa) = ep.parse::<SocketAddr>() {
+                return Ok(Some(sa.ip().to_string()));
+            }
+        }
+    }
+    Ok(None)
+}
+
+async fn read_own_endpoint(db: &Database, own_pk: &str) -> Result<Option<String>, MeshError> {
+    let rows: Vec<EndpointRow> = db
+        .query_take(&format!(
+            "SELECT endpoint FROM hypervisor WHERE public_key = '{own_pk}'"
+        ))
+        .await
+        .map_err(|e| MeshError::State(e.to_string()))?;
+    Ok(rows.into_iter().next().and_then(|r| r.endpoint))
 }
 
 /// Explicit teardown — removes state from DB

--- a/layers/hypervisor/src/mesh/join.rs
+++ b/layers/hypervisor/src/mesh/join.rs
@@ -253,16 +253,27 @@ async fn handle_connection(
         let req: RemoveRequest =
             serde_json::from_value(v).map_err(|e| MeshError::Join(e.to_string()))?;
 
+        // Parse as a WireGuard key to reject anything that isn't a pubkey
+        // (including SurQL-breaking characters) before touching the DB.
+        let canonical_pk = match Key::from_str(&req.remove_public_key) {
+            Ok(k) => k.to_string(),
+            Err(_) => {
+                let _ = writer
+                    .write_all(b"{\"error\":\"invalid public key\"}\n")
+                    .await;
+                return Err(MeshError::InvalidKey);
+            }
+        };
+
         let surql = format!(
-            "DELETE hypervisor WHERE public_key = '{}'",
-            req.remove_public_key
+            "DELETE hypervisor WHERE public_key = '{canonical_pk}'"
         );
         if let Err(e) = raft.write(surql).await {
             eprintln!("  ! raft remove failed: {e}");
             let _ = writer.write_all(b"{\"error\":\"raft write failed\"}\n").await;
         } else {
             let _ = writer.write_all(b"{\"ok\":true}\n").await;
-            println!("  - peer removed: {}", req.remove_public_key);
+            println!("  - peer removed: {canonical_pk}");
         }
     }
 
@@ -373,4 +384,48 @@ pub fn request_peer_removal(join_port: u16, public_key: &str) -> Result<(), Mesh
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The validation in handle_connection (remove path) relies on
+    // `Key::from_str` to reject anything that isn't a canonical WireGuard
+    // public key before the value enters a SurQL literal. These tests lock
+    // in that assumption — if the key crate ever starts accepting looser
+    // inputs, the `DELETE hypervisor WHERE public_key = '...'` path would
+    // become injectable again.
+    const VALID_WG_PUBKEY: &str = "PQgVf+YiO+S7LTaOqtGSEUxXpmEb5hPEb+g5mTwQdC0=";
+
+    #[test]
+    fn key_from_str_rejects_surql_injection() {
+        let attacks = [
+            "'; DROP TABLE hypervisor; --",
+            "' OR 1=1; --",
+            "abc'; DELETE hypervisor; '",
+            "\"injected\"",
+            "", // empty
+            "not base64 at all",
+        ];
+        for a in attacks {
+            assert!(
+                Key::from_str(a).is_err(),
+                "Key::from_str should reject {a:?} but accepted it"
+            );
+        }
+    }
+
+    #[test]
+    fn key_from_str_accepts_canonical_pubkey_and_roundtrips() {
+        let k = Key::from_str(VALID_WG_PUBKEY).expect("valid pubkey should parse");
+        assert_eq!(k.to_string(), VALID_WG_PUBKEY);
+    }
+
+    #[test]
+    fn key_from_str_rejects_wrong_length_base64() {
+        // Valid base64 but wrong size for a 32-byte WG key.
+        assert!(Key::from_str("dGVzdA==").is_err()); // 4 bytes
+        assert!(Key::from_str("AA==").is_err()); // 1 byte
+    }
 }

--- a/layers/hypervisor/src/mesh/join.rs
+++ b/layers/hypervisor/src/mesh/join.rs
@@ -153,7 +153,14 @@ async fn handle_connection(
     let v: serde_json::Value =
         serde_json::from_str(&line).map_err(|e| MeshError::Join(e.to_string()))?;
 
-    if v.get("pin").is_some() {
+    if v.get("whoami").is_some() {
+        // --- Observability: tell the caller what public IP we see them on.
+        // Used by restarted nodes to detect their current public address
+        // without depending on external STUN-like services.
+        let resp = format!("{{\"observed_ip\":\"{}\"}}\n", peer_addr.ip());
+        let _ = writer.write_all(resp.as_bytes()).await;
+        return Ok(());
+    } else if v.get("pin").is_some() {
         // --- Join request ---
         let pin = peering_pin.ok_or_else(|| MeshError::Join("peering not enabled".into()))?;
         let raft = raft.as_ref().ok_or_else(|| MeshError::Join("no raft".into()))?;
@@ -361,6 +368,36 @@ pub fn join_mesh(
     };
 
     Ok((mesh, all_peers, tls_certs))
+}
+
+/// Ask a remote peer what IP it observes us on. Used by restart flow to
+/// learn our current public endpoint without an external STUN-like service.
+pub async fn whoami(peer_ip: &str, join_port: u16) -> Result<std::net::IpAddr, MeshError> {
+    use tokio::io::AsyncBufReadExt as _;
+    use tokio::net::TcpStream;
+    let addr = format!("{peer_ip}:{join_port}");
+    let stream = TcpStream::connect(&addr)
+        .await
+        .map_err(|e| MeshError::Join(format!("whoami connect {addr}: {e}")))?;
+    let (reader, mut writer) = stream.into_split();
+    tokio::io::AsyncWriteExt::write_all(&mut writer, b"{\"whoami\":true}\n")
+        .await
+        .map_err(|e| MeshError::Join(format!("whoami write: {e}")))?;
+    let mut lines = tokio::io::BufReader::new(reader).lines();
+    let line = lines
+        .next_line()
+        .await
+        .map_err(|e| MeshError::Join(format!("whoami read: {e}")))?
+        .ok_or_else(|| MeshError::Join("whoami empty response".into()))?;
+    let v: serde_json::Value = serde_json::from_str(&line)
+        .map_err(|e| MeshError::Join(format!("whoami parse: {e}")))?;
+    let ip_str = v
+        .get("observed_ip")
+        .and_then(|x| x.as_str())
+        .ok_or_else(|| MeshError::Join("whoami: missing observed_ip".into()))?;
+    ip_str
+        .parse()
+        .map_err(|_| MeshError::Join(format!("whoami: invalid ip {ip_str}")))
 }
 
 /// Send a remove-peer command to the local daemon

--- a/layers/hypervisor/src/mesh/mod.rs
+++ b/layers/hypervisor/src/mesh/mod.rs
@@ -11,8 +11,8 @@ mod state;
 pub use address::MeshId;
 pub use error::MeshError;
 pub use join::{
-    generate_pin, join_mesh, mesh_listener, request_peer_removal, PeerInfo, DEFAULT_JOIN_PORT,
-    DEFAULT_PEERING_TIMEOUT,
+    generate_pin, join_mesh, mesh_listener, request_peer_removal, whoami, PeerInfo,
+    DEFAULT_JOIN_PORT, DEFAULT_PEERING_TIMEOUT,
 };
 pub use key::KeyPair;
 pub use peer::MeshPeer;

--- a/layers/hypervisor/src/mesh/reconciler.rs
+++ b/layers/hypervisor/src/mesh/reconciler.rs
@@ -34,24 +34,30 @@ async fn reconcile(
 
     let api = WGApi::<Kernel>::new(interface_name.to_string())?;
     let host = api.read_interface_data()?;
-    let wg_keys: std::collections::HashSet<String> =
-        host.peers.keys().map(|k| k.to_string()).collect();
 
     let db_keys: std::collections::HashSet<String> =
         db_hypervisors.iter().map(|p| p.public_key.clone()).collect();
 
-    // Add hypervisors in DB but not in WG
+    // Add hypervisors in DB but not in WG, or update WG peers whose endpoint
+    // no longer matches the DB record (happens after another node restarts
+    // with a new public IP).
     for record in &db_hypervisors {
         if record.public_key == own_public_key {
-            continue;
-        }
-        if wg_keys.contains(&record.public_key) {
             continue;
         }
 
         let Ok(key) = defguard_wireguard_rs::key::Key::from_str(&record.public_key) else {
             continue;
         };
+
+        let existing = host.peers.get(&key);
+        let wg_endpoint_str = existing
+            .and_then(|p| p.endpoint)
+            .map(|e| e.to_string());
+        if existing.is_some() && wg_endpoint_str == record.endpoint {
+            continue; // already configured with the right endpoint
+        }
+
         let mut peer = defguard_wireguard_rs::peer::Peer::new(key);
         if let Some(ref ep) = record.endpoint {
             let _ = peer.set_endpoint(ep);
@@ -64,7 +70,11 @@ async fn reconcile(
         }
         if api.configure_peer(&peer).is_ok() {
             let _ = api.configure_peer_routing(&[peer]);
-            eprintln!("  reconciler: +peer {}", record.public_key);
+            let verb = if existing.is_some() { "update" } else { "add" };
+            eprintln!(
+                "  reconciler: {verb} peer {} endpoint={:?}",
+                record.public_key, record.endpoint
+            );
         }
     }
 

--- a/layers/state/definition.surql
+++ b/layers/state/definition.surql
@@ -1,19 +1,19 @@
 -- Raft consensus state (local to each node)
-DEFINE TABLE _raft_meta SCHEMAFULL;
-DEFINE FIELD hypervisor ON _raft_meta TYPE int;
-DEFINE FIELD vote       ON _raft_meta TYPE option<string>;
-DEFINE FIELD committed  ON _raft_meta TYPE option<string>;
-DEFINE FIELD purged     ON _raft_meta TYPE option<string>;
+DEFINE TABLE IF NOT EXISTS _raft_meta SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS hypervisor ON _raft_meta TYPE int;
+DEFINE FIELD IF NOT EXISTS vote       ON _raft_meta TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS committed  ON _raft_meta TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS purged     ON _raft_meta TYPE option<string>;
 
-DEFINE TABLE _raft_log SCHEMAFULL;
-DEFINE FIELD hypervisor ON _raft_log TYPE int;
-DEFINE FIELD log_index  ON _raft_log TYPE int;
-DEFINE FIELD entry      ON _raft_log TYPE string;
-DEFINE INDEX raft_log_idx ON _raft_log FIELDS hypervisor, log_index UNIQUE;
+DEFINE TABLE IF NOT EXISTS _raft_log SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS hypervisor ON _raft_log TYPE int;
+DEFINE FIELD IF NOT EXISTS log_index  ON _raft_log TYPE int;
+DEFINE FIELD IF NOT EXISTS entry      ON _raft_log TYPE string;
+DEFINE INDEX IF NOT EXISTS raft_log_idx ON _raft_log FIELDS hypervisor, log_index UNIQUE;
 
-DEFINE TABLE _raft_snapshot SCHEMAFULL;
-DEFINE FIELD hypervisor      ON _raft_snapshot TYPE int;
-DEFINE FIELD snapshot_id     ON _raft_snapshot TYPE string;
-DEFINE FIELD last_applied    ON _raft_snapshot TYPE option<string>;
-DEFINE FIELD last_membership ON _raft_snapshot TYPE string;
-DEFINE FIELD data            ON _raft_snapshot TYPE string;
+DEFINE TABLE IF NOT EXISTS _raft_snapshot SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS hypervisor      ON _raft_snapshot TYPE int;
+DEFINE FIELD IF NOT EXISTS snapshot_id     ON _raft_snapshot TYPE string;
+DEFINE FIELD IF NOT EXISTS last_applied    ON _raft_snapshot TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS last_membership ON _raft_snapshot TYPE string;
+DEFINE FIELD IF NOT EXISTS data            ON _raft_snapshot TYPE string;

--- a/layers/state/src/db.rs
+++ b/layers/state/src/db.rs
@@ -24,7 +24,7 @@ impl Database {
     }
 
     pub async fn query(&self, surql: &str) -> Result<(), StateError> {
-        self.db.query(surql).await?;
+        self.db.query(surql).await?.check()?;
         Ok(())
     }
 
@@ -38,5 +38,54 @@ impl Database {
 
     pub fn inner(&self) -> &Surreal<surrealdb::engine::local::Db> {
         &self.db
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn open_tmp() -> (Database, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        let db = Database::open(Some(path.to_str().unwrap())).await.unwrap();
+        (db, dir)
+    }
+
+    #[tokio::test]
+    async fn query_propagates_schema_violation() {
+        let (db, _dir) = open_tmp().await;
+        db.query(
+            "DEFINE TABLE t SCHEMAFULL; \
+             DEFINE FIELD name ON t TYPE string; \
+             DEFINE INDEX t_name ON t FIELDS name UNIQUE;",
+        )
+        .await
+        .unwrap();
+
+        db.query("CREATE t SET name = 'foo'").await.unwrap();
+        let result = db.query("CREATE t SET name = 'foo'").await;
+        assert!(
+            result.is_err(),
+            "expected unique-constraint error, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn query_propagates_missing_required_field() {
+        let (db, _dir) = open_tmp().await;
+        db.query(
+            "DEFINE TABLE t SCHEMAFULL; \
+             DEFINE FIELD name ON t TYPE string;",
+        )
+        .await
+        .unwrap();
+
+        // Missing required `name` field
+        let result = db.query("CREATE t SET other = 'x'").await;
+        assert!(
+            result.is_err(),
+            "expected schema-violation error, got: {result:?}"
+        );
     }
 }

--- a/layers/state/src/raft/log_store.rs
+++ b/layers/state/src/raft/log_store.rs
@@ -331,6 +331,11 @@ mod impl_log_store {
 
             let json = serde_json::to_string(&log_id)
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            tracing::info!(
+                node_id = self.node_id,
+                up_to_index = idx,
+                "raft: purged log entries"
+            );
             self.update_meta_field("purged", &json).await
         }
 

--- a/layers/state/src/raft/mod.rs
+++ b/layers/state/src/raft/mod.rs
@@ -12,6 +12,7 @@ use openraft::error::{ClientWriteError, ForwardToLeader, RaftError};
 use openraft::BasicNode;
 use openraft::ChangeMembers;
 use openraft::Config;
+use openraft::SnapshotPolicy;
 use rustls::pki_types::ServerName;
 use tokio::net::TcpStream;
 
@@ -25,6 +26,13 @@ use self::tls::{TlsConfig, RAFT_TLS_SAN};
 use self::types::{SurqlCommand, SurqlResponse, TypeConfig};
 
 pub type Raft = openraft::Raft<TypeConfig, StateMachineStore<TypeConfig>>;
+
+/// How many committed log entries accumulate before a snapshot is built
+/// and the preceding log entries are purged from SurrealDB. Tuned for a
+/// cluster with mostly-idle steady-state writes (joins/removes/endpoint
+/// refreshes) — fast enough that a new follower doesn't stream forever
+/// to catch up, slow enough that we aren't snapshotting constantly.
+pub const SNAPSHOT_THRESHOLD: u64 = 1000;
 
 pub fn node_id_from_key(public_key: &str) -> u64 {
     let bytes = public_key.as_bytes();
@@ -47,10 +55,27 @@ impl RaftNode {
         db: Arc<Database>,
         tls: Option<TlsConfig>,
     ) -> Result<Self, StateError> {
+        Self::new_with_snapshot_threshold(node_id, db, tls, SNAPSHOT_THRESHOLD).await
+    }
+
+    /// Test-friendly constructor that accepts an arbitrary snapshot
+    /// threshold. Production callers should use `new` and inherit
+    /// `SNAPSHOT_THRESHOLD`.
+    pub async fn new_with_snapshot_threshold(
+        node_id: u64,
+        db: Arc<Database>,
+        tls: Option<TlsConfig>,
+        snapshot_threshold: u64,
+    ) -> Result<Self, StateError> {
         let config = Config {
             heartbeat_interval: 500,
             election_timeout_min: 1500,
             election_timeout_max: 3000,
+            snapshot_policy: SnapshotPolicy::LogsSinceLast(snapshot_threshold),
+            // Keep one snapshot-window worth of logs around past the most
+            // recent snapshot so a catching-up follower can stream from log
+            // instead of downloading a fresh snapshot every time.
+            max_in_snapshot_log_to_keep: snapshot_threshold,
             ..Default::default()
         };
         let config = Arc::new(

--- a/layers/state/src/raft/mod.rs
+++ b/layers/state/src/raft/mod.rs
@@ -8,17 +8,20 @@ pub mod types;
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
+use openraft::error::{ClientWriteError, ForwardToLeader, RaftError};
 use openraft::BasicNode;
 use openraft::ChangeMembers;
 use openraft::Config;
+use rustls::pki_types::ServerName;
+use tokio::net::TcpStream;
 
 use crate::db::Database;
 use crate::StateError;
 
 use self::log_store::LogStore;
-use self::network::NetworkFactory;
+use self::network::{rpc_over, NetworkFactory};
 use self::state_machine::StateMachineStore;
-use self::tls::TlsConfig;
+use self::tls::{TlsConfig, RAFT_TLS_SAN};
 use self::types::{SurqlCommand, SurqlResponse, TypeConfig};
 
 pub type Raft = openraft::Raft<TypeConfig, StateMachineStore<TypeConfig>>;
@@ -102,16 +105,58 @@ impl RaftNode {
     }
 
     /// Write a SurrealQL command through Raft consensus.
-    /// Replicates to all nodes before returning.
+    /// On a follower, forwards to the current leader over the Raft RPC
+    /// channel (reusing the same mTLS) and returns the leader's response.
     pub async fn write(&self, query: String) -> Result<SurqlResponse, StateError> {
-        let resp = self
-            .raft
-            .client_write(SurqlCommand { query })
+        let cmd = SurqlCommand { query };
+        match self.raft.client_write(cmd.clone()).await {
+            Ok(resp) => {
+                let response = resp.response().clone();
+                if let Some(ref err) = response.error {
+                    return Err(StateError::Raft(format!("state machine: {err}")));
+                }
+                Ok(response)
+            }
+            Err(RaftError::APIError(ClientWriteError::ForwardToLeader(ftl))) => {
+                self.forward_write(&ftl, cmd).await
+            }
+            Err(e) => Err(StateError::Raft(format!("client_write: {e}"))),
+        }
+    }
+
+    async fn forward_write(
+        &self,
+        ftl: &ForwardToLeader<TypeConfig>,
+        cmd: SurqlCommand,
+    ) -> Result<SurqlResponse, StateError> {
+        let Some(ref leader) = ftl.leader_node else {
+            return Err(StateError::Raft("no leader elected yet".into()));
+        };
+        let addr = leader.addr.clone();
+
+        let tcp = TcpStream::connect(&addr)
             .await
-            .map_err(|e| StateError::Raft(format!("client_write: {e}")))?;
-        let response = resp.response().clone();
+            .map_err(|e| StateError::Network(format!("connect leader {addr}: {e}")))?;
+
+        let response: SurqlResponse = if let Some(ref tls) = self.tls {
+            let server_name = ServerName::try_from(RAFT_TLS_SAN)
+                .map_err(|e| StateError::Network(e.to_string()))?;
+            let connector = tokio_rustls::TlsConnector::from(tls.client.clone());
+            let stream = connector
+                .connect(server_name, tcp)
+                .await
+                .map_err(|e| StateError::Network(e.to_string()))?;
+            rpc_over(stream, "app_write", &cmd)
+                .await
+                .map_err(|e| StateError::Raft(format!("forward to {addr}: {e}")))?
+        } else {
+            rpc_over(tcp, "app_write", &cmd)
+                .await
+                .map_err(|e| StateError::Raft(format!("forward to {addr}: {e}")))?
+        };
+
         if let Some(ref err) = response.error {
-            return Err(StateError::Raft(format!("state machine: {err}")));
+            return Err(StateError::Raft(format!("state machine (leader): {err}")));
         }
         Ok(response)
     }

--- a/layers/state/src/raft/mod.rs
+++ b/layers/state/src/raft/mod.rs
@@ -109,7 +109,11 @@ impl RaftNode {
             .client_write(SurqlCommand { query })
             .await
             .map_err(|e| StateError::Raft(format!("client_write: {e}")))?;
-        Ok(resp.response().clone())
+        let response = resp.response().clone();
+        if let Some(ref err) = response.error {
+            return Err(StateError::Raft(format!("state machine: {err}")));
+        }
+        Ok(response)
     }
 
     pub async fn start_server(&self, bind_addr: String) -> tokio::task::JoinHandle<()> {

--- a/layers/state/src/raft/network.rs
+++ b/layers/state/src/raft/network.rs
@@ -44,7 +44,7 @@ pub struct NetworkClient {
     tls: Option<TlsConfig>,
 }
 
-async fn rpc_over<S, Req, Resp>(stream: S, uri: &str, req: &Req) -> Result<Resp, io::Error>
+pub(super) async fn rpc_over<S, Req, Resp>(stream: S, uri: &str, req: &Req) -> Result<Resp, io::Error>
 where
     S: AsyncRead + AsyncWrite + Unpin,
     Req: Serialize,

--- a/layers/state/src/raft/server.rs
+++ b/layers/state/src/raft/server.rs
@@ -6,7 +6,7 @@ use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader
 use tokio::net::TcpListener;
 
 use super::tls::TlsConfig;
-use super::types::TypeConfig;
+use super::types::{SurqlCommand, TypeConfig};
 use super::Raft;
 use crate::StateError;
 
@@ -91,6 +91,18 @@ async fn handle_rpc<S: AsyncRead + AsyncWrite + Unpin + Send>(
                 .await
                 .map_err(|e| format!("install_full_snapshot: {e}"))?;
             serde_json::to_string(&resp)?
+        }
+        "app_write" => {
+            // Followers forward application writes to the leader via this RPC.
+            // On the leader, client_write actually commits the entry. On a
+            // non-leader receiver, client_write still returns an error — we
+            // surface it so the caller can retry somewhere else.
+            let cmd: SurqlCommand = serde_json::from_value(body.clone())?;
+            let resp = raft
+                .client_write(cmd)
+                .await
+                .map_err(|e| format!("client_write: {e}"))?;
+            serde_json::to_string(resp.response())?
         }
         other => return Err(format!("unknown rpc: {other}").into()),
     };

--- a/layers/state/src/raft/state_machine.rs
+++ b/layers/state/src/raft/state_machine.rs
@@ -258,15 +258,15 @@ where
                 }
                 EntryPayload::Normal(cmd) => {
                     eprintln!("  sm: apply query: {}", cmd.query);
-                    inner.data.applied_queries.push(cmd.query.clone());
                     match self.db.query(&cmd.query).await {
                         Ok(_) => {
                             eprintln!("  sm: query OK");
+                            inner.data.applied_queries.push(cmd.query.clone());
                             SurqlResponse::ok()
                         }
                         Err(e) => {
                             eprintln!("  sm: query FAILED: {e}");
-                            SurqlResponse::none()
+                            SurqlResponse::err(e.to_string())
                         }
                     }
                 }

--- a/layers/state/src/raft/state_machine.rs
+++ b/layers/state/src/raft/state_machine.rs
@@ -207,6 +207,7 @@ where
             snapshot_id,
         };
 
+        let applied_query_count = inner.data.applied_queries.len();
         inner.snapshot = Some(StoredSnapshot {
             meta: meta.clone(),
             data: data.clone(),
@@ -214,6 +215,14 @@ where
 
         drop(inner);
         self.persist_snapshot(&meta, &data).await?;
+
+        tracing::info!(
+            node_id = self.node_id,
+            snapshot_id = %meta.snapshot_id,
+            applied_queries = applied_query_count,
+            bytes = data.len(),
+            "raft: built snapshot"
+        );
 
         Ok(SnapshotOf::<C> {
             meta,

--- a/layers/state/src/raft/types.rs
+++ b/layers/state/src/raft/types.rs
@@ -23,14 +23,29 @@ impl fmt::Display for SurqlCommand {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SurqlResponse {
     pub success: bool,
+    #[serde(default)]
+    pub error: Option<String>,
 }
 
 impl SurqlResponse {
     pub fn ok() -> Self {
-        Self { success: true }
+        Self {
+            success: true,
+            error: None,
+        }
     }
 
     pub fn none() -> Self {
-        Self { success: false }
+        Self {
+            success: false,
+            error: None,
+        }
+    }
+
+    pub fn err(msg: impl Into<String>) -> Self {
+        Self {
+            success: false,
+            error: Some(msg.into()),
+        }
     }
 }

--- a/layers/state/tests/raft_cluster.rs
+++ b/layers/state/tests/raft_cluster.rs
@@ -37,6 +37,10 @@ fn pick_free_port() -> u16 {
 }
 
 async fn spawn_node(node_id: u64) -> TestNode {
+    spawn_node_with_threshold(node_id, nauka_state::raft::SNAPSHOT_THRESHOLD).await
+}
+
+async fn spawn_node_with_threshold(node_id: u64, threshold: u64) -> TestNode {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("raft.db");
     let db = Arc::new(
@@ -51,7 +55,7 @@ async fn spawn_node(node_id: u64) -> TestNode {
     let addr = format!("127.0.0.1:{port}");
 
     let raft = Arc::new(
-        RaftNode::new(node_id, db.clone(), None)
+        RaftNode::new_with_snapshot_threshold(node_id, db.clone(), None, threshold)
             .await
             .expect("raft node"),
     );
@@ -177,6 +181,58 @@ async fn follower_write_is_forwarded_to_leader() {
             .unwrap_or_else(|| panic!("forwarded write not replicated to node {}", i + 1));
         assert_eq!(row.value, "ok");
     }
+}
+
+#[tokio::test]
+async fn writes_past_threshold_trigger_snapshot_and_log_purge() {
+    #[derive(serde::Deserialize, SurrealValue)]
+    struct Count {
+        count: i64,
+    }
+
+    const THRESHOLD: u64 = 5;
+    let n1 = spawn_node_with_threshold(5000, THRESHOLD).await;
+    n1.raft.init_cluster(&n1.addr).await.expect("init_cluster");
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Write well past the threshold — openraft builds a snapshot and the
+    // log_store purges committed entries in the background.
+    for i in 0..(THRESHOLD as usize * 4) {
+        n1.raft
+            .write(format!(
+                "CREATE kv SET key = 'snap-{i}', value = '{i}'"
+            ))
+            .await
+            .expect("write");
+    }
+
+    // Give the snapshot + purge tasks a moment to run.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // A snapshot row should exist in _raft_snapshot for our node_id.
+    let snaps: Vec<Count> = n1
+        .db
+        .query_take("SELECT count() AS count FROM _raft_snapshot GROUP ALL")
+        .await
+        .expect("count snapshots");
+    let snap_count = snaps.first().map(|c| c.count).unwrap_or(0);
+    assert!(
+        snap_count >= 1,
+        "expected at least one snapshot row, got {snap_count}"
+    );
+
+    // And the log should have been purged: fewer live _raft_log rows than
+    // total writes (we wrote THRESHOLD*4 entries plus membership ones).
+    let logs: Vec<Count> = n1
+        .db
+        .query_take("SELECT count() AS count FROM _raft_log GROUP ALL")
+        .await
+        .expect("count logs");
+    let log_count = logs.first().map(|c| c.count).unwrap_or(0);
+    assert!(
+        log_count < (THRESHOLD as i64 * 4),
+        "expected log to be purged below write count, got {log_count}"
+    );
 }
 
 #[tokio::test]

--- a/layers/state/tests/raft_cluster.rs
+++ b/layers/state/tests/raft_cluster.rs
@@ -1,0 +1,171 @@
+//! End-to-end integration tests for the Raft consensus layer.
+//!
+//! Spins up in-process 3-node clusters over loopback TCP and exercises
+//! `RaftNode::write` — the same path used by the daemon.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use nauka_state::{Database, RaftNode};
+use serde::Deserialize;
+use surrealdb::types::SurrealValue;
+
+const TEST_SCHEMA: &str = "\
+DEFINE TABLE IF NOT EXISTS kv SCHEMAFULL;\
+DEFINE FIELD IF NOT EXISTS key ON kv TYPE string;\
+DEFINE FIELD IF NOT EXISTS value ON kv TYPE string;\
+DEFINE INDEX IF NOT EXISTS kv_key ON kv FIELDS key UNIQUE;\
+";
+
+#[derive(Deserialize, SurrealValue, Debug)]
+struct Kv {
+    #[allow(dead_code)]
+    key: String,
+    value: String,
+}
+
+struct TestNode {
+    raft: Arc<RaftNode>,
+    db: Arc<Database>,
+    addr: String,
+    _dir: tempfile::TempDir,
+}
+
+fn pick_free_port() -> u16 {
+    let l = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    l.local_addr().expect("local_addr").port()
+}
+
+async fn spawn_node(node_id: u64) -> TestNode {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("raft.db");
+    let db = Arc::new(
+        Database::open(Some(path.to_str().unwrap()))
+            .await
+            .expect("open db"),
+    );
+    db.query(nauka_state::SCHEMA).await.expect("raft schema");
+    db.query(TEST_SCHEMA).await.expect("test schema");
+
+    let port = pick_free_port();
+    let addr = format!("127.0.0.1:{port}");
+
+    let raft = Arc::new(
+        RaftNode::new(node_id, db.clone(), None)
+            .await
+            .expect("raft node"),
+    );
+    raft.start_server(addr.clone()).await;
+
+    TestNode {
+        raft,
+        db,
+        addr,
+        _dir: dir,
+    }
+}
+
+async fn add_and_promote(leader: &RaftNode, node_id: u64, addr: &str) {
+    for attempt in 1..=10 {
+        match leader.add_learner(node_id, addr).await {
+            Ok(_) => break,
+            Err(e) if attempt < 10 => {
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                eprintln!("  test: add_learner retry {attempt}: {e}");
+            }
+            Err(e) => panic!("add_learner failed after retries: {e}"),
+        }
+    }
+    for attempt in 1..=10 {
+        match leader.promote_voter(node_id).await {
+            Ok(_) => return,
+            Err(e) if attempt < 10 => {
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                eprintln!("  test: promote_voter retry {attempt}: {e}");
+            }
+            Err(e) => panic!("promote_voter failed after retries: {e}"),
+        }
+    }
+}
+
+async fn poll_kv(db: &Database, key: &str, timeout: Duration) -> Option<Kv> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        let rows: Vec<Kv> = db
+            .query_take(&format!("SELECT key, value FROM kv WHERE key = '{key}'"))
+            .await
+            .unwrap_or_default();
+        if let Some(row) = rows.into_iter().next() {
+            return Some(row);
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    None
+}
+
+#[tokio::test]
+async fn write_replicates_to_all_nodes() {
+    let n1 = spawn_node(1).await;
+    let n2 = spawn_node(2).await;
+    let n3 = spawn_node(3).await;
+
+    n1.raft.init_cluster(&n1.addr).await.expect("init_cluster");
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    add_and_promote(&n1.raft, 2, &n2.addr).await;
+    add_and_promote(&n1.raft, 3, &n3.addr).await;
+
+    n1.raft
+        .write("CREATE kv SET key = 'hello', value = 'world'".into())
+        .await
+        .expect("write");
+
+    for (i, node) in [&n1, &n2, &n3].iter().enumerate() {
+        let row = poll_kv(&node.db, "hello", Duration::from_secs(5))
+            .await
+            .unwrap_or_else(|| panic!("record not replicated to node {}", i + 1));
+        assert_eq!(row.value, "world");
+    }
+}
+
+#[tokio::test]
+async fn invalid_surql_surfaces_error_to_caller() {
+    let n1 = spawn_node(10).await;
+    n1.raft.init_cluster(&n1.addr).await.expect("init_cluster");
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    n1.raft
+        .write("CREATE kv SET key = 'dup', value = '1'".into())
+        .await
+        .expect("first write");
+
+    let result = n1
+        .raft
+        .write("CREATE kv SET key = 'dup', value = '2'".into())
+        .await;
+
+    assert!(
+        result.is_err(),
+        "expected unique-constraint error to surface, got: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn followers_see_writes_committed_before_they_joined() {
+    let n1 = spawn_node(100).await;
+    n1.raft.init_cluster(&n1.addr).await.expect("init_cluster");
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    n1.raft
+        .write("CREATE kv SET key = 'early', value = '1'".into())
+        .await
+        .expect("early write");
+
+    let n2 = spawn_node(200).await;
+    add_and_promote(&n1.raft, 200, &n2.addr).await;
+
+    let row = poll_kv(&n2.db, "early", Duration::from_secs(5))
+        .await
+        .expect("late joiner missed the pre-join write");
+    assert_eq!(row.value, "1");
+}

--- a/layers/state/tests/raft_cluster.rs
+++ b/layers/state/tests/raft_cluster.rs
@@ -151,6 +151,35 @@ async fn invalid_surql_surfaces_error_to_caller() {
 }
 
 #[tokio::test]
+async fn follower_write_is_forwarded_to_leader() {
+    let n1 = spawn_node(1000).await;
+    let n2 = spawn_node(2000).await;
+    let n3 = spawn_node(3000).await;
+
+    n1.raft.init_cluster(&n1.addr).await.expect("init_cluster");
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    add_and_promote(&n1.raft, 2000, &n2.addr).await;
+    add_and_promote(&n1.raft, 3000, &n3.addr).await;
+
+    // Give followers a moment to sync their view of the leader.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // n1 is the leader; n2 is a follower. Writing on n2 must still land.
+    n2.raft
+        .write("CREATE kv SET key = 'from-follower', value = 'ok'".into())
+        .await
+        .expect("follower write via forwarding");
+
+    for (i, node) in [&n1, &n2, &n3].iter().enumerate() {
+        let row = poll_kv(&node.db, "from-follower", Duration::from_secs(5))
+            .await
+            .unwrap_or_else(|| panic!("forwarded write not replicated to node {}", i + 1));
+        assert_eq!(row.value, "ok");
+    }
+}
+
+#[tokio::test]
 async fn followers_see_writes_committed_before_they_joined() {
     let n1 = spawn_node(100).await;
     n1.raft.init_cluster(&n1.addr).await.expect("init_cluster");

--- a/tests/test-chaos-304.sh
+++ b/tests/test-chaos-304.sh
@@ -244,6 +244,62 @@ log "    final alive: $final_alive / $NODE_COUNT"
 [[ $final_alive -eq $NODE_COUNT ]] || die "some nodes died during recovery"
 ok "cluster fully recovered — $final_alive/$NODE_COUNT nodes alive"
 
+# ═══════════════════════════════════════════════════════════════════
+# CHAOS PHASE 4: functional consensus check
+# Prove the cluster can still do Raft writes post-recovery:
+# 1. remove a peer via CLI (issues DELETE hypervisor through Raft)
+# 2. verify every non-victim node's reconciler picks up the change
+# ═══════════════════════════════════════════════════════════════════
+log ""
+log "═══ CHAOS PHASE 4: functional consensus check ═══"
+
+VICTIM_IDX=$((NODE_COUNT - 1))
+VICTIM_IP=${IPS[$VICTIM_IDX]}
+VICTIM_PK=$(ssh_node "$VICTIM_IP" \
+    "grep -hoP 'public key:\s+\K\S+' /tmp/nauka.log /tmp/nauka-restart.log 2>/dev/null | head -1")
+[[ -n $VICTIM_PK ]] || die "could not read victim pubkey"
+log "  victim: node-$((VICTIM_IDX + 1)) ($VICTIM_IP) pk=$VICTIM_PK"
+
+# Raft writes must land on the leader; post-chaos the leader is whichever
+# node won the re-election, not necessarily node-1. Daemons today don't
+# forward to the leader (separate concern), so we try every non-victim
+# node until one — the leader — accepts.
+log "  ▶ nauka mesh peer remove (probing every node for the leader)"
+remove_ok=false
+for i in "${!IPS[@]}"; do
+    [[ $i -eq $VICTIM_IDX ]] && continue
+    ip=${IPS[$i]}
+    wait_port "$ip" 51821 2>/dev/null || continue
+    if ssh_node "$ip" "nauka mesh peer remove --public-key '$VICTIM_PK'" 2>&1 \
+        | tee -a "$RUN_DIR/remove-attempts.log" \
+        | grep -q '^peer removal requested'; then
+        ok "  peer remove accepted by node-$((i + 1)) (leader)"
+        remove_ok=true
+        break
+    fi
+done
+$remove_ok || die "no node accepted the peer-remove — Raft write rejected everywhere"
+
+# Each node's reconciler polls every 5s — give 2 cycles for apply+reconcile
+log "  waiting 12s for Raft apply + reconciler cycle..."
+sleep 12
+
+# Every non-victim node must have dropped the victim from its WG peer list.
+# The victim still sees its old peers — with its own record deleted, its
+# reconciler has nothing to diff against. Skipping the victim is intentional.
+log "  ▶ checking WG peer counts on non-victim nodes"
+expected=$((NODE_COUNT - 2))   # self already excluded; victim now excluded too
+for i in "${!IPS[@]}"; do
+    [[ $i -eq $VICTIM_IDX ]] && continue
+    ip=${IPS[$i]}
+    count=$(ssh_node "$ip" "nauka mesh status 2>/dev/null | grep -c ': Peer {'" \
+        2>/dev/null || echo -1)
+    log "    node-$((i + 1)): $count peers (want $expected)"
+    [[ $count -eq $expected ]] || \
+        die "node-$((i + 1)) still has $count peers after peer-remove (expected $expected)"
+done
+ok "post-recovery Raft write replicated to all $((NODE_COUNT - 1)) non-victim nodes"
+
 # ─── Collect logs ────────────────────────────────────────────────────
 log "▶ collecting logs"
 for i in "${!IPS[@]}"; do


### PR DESCRIPTION
Closes #314.

**Stacked on #320** (feat/315) → #319 (fix/313) → #318 (test/310) → #317 (feat/311) → #316 (fix/312).

## Summary

Compaction was already running via openraft's defaults (`LogsSinceLast(5000)` + `max_in_snapshot_log_to_keep = 1000`), but the numbers were invisible in code review, untunable without recompiling, and CI had no check that it ever fired.

- **Explicit `SnapshotPolicy`** in `RaftNode::new`. `SNAPSHOT_THRESHOLD = 1000` is now a public constant; `max_in_snapshot_log_to_keep` is tied to it so exactly one snapshot-window of log is retained for catch-up.
- **`new_with_snapshot_threshold`** constructor lets tests pass a small threshold.
- **Tracing events** — `tracing::info!("raft: built snapshot", snapshot_id, applied_queries, bytes)` and `tracing::info!("raft: purged log entries", up_to_index)`.
- **Tracing subscriber** in `bin/nauka/src/main.rs` — `tracing_subscriber::fmt` at `info`, overridable via `RUST_LOG`, written to stderr.
- **Integration test** `writes_past_threshold_trigger_snapshot_and_log_purge`: threshold=5, 20 writes, asserts `_raft_snapshot` row exists and `_raft_log` is purged below the write count.

## Test plan

- [x] `cargo test` — 16/16 (8 state + 3 hypervisor + 5 raft_cluster)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Hetzner 2-node (`tests/test-issue-305.sh`) — PASS, `tracing_subscriber` output visible in the captured daemon logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)