### PR TITLE
fix(#313): validate peer-controlled inputs before SurQL interpolation

### DIFF
--- a/layers/hypervisor/src/daemon.rs
+++ b/layers/hypervisor/src/daemon.rs
@@ -1,3 +1,4 @@
+use std::str::FromStr;
 use std::sync::Arc;
 
 use nauka_state::{node_id_from_key, Database, RaftNode, TlsConfig};
@@ -161,19 +162,39 @@ pub async fn run_daemon_join(
 
     let tls = build_tls(&state);
 
-    // Save bootstrap hypervisors to local DB so reconciler picks them up
+    // Save bootstrap hypervisors to local DB so reconciler picks them up.
+    // Validate every field before interpolating — the bootstrap server is
+    // trusted by the PIN, but we still refuse to pass un-parseable strings
+    // into SurQL.
     for p in &bootstrap_peers {
+        let canonical_pk = match defguard_wireguard_rs::key::Key::from_str(&p.public_key) {
+            Ok(k) => k.to_string(),
+            Err(_) => {
+                eprintln!("  ! bootstrap peer: invalid public_key, skipping");
+                continue;
+            }
+        };
+        let endpoint: std::net::SocketAddr = match p.endpoint.parse() {
+            Ok(a) => a,
+            Err(_) => {
+                eprintln!("  ! bootstrap peer {canonical_pk}: invalid endpoint, skipping");
+                continue;
+            }
+        };
+        let mesh_addr_mask: defguard_wireguard_rs::net::IpAddrMask = match p.mesh_address.parse() {
+            Ok(m) => m,
+            Err(_) => {
+                eprintln!("  ! bootstrap peer {canonical_pk}: invalid mesh_address, skipping");
+                continue;
+            }
+        };
         let surql = format!(
             "CREATE hypervisor SET \
-             public_key = '{}', node_id = {}, address = '{}', \
-             endpoint = '{}', allowed_ips = ['{}'], keepalive = 25, \
-             raft_addr = '[{}]:4001'",
-            p.public_key,
-            node_id_from_key(&p.public_key) as i64,
-            p.mesh_address,
-            p.endpoint,
-            p.mesh_address,
-            p.mesh_address.split('/').next().unwrap_or(""),
+             public_key = '{canonical_pk}', node_id = {node_id}, address = '{mesh_addr_mask}', \
+             endpoint = '{endpoint}', allowed_ips = ['{mesh_addr_mask}'], keepalive = 25, \
+             raft_addr = '[{ip}]:4001'",
+            node_id = node_id_from_key(&canonical_pk) as i64,
+            ip = mesh_addr_mask.address,
         );
         let _ = db.query(&surql).await;
     }

--- a/layers/hypervisor/src/mesh/join.rs
+++ b/layers/hypervisor/src/mesh/join.rs
@@ -253,16 +253,27 @@ async fn handle_connection(
         let req: RemoveRequest =
             serde_json::from_value(v).map_err(|e| MeshError::Join(e.to_string()))?;
 
+        // Parse as a WireGuard key to reject anything that isn't a pubkey
+        // (including SurQL-breaking characters) before touching the DB.
+        let canonical_pk = match Key::from_str(&req.remove_public_key) {
+            Ok(k) => k.to_string(),
+            Err(_) => {
+                let _ = writer
+                    .write_all(b"{\"error\":\"invalid public key\"}\n")
+                    .await;
+                return Err(MeshError::InvalidKey);
+            }
+        };
+
         let surql = format!(
-            "DELETE hypervisor WHERE public_key = '{}'",
-            req.remove_public_key
+            "DELETE hypervisor WHERE public_key = '{canonical_pk}'"
         );
         if let Err(e) = raft.write(surql).await {
             eprintln!("  ! raft remove failed: {e}");
             let _ = writer.write_all(b"{\"error\":\"raft write failed\"}\n").await;
         } else {
             let _ = writer.write_all(b"{\"ok\":true}\n").await;
-            println!("  - peer removed: {}", req.remove_public_key);
+            println!("  - peer removed: {canonical_pk}");
         }
     }
 
@@ -373,4 +384,48 @@ pub fn request_peer_removal(join_port: u16, public_key: &str) -> Result<(), Mesh
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The validation in handle_connection (remove path) relies on
+    // `Key::from_str` to reject anything that isn't a canonical WireGuard
+    // public key before the value enters a SurQL literal. These tests lock
+    // in that assumption — if the key crate ever starts accepting looser
+    // inputs, the `DELETE hypervisor WHERE public_key = '...'` path would
+    // become injectable again.
+    const VALID_WG_PUBKEY: &str = "PQgVf+YiO+S7LTaOqtGSEUxXpmEb5hPEb+g5mTwQdC0=";
+
+    #[test]
+    fn key_from_str_rejects_surql_injection() {
+        let attacks = [
+            "'; DROP TABLE hypervisor; --",
+            "' OR 1=1; --",
+            "abc'; DELETE hypervisor; '",
+            "\"injected\"",
+            "", // empty
+            "not base64 at all",
+        ];
+        for a in attacks {
+            assert!(
+                Key::from_str(a).is_err(),
+                "Key::from_str should reject {a:?} but accepted it"
+            );
+        }
+    }
+
+    #[test]
+    fn key_from_str_accepts_canonical_pubkey_and_roundtrips() {
+        let k = Key::from_str(VALID_WG_PUBKEY).expect("valid pubkey should parse");
+        assert_eq!(k.to_string(), VALID_WG_PUBKEY);
+    }
+
+    #[test]
+    fn key_from_str_rejects_wrong_length_base64() {
+        // Valid base64 but wrong size for a 32-byte WG key.
+        assert!(Key::from_str("dGVzdA==").is_err()); // 4 bytes
+        assert!(Key::from_str("AA==").is_err()); // 1 byte
+    }
 }


### PR DESCRIPTION
Closes #313. (Re-created after #323 merged.)

## Summary

- `remove_public_key` → validated via `Key::from_str` before reaching SurQL. Invalid keys get `{"error":"invalid public key"}` and `MeshError::InvalidKey`.
- Bootstrap peers → `public_key` as `Key`, `endpoint` as `SocketAddr`, `mesh_address` as `IpAddrMask`. Invalid peers skipped.
- Unit tests in `join.rs` confirm `Key::from_str` rejects SurQL metacharacters and wrong-size base64.

## Test plan

- [x] `cargo test` — passes
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Hetzner 2-node (`tests/test-issue-305.sh`) — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)