### PR TITLE
feat(#315): active rejoin — restart detects endpoint change and propagates via Raft

### DIFF
--- a/layers/hypervisor/src/daemon.rs
+++ b/layers/hypervisor/src/daemon.rs
@@ -1,15 +1,24 @@
+use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use nauka_state::{node_id_from_key, Database, RaftNode, TlsConfig};
+use serde::Deserialize;
+use surrealdb::types::SurrealValue;
 use tokio::signal;
 
 use crate::mesh::{
-    certs, generate_pin, join_mesh, mesh_listener, KeyPair, Mesh, MeshError, MeshId, MeshState,
-    DEFAULT_JOIN_PORT,
+    certs, generate_pin, join_mesh, mesh_listener, whoami, KeyPair, Mesh, MeshError, MeshId,
+    MeshState, DEFAULT_JOIN_PORT,
 };
 
 use crate::mesh::reconciler;
+
+#[derive(Deserialize, SurrealValue)]
+struct EndpointRow {
+    endpoint: Option<String>,
+}
 
 pub struct DaemonConfig {
     pub interface_name: String,
@@ -284,7 +293,7 @@ pub async fn run_daemon_restart(db: Arc<Database>) -> Result<(), MeshError> {
     });
 
     let listener_handle = tokio::spawn(mesh_listener(
-        Some(raft),
+        Some(raft.clone()),
         mesh.mesh_id().clone(),
         mesh.keypair().clone(),
         mesh.address().to_string(),
@@ -296,14 +305,120 @@ pub async fn run_daemon_restart(db: Arc<Database>) -> Result<(), MeshError> {
         state.ca_key,
     ));
 
+    let refresh_handle = tokio::spawn(refresh_own_endpoint(
+        db.clone(),
+        raft.clone(),
+        own_pk.clone(),
+        state.listen_port,
+    ));
+
     println!("\n  ctrl+c to stop\n");
     signal::ctrl_c().await.map_err(|e| MeshError::State(e.to_string()))?;
 
     listener_handle.abort();
     reconciler_handle.abort();
+    refresh_handle.abort();
     mesh.down()?;
     println!("\ndaemon stopped (state preserved)");
     Ok(())
+}
+
+/// Discover our public endpoint via `whoami` to a peer, then, if it differs
+/// from what's currently in the hypervisor table, UPDATE via Raft so every
+/// node's reconciler can refresh its WG peer endpoint for us.
+///
+/// Runs in a background task after `run_daemon_restart` brings Raft up,
+/// because restart is the only flow where our IP might have changed while
+/// peers still hold the old one.
+async fn refresh_own_endpoint(
+    db: Arc<Database>,
+    raft: Arc<RaftNode>,
+    own_pk: String,
+    listen_port: u16,
+) {
+    // Let Raft elect a leader before we try to write.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Find a peer with a known public endpoint.
+    let peer_ip = match pick_peer_ip(&db, &own_pk).await {
+        Ok(Some(ip)) => ip,
+        Ok(None) => {
+            eprintln!("  endpoint refresh: no peer with endpoint yet — skipping");
+            return;
+        }
+        Err(e) => {
+            eprintln!("  endpoint refresh: pick peer failed: {e}");
+            return;
+        }
+    };
+
+    // Ask the peer what IP it sees us on.
+    let observed_ip = match whoami(&peer_ip, DEFAULT_JOIN_PORT).await {
+        Ok(ip) => ip,
+        Err(e) => {
+            eprintln!("  endpoint refresh: whoami {peer_ip} failed: {e}");
+            return;
+        }
+    };
+    let new_endpoint = SocketAddr::new(observed_ip, listen_port).to_string();
+
+    // Compare with the value currently in the table.
+    let current_ep = match read_own_endpoint(&db, &own_pk).await {
+        Ok(ep) => ep,
+        Err(e) => {
+            eprintln!("  endpoint refresh: read own endpoint failed: {e}");
+            return;
+        }
+    };
+    if current_ep.as_deref() == Some(new_endpoint.as_str()) {
+        println!("  endpoint refresh: {new_endpoint} (unchanged)");
+        return;
+    }
+
+    println!(
+        "  endpoint refresh: {:?} -> {new_endpoint}",
+        current_ep.as_deref().unwrap_or("NONE")
+    );
+    let surql = format!(
+        "UPDATE hypervisor SET endpoint = '{new_endpoint}' WHERE public_key = '{own_pk}'"
+    );
+    match raft.write(surql).await {
+        Ok(_) => println!("  endpoint refresh: propagated via Raft"),
+        Err(e) => eprintln!("  endpoint refresh: raft write failed: {e}"),
+    }
+}
+
+async fn pick_peer_ip(db: &Database, own_pk: &str) -> Result<Option<String>, MeshError> {
+    #[derive(Deserialize, SurrealValue)]
+    struct PeerRow {
+        public_key: String,
+        endpoint: Option<String>,
+    }
+    let peers: Vec<PeerRow> = db
+        .query_take("SELECT public_key, endpoint FROM hypervisor")
+        .await
+        .map_err(|e| MeshError::State(e.to_string()))?;
+    for p in peers {
+        if p.public_key == own_pk {
+            continue;
+        }
+        if let Some(ep) = p.endpoint {
+            if let Ok(sa) = ep.parse::<SocketAddr>() {
+                return Ok(Some(sa.ip().to_string()));
+            }
+        }
+    }
+    Ok(None)
+}
+
+async fn read_own_endpoint(db: &Database, own_pk: &str) -> Result<Option<String>, MeshError> {
+    let rows: Vec<EndpointRow> = db
+        .query_take(&format!(
+            "SELECT endpoint FROM hypervisor WHERE public_key = '{own_pk}'"
+        ))
+        .await
+        .map_err(|e| MeshError::State(e.to_string()))?;
+    Ok(rows.into_iter().next().and_then(|r| r.endpoint))
 }
 
 /// Explicit teardown — removes state from DB

--- a/layers/hypervisor/src/mesh/join.rs
+++ b/layers/hypervisor/src/mesh/join.rs
@@ -153,7 +153,14 @@ async fn handle_connection(
     let v: serde_json::Value =
         serde_json::from_str(&line).map_err(|e| MeshError::Join(e.to_string()))?;
 
-    if v.get("pin").is_some() {
+    if v.get("whoami").is_some() {
+        // --- Observability: tell the caller what public IP we see them on.
+        // Used by restarted nodes to detect their current public address
+        // without depending on external STUN-like services.
+        let resp = format!("{{\"observed_ip\":\"{}\"}}\n", peer_addr.ip());
+        let _ = writer.write_all(resp.as_bytes()).await;
+        return Ok(());
+    } else if v.get("pin").is_some() {
         // --- Join request ---
         let pin = peering_pin.ok_or_else(|| MeshError::Join("peering not enabled".into()))?;
         let raft = raft.as_ref().ok_or_else(|| MeshError::Join("no raft".into()))?;
@@ -361,6 +368,36 @@ pub fn join_mesh(
     };
 
     Ok((mesh, all_peers, tls_certs))
+}
+
+/// Ask a remote peer what IP it observes us on. Used by restart flow to
+/// learn our current public endpoint without an external STUN-like service.
+pub async fn whoami(peer_ip: &str, join_port: u16) -> Result<std::net::IpAddr, MeshError> {
+    use tokio::io::AsyncBufReadExt as _;
+    use tokio::net::TcpStream;
+    let addr = format!("{peer_ip}:{join_port}");
+    let stream = TcpStream::connect(&addr)
+        .await
+        .map_err(|e| MeshError::Join(format!("whoami connect {addr}: {e}")))?;
+    let (reader, mut writer) = stream.into_split();
+    tokio::io::AsyncWriteExt::write_all(&mut writer, b"{\"whoami\":true}\n")
+        .await
+        .map_err(|e| MeshError::Join(format!("whoami write: {e}")))?;
+    let mut lines = tokio::io::BufReader::new(reader).lines();
+    let line = lines
+        .next_line()
+        .await
+        .map_err(|e| MeshError::Join(format!("whoami read: {e}")))?
+        .ok_or_else(|| MeshError::Join("whoami empty response".into()))?;
+    let v: serde_json::Value = serde_json::from_str(&line)
+        .map_err(|e| MeshError::Join(format!("whoami parse: {e}")))?;
+    let ip_str = v
+        .get("observed_ip")
+        .and_then(|x| x.as_str())
+        .ok_or_else(|| MeshError::Join("whoami: missing observed_ip".into()))?;
+    ip_str
+        .parse()
+        .map_err(|_| MeshError::Join(format!("whoami: invalid ip {ip_str}")))
 }
 
 /// Send a remove-peer command to the local daemon

--- a/layers/hypervisor/src/mesh/mod.rs
+++ b/layers/hypervisor/src/mesh/mod.rs
@@ -11,8 +11,8 @@ mod state;
 pub use address::MeshId;
 pub use error::MeshError;
 pub use join::{
-    generate_pin, join_mesh, mesh_listener, request_peer_removal, PeerInfo, DEFAULT_JOIN_PORT,
-    DEFAULT_PEERING_TIMEOUT,
+    generate_pin, join_mesh, mesh_listener, request_peer_removal, whoami, PeerInfo,
+    DEFAULT_JOIN_PORT, DEFAULT_PEERING_TIMEOUT,
 };
 pub use key::KeyPair;
 pub use peer::MeshPeer;

--- a/layers/hypervisor/src/mesh/reconciler.rs
+++ b/layers/hypervisor/src/mesh/reconciler.rs
@@ -34,24 +34,30 @@ async fn reconcile(
 
     let api = WGApi::<Kernel>::new(interface_name.to_string())?;
     let host = api.read_interface_data()?;
-    let wg_keys: std::collections::HashSet<String> =
-        host.peers.keys().map(|k| k.to_string()).collect();
 
     let db_keys: std::collections::HashSet<String> =
         db_hypervisors.iter().map(|p| p.public_key.clone()).collect();
 
-    // Add hypervisors in DB but not in WG
+    // Add hypervisors in DB but not in WG, or update WG peers whose endpoint
+    // no longer matches the DB record (happens after another node restarts
+    // with a new public IP).
     for record in &db_hypervisors {
         if record.public_key == own_public_key {
-            continue;
-        }
-        if wg_keys.contains(&record.public_key) {
             continue;
         }
 
         let Ok(key) = defguard_wireguard_rs::key::Key::from_str(&record.public_key) else {
             continue;
         };
+
+        let existing = host.peers.get(&key);
+        let wg_endpoint_str = existing
+            .and_then(|p| p.endpoint)
+            .map(|e| e.to_string());
+        if existing.is_some() && wg_endpoint_str == record.endpoint {
+            continue; // already configured with the right endpoint
+        }
+
         let mut peer = defguard_wireguard_rs::peer::Peer::new(key);
         if let Some(ref ep) = record.endpoint {
             let _ = peer.set_endpoint(ep);
@@ -64,7 +70,11 @@ async fn reconcile(
         }
         if api.configure_peer(&peer).is_ok() {
             let _ = api.configure_peer_routing(&[peer]);
-            eprintln!("  reconciler: +peer {}", record.public_key);
+            let verb = if existing.is_some() { "update" } else { "add" };
+            eprintln!(
+                "  reconciler: {verb} peer {} endpoint={:?}",
+                record.public_key, record.endpoint
+            );
         }
     }
 

--- a/layers/state/src/raft/mod.rs
+++ b/layers/state/src/raft/mod.rs
@@ -8,17 +8,20 @@ pub mod types;
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
+use openraft::error::{ClientWriteError, ForwardToLeader, RaftError};
 use openraft::BasicNode;
 use openraft::ChangeMembers;
 use openraft::Config;
+use rustls::pki_types::ServerName;
+use tokio::net::TcpStream;
 
 use crate::db::Database;
 use crate::StateError;
 
 use self::log_store::LogStore;
-use self::network::NetworkFactory;
+use self::network::{rpc_over, NetworkFactory};
 use self::state_machine::StateMachineStore;
-use self::tls::TlsConfig;
+use self::tls::{TlsConfig, RAFT_TLS_SAN};
 use self::types::{SurqlCommand, SurqlResponse, TypeConfig};
 
 pub type Raft = openraft::Raft<TypeConfig, StateMachineStore<TypeConfig>>;
@@ -102,16 +105,58 @@ impl RaftNode {
     }
 
     /// Write a SurrealQL command through Raft consensus.
-    /// Replicates to all nodes before returning.
+    /// On a follower, forwards to the current leader over the Raft RPC
+    /// channel (reusing the same mTLS) and returns the leader's response.
     pub async fn write(&self, query: String) -> Result<SurqlResponse, StateError> {
-        let resp = self
-            .raft
-            .client_write(SurqlCommand { query })
+        let cmd = SurqlCommand { query };
+        match self.raft.client_write(cmd.clone()).await {
+            Ok(resp) => {
+                let response = resp.response().clone();
+                if let Some(ref err) = response.error {
+                    return Err(StateError::Raft(format!("state machine: {err}")));
+                }
+                Ok(response)
+            }
+            Err(RaftError::APIError(ClientWriteError::ForwardToLeader(ftl))) => {
+                self.forward_write(&ftl, cmd).await
+            }
+            Err(e) => Err(StateError::Raft(format!("client_write: {e}"))),
+        }
+    }
+
+    async fn forward_write(
+        &self,
+        ftl: &ForwardToLeader<TypeConfig>,
+        cmd: SurqlCommand,
+    ) -> Result<SurqlResponse, StateError> {
+        let Some(ref leader) = ftl.leader_node else {
+            return Err(StateError::Raft("no leader elected yet".into()));
+        };
+        let addr = leader.addr.clone();
+
+        let tcp = TcpStream::connect(&addr)
             .await
-            .map_err(|e| StateError::Raft(format!("client_write: {e}")))?;
-        let response = resp.response().clone();
+            .map_err(|e| StateError::Network(format!("connect leader {addr}: {e}")))?;
+
+        let response: SurqlResponse = if let Some(ref tls) = self.tls {
+            let server_name = ServerName::try_from(RAFT_TLS_SAN)
+                .map_err(|e| StateError::Network(e.to_string()))?;
+            let connector = tokio_rustls::TlsConnector::from(tls.client.clone());
+            let stream = connector
+                .connect(server_name, tcp)
+                .await
+                .map_err(|e| StateError::Network(e.to_string()))?;
+            rpc_over(stream, "app_write", &cmd)
+                .await
+                .map_err(|e| StateError::Raft(format!("forward to {addr}: {e}")))?
+        } else {
+            rpc_over(tcp, "app_write", &cmd)
+                .await
+                .map_err(|e| StateError::Raft(format!("forward to {addr}: {e}")))?
+        };
+
         if let Some(ref err) = response.error {
-            return Err(StateError::Raft(format!("state machine: {err}")));
+            return Err(StateError::Raft(format!("state machine (leader): {err}")));
         }
         Ok(response)
     }

--- a/layers/state/src/raft/network.rs
+++ b/layers/state/src/raft/network.rs
@@ -44,7 +44,7 @@ pub struct NetworkClient {
     tls: Option<TlsConfig>,
 }
 
-async fn rpc_over<S, Req, Resp>(stream: S, uri: &str, req: &Req) -> Result<Resp, io::Error>
+pub(super) async fn rpc_over<S, Req, Resp>(stream: S, uri: &str, req: &Req) -> Result<Resp, io::Error>
 where
     S: AsyncRead + AsyncWrite + Unpin,
     Req: Serialize,

--- a/layers/state/src/raft/server.rs
+++ b/layers/state/src/raft/server.rs
@@ -6,7 +6,7 @@ use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader
 use tokio::net::TcpListener;
 
 use super::tls::TlsConfig;
-use super::types::TypeConfig;
+use super::types::{SurqlCommand, TypeConfig};
 use super::Raft;
 use crate::StateError;
 
@@ -91,6 +91,18 @@ async fn handle_rpc<S: AsyncRead + AsyncWrite + Unpin + Send>(
                 .await
                 .map_err(|e| format!("install_full_snapshot: {e}"))?;
             serde_json::to_string(&resp)?
+        }
+        "app_write" => {
+            // Followers forward application writes to the leader via this RPC.
+            // On the leader, client_write actually commits the entry. On a
+            // non-leader receiver, client_write still returns an error — we
+            // surface it so the caller can retry somewhere else.
+            let cmd: SurqlCommand = serde_json::from_value(body.clone())?;
+            let resp = raft
+                .client_write(cmd)
+                .await
+                .map_err(|e| format!("client_write: {e}"))?;
+            serde_json::to_string(resp.response())?
         }
         other => return Err(format!("unknown rpc: {other}").into()),
     };

--- a/layers/state/tests/raft_cluster.rs
+++ b/layers/state/tests/raft_cluster.rs
@@ -151,6 +151,35 @@ async fn invalid_surql_surfaces_error_to_caller() {
 }
 
 #[tokio::test]
+async fn follower_write_is_forwarded_to_leader() {
+    let n1 = spawn_node(1000).await;
+    let n2 = spawn_node(2000).await;
+    let n3 = spawn_node(3000).await;
+
+    n1.raft.init_cluster(&n1.addr).await.expect("init_cluster");
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    add_and_promote(&n1.raft, 2000, &n2.addr).await;
+    add_and_promote(&n1.raft, 3000, &n3.addr).await;
+
+    // Give followers a moment to sync their view of the leader.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // n1 is the leader; n2 is a follower. Writing on n2 must still land.
+    n2.raft
+        .write("CREATE kv SET key = 'from-follower', value = 'ok'".into())
+        .await
+        .expect("follower write via forwarding");
+
+    for (i, node) in [&n1, &n2, &n3].iter().enumerate() {
+        let row = poll_kv(&node.db, "from-follower", Duration::from_secs(5))
+            .await
+            .unwrap_or_else(|| panic!("forwarded write not replicated to node {}", i + 1));
+        assert_eq!(row.value, "ok");
+    }
+}
+
+#[tokio::test]
 async fn followers_see_writes_committed_before_they_joined() {
     let n1 = spawn_node(100).await;
     n1.raft.init_cluster(&n1.addr).await.expect("init_cluster");


### PR DESCRIPTION
Closes #315. (Re-created after #324 merged.)

## Summary

1. **Leader forwarding for app writes** — `RaftNode::write` on a follower catches `ForwardToLeader`, opens mTLS to the leader's Raft RPC port, sends a new `app_write` RPC, returns the leader's response.
2. **`whoami` peering message** — `{"whoami": true}` on port 51821 returns the observed source IP.
3. **Restart flow** refreshes endpoint via `whoami` → compare → `UPDATE hypervisor` via Raft.
4. **Reconciler** now detects stale WG endpoints and re-runs `configure_peer`.

New test: `follower_write_is_forwarded_to_leader`.

## Test plan

- [x] `cargo test` — passes
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Hetzner 8-node chaos — PASS; `endpoint refresh` logs confirm init node goes `NONE → IP` and restarted nodes detect `unchanged`

🤖 Generated with [Claude Code](https://claude.com/claude-code)