### PR TITLE
feat(#314): explicit snapshot policy, tracing on build/purge, compaction test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,6 +2445,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2518,6 +2527,8 @@ dependencies = [
  "nauka-state",
  "serde_json",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2705,6 +2716,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4102,6 +4122,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4958,6 +4987,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -5258,6 +5317,12 @@ checksum = "4efba0434d5a0a62d4f22070b44ce055dc18cb64d4fa98276aa523dadfaba0e7"
 dependencies = [
  "anyerror",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vart"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ thiserror = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 surrealdb = { version = "3", default-features = false, features = ["kv-surrealkv"] }

--- a/bin/nauka/Cargo.toml
+++ b/bin/nauka/Cargo.toml
@@ -15,5 +15,7 @@ clap.workspace = true
 anyhow.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 nauka-hypervisor.workspace = true
 nauka-state.workspace = true

--- a/bin/nauka/src/main.rs
+++ b/bin/nauka/src/main.rs
@@ -9,6 +9,15 @@ use nauka_state::Database;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Init tracing. Defaults to `info` level; override via `RUST_LOG`.
+    // Output goes to stderr so it coexists with println! on stdout.
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .init();
+
     let app = Command::new("nauka")
         .about("Nauka — turn dedicated servers into a programmable cloud")
         .version(option_env!("NAUKA_VERSION").unwrap_or(env!("CARGO_PKG_VERSION")))

--- a/layers/state/src/raft/log_store.rs
+++ b/layers/state/src/raft/log_store.rs
@@ -331,6 +331,11 @@ mod impl_log_store {
 
             let json = serde_json::to_string(&log_id)
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            tracing::info!(
+                node_id = self.node_id,
+                up_to_index = idx,
+                "raft: purged log entries"
+            );
             self.update_meta_field("purged", &json).await
         }
 

--- a/layers/state/src/raft/mod.rs
+++ b/layers/state/src/raft/mod.rs
@@ -12,6 +12,7 @@ use openraft::error::{ClientWriteError, ForwardToLeader, RaftError};
 use openraft::BasicNode;
 use openraft::ChangeMembers;
 use openraft::Config;
+use openraft::SnapshotPolicy;
 use rustls::pki_types::ServerName;
 use tokio::net::TcpStream;
 
@@ -25,6 +26,13 @@ use self::tls::{TlsConfig, RAFT_TLS_SAN};
 use self::types::{SurqlCommand, SurqlResponse, TypeConfig};
 
 pub type Raft = openraft::Raft<TypeConfig, StateMachineStore<TypeConfig>>;
+
+/// How many committed log entries accumulate before a snapshot is built
+/// and the preceding log entries are purged from SurrealDB. Tuned for a
+/// cluster with mostly-idle steady-state writes (joins/removes/endpoint
+/// refreshes) — fast enough that a new follower doesn't stream forever
+/// to catch up, slow enough that we aren't snapshotting constantly.
+pub const SNAPSHOT_THRESHOLD: u64 = 1000;
 
 pub fn node_id_from_key(public_key: &str) -> u64 {
     let bytes = public_key.as_bytes();
@@ -47,10 +55,27 @@ impl RaftNode {
         db: Arc<Database>,
         tls: Option<TlsConfig>,
     ) -> Result<Self, StateError> {
+        Self::new_with_snapshot_threshold(node_id, db, tls, SNAPSHOT_THRESHOLD).await
+    }
+
+    /// Test-friendly constructor that accepts an arbitrary snapshot
+    /// threshold. Production callers should use `new` and inherit
+    /// `SNAPSHOT_THRESHOLD`.
+    pub async fn new_with_snapshot_threshold(
+        node_id: u64,
+        db: Arc<Database>,
+        tls: Option<TlsConfig>,
+        snapshot_threshold: u64,
+    ) -> Result<Self, StateError> {
         let config = Config {
             heartbeat_interval: 500,
             election_timeout_min: 1500,
             election_timeout_max: 3000,
+            snapshot_policy: SnapshotPolicy::LogsSinceLast(snapshot_threshold),
+            // Keep one snapshot-window worth of logs around past the most
+            // recent snapshot so a catching-up follower can stream from log
+            // instead of downloading a fresh snapshot every time.
+            max_in_snapshot_log_to_keep: snapshot_threshold,
             ..Default::default()
         };
         let config = Arc::new(

--- a/layers/state/src/raft/state_machine.rs
+++ b/layers/state/src/raft/state_machine.rs
@@ -207,6 +207,7 @@ where
             snapshot_id,
         };
 
+        let applied_query_count = inner.data.applied_queries.len();
         inner.snapshot = Some(StoredSnapshot {
             meta: meta.clone(),
             data: data.clone(),
@@ -214,6 +215,14 @@ where
 
         drop(inner);
         self.persist_snapshot(&meta, &data).await?;
+
+        tracing::info!(
+            node_id = self.node_id,
+            snapshot_id = %meta.snapshot_id,
+            applied_queries = applied_query_count,
+            bytes = data.len(),
+            "raft: built snapshot"
+        );
 
         Ok(SnapshotOf::<C> {
             meta,

--- a/layers/state/tests/raft_cluster.rs
+++ b/layers/state/tests/raft_cluster.rs
@@ -37,6 +37,10 @@ fn pick_free_port() -> u16 {
 }
 
 async fn spawn_node(node_id: u64) -> TestNode {
+    spawn_node_with_threshold(node_id, nauka_state::raft::SNAPSHOT_THRESHOLD).await
+}
+
+async fn spawn_node_with_threshold(node_id: u64, threshold: u64) -> TestNode {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("raft.db");
     let db = Arc::new(
@@ -51,7 +55,7 @@ async fn spawn_node(node_id: u64) -> TestNode {
     let addr = format!("127.0.0.1:{port}");
 
     let raft = Arc::new(
-        RaftNode::new(node_id, db.clone(), None)
+        RaftNode::new_with_snapshot_threshold(node_id, db.clone(), None, threshold)
             .await
             .expect("raft node"),
     );
@@ -177,6 +181,58 @@ async fn follower_write_is_forwarded_to_leader() {
             .unwrap_or_else(|| panic!("forwarded write not replicated to node {}", i + 1));
         assert_eq!(row.value, "ok");
     }
+}
+
+#[tokio::test]
+async fn writes_past_threshold_trigger_snapshot_and_log_purge() {
+    #[derive(serde::Deserialize, SurrealValue)]
+    struct Count {
+        count: i64,
+    }
+
+    const THRESHOLD: u64 = 5;
+    let n1 = spawn_node_with_threshold(5000, THRESHOLD).await;
+    n1.raft.init_cluster(&n1.addr).await.expect("init_cluster");
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Write well past the threshold — openraft builds a snapshot and the
+    // log_store purges committed entries in the background.
+    for i in 0..(THRESHOLD as usize * 4) {
+        n1.raft
+            .write(format!(
+                "CREATE kv SET key = 'snap-{i}', value = '{i}'"
+            ))
+            .await
+            .expect("write");
+    }
+
+    // Give the snapshot + purge tasks a moment to run.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // A snapshot row should exist in _raft_snapshot for our node_id.
+    let snaps: Vec<Count> = n1
+        .db
+        .query_take("SELECT count() AS count FROM _raft_snapshot GROUP ALL")
+        .await
+        .expect("count snapshots");
+    let snap_count = snaps.first().map(|c| c.count).unwrap_or(0);
+    assert!(
+        snap_count >= 1,
+        "expected at least one snapshot row, got {snap_count}"
+    );
+
+    // And the log should have been purged: fewer live _raft_log rows than
+    // total writes (we wrote THRESHOLD*4 entries plus membership ones).
+    let logs: Vec<Count> = n1
+        .db
+        .query_take("SELECT count() AS count FROM _raft_log GROUP ALL")
+        .await
+        .expect("count logs");
+    let log_count = logs.first().map(|c| c.count).unwrap_or(0);
+    assert!(
+        log_count < (THRESHOLD as i64 * 4),
+        "expected log to be purged below write count, got {log_count}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #314. (Re-created after #325 merged.)

## Summary

- Explicit `SnapshotPolicy` in `RaftNode::new` via `SNAPSHOT_THRESHOLD = 1000` constant
- `new_with_snapshot_threshold` test-only constructor for low thresholds in integration tests
- `tracing::info!` on `build_snapshot` and `log_store::purge`
- `tracing_subscriber` init in `bin/nauka/main.rs`
- Integration test `writes_past_threshold_trigger_snapshot_and_log_purge`

## Test plan

- [x] `cargo test` — passes
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Hetzner 2-node — PASS, tracing output visible in daemon logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)