### PR TITLE
followups: close out remaining AC gaps on #310, #314, #315

### DIFF
--- a/bin/nauka/src/main.rs
+++ b/bin/nauka/src/main.rs
@@ -82,6 +82,20 @@ fn mesh_cmd() -> Command {
                         ),
                 ),
         )
+        .subcommand(
+            Command::new("debug")
+                .about("Operator escape hatches — not part of the stable CLI")
+                .arg_required_else_help(true)
+                .subcommand(
+                    Command::new("raft-write")
+                        .about("Send arbitrary SurQL through Raft (loopback only)")
+                        .arg(
+                            Arg::new("query")
+                                .required(true)
+                                .help("SurQL statement, e.g. \"UPDATE hypervisor SET ...\""),
+                        ),
+                ),
+        )
 }
 
 async fn handle_mesh(matches: &clap::ArgMatches) -> Result<()> {
@@ -145,6 +159,18 @@ async fn handle_mesh(matches: &clap::ArgMatches) -> Result<()> {
                 Ok(())
             }
             _ => anyhow::bail!("unknown peer subcommand"),
+        },
+        Some(("debug", sub)) => match sub.subcommand() {
+            Some(("raft-write", rw)) => {
+                let query = rw.get_one::<String>("query").unwrap();
+                nauka_hypervisor::mesh::request_raft_write(
+                    nauka_hypervisor::mesh::DEFAULT_JOIN_PORT,
+                    query,
+                )?;
+                println!("raft write ok");
+                Ok(())
+            }
+            _ => anyhow::bail!("unknown debug subcommand"),
         },
         _ => anyhow::bail!("unknown mesh subcommand"),
     }

--- a/layers/hypervisor/src/daemon.rs
+++ b/layers/hypervisor/src/daemon.rs
@@ -8,6 +8,17 @@ use serde::Deserialize;
 use surrealdb::types::SurrealValue;
 use tokio::signal;
 
+/// Read the snapshot threshold from `NAUKA_SNAPSHOT_THRESHOLD` if set,
+/// otherwise fall back to the production default. Lets ops tune (or CI
+/// tests force) how often Raft snapshots fire.
+fn snapshot_threshold() -> u64 {
+    std::env::var("NAUKA_SNAPSHOT_THRESHOLD")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(nauka_state::raft::SNAPSHOT_THRESHOLD)
+}
+
 use crate::mesh::{
     certs, generate_pin, join_mesh, mesh_listener, whoami, KeyPair, Mesh, MeshError, MeshId,
     MeshState, DEFAULT_JOIN_PORT,
@@ -94,7 +105,7 @@ pub async fn run_daemon(db: Arc<Database>, config: DaemonConfig) -> Result<(), M
     println!("  tls:        {}", if tls.is_some() { "enabled" } else { "disabled" });
     println!("  join pin:   {pin}");
 
-    let raft_node = RaftNode::new(node_id, db.clone(), tls)
+    let raft_node = RaftNode::new_with_snapshot_threshold(node_id, db.clone(), tls, snapshot_threshold())
         .await
         .map_err(|e| MeshError::State(e.to_string()))?;
     raft_node
@@ -221,7 +232,7 @@ pub async fn run_daemon_join(
     println!("  raft:       {raft_addr}");
     println!("  tls:        {}", if tls.is_some() { "enabled" } else { "disabled" });
 
-    let raft_node = RaftNode::new(node_id, db.clone(), tls)
+    let raft_node = RaftNode::new_with_snapshot_threshold(node_id, db.clone(), tls, snapshot_threshold())
         .await
         .map_err(|e| MeshError::State(e.to_string()))?;
     let _raft_server = raft_node.start_server(raft_addr).await;
@@ -278,7 +289,7 @@ pub async fn run_daemon_restart(db: Arc<Database>) -> Result<(), MeshError> {
     println!("  raft:       {raft_addr}");
     println!("  tls:        {}", if tls.is_some() { "enabled" } else { "disabled" });
 
-    let raft_node = RaftNode::new(node_id, db.clone(), tls)
+    let raft_node = RaftNode::new_with_snapshot_threshold(node_id, db.clone(), tls, snapshot_threshold())
         .await
         .map_err(|e| MeshError::State(e.to_string()))?;
     let _raft_server = raft_node.start_server(raft_addr).await;

--- a/layers/hypervisor/src/mesh/join.rs
+++ b/layers/hypervisor/src/mesh/join.rs
@@ -48,6 +48,11 @@ struct RemoveRequest {
     remove_public_key: String,
 }
 
+#[derive(Serialize, Deserialize)]
+struct RaftWriteRequest {
+    query: String,
+}
+
 pub fn generate_pin() -> String {
     let entropy = Key::generate();
     let bytes = entropy.as_array();
@@ -282,6 +287,31 @@ async fn handle_connection(
             let _ = writer.write_all(b"{\"ok\":true}\n").await;
             println!("  - peer removed: {canonical_pk}");
         }
+    } else if v.get("raft_write").is_some() {
+        // Debug escape hatch: write arbitrary SurQL through Raft. Restricted
+        // to loopback so an attacker on the public peering port can't
+        // corrupt cluster state. Used by operators (and test-issue-315.sh)
+        // to simulate scenarios like stale endpoints.
+        if !peer_addr.ip().is_loopback() {
+            let _ = writer
+                .write_all(b"{\"error\":\"raft_write requires loopback\"}\n")
+                .await;
+            return Err(MeshError::Join("non-loopback raft_write".into()));
+        }
+        let raft = raft.as_ref().ok_or_else(|| MeshError::Join("no raft".into()))?;
+        let req: RaftWriteRequest =
+            serde_json::from_value(v).map_err(|e| MeshError::Join(e.to_string()))?;
+        match raft.write(req.query.clone()).await {
+            Ok(_) => {
+                let _ = writer.write_all(b"{\"ok\":true}\n").await;
+                println!("  # raft_write ok: {}", req.query);
+            }
+            Err(e) => {
+                let body = serde_json::json!({ "error": e.to_string() }).to_string();
+                let _ = writer.write_all(format!("{body}\n").as_bytes()).await;
+                eprintln!("  ! raft_write failed: {e}");
+            }
+        }
     }
 
     Ok(())
@@ -368,6 +398,28 @@ pub fn join_mesh(
     };
 
     Ok((mesh, all_peers, tls_certs))
+}
+
+/// Debug escape hatch: send an arbitrary SurQL write to the local daemon,
+/// which forwards it to the Raft leader. Connects over loopback only; any
+/// non-loopback peer trying the same thing is rejected by the listener.
+pub fn request_raft_write(join_port: u16, query: &str) -> Result<(), MeshError> {
+    let addr = format!("127.0.0.1:{join_port}");
+    let mut stream =
+        TcpStream::connect(&addr).map_err(|e| MeshError::Join(format!("connect daemon: {e}")))?;
+
+    let req = serde_json::json!({ "raft_write": true, "query": query });
+    writeln!(stream, "{req}").map_err(|e| MeshError::Join(e.to_string()))?;
+
+    let reader = BufReader::new(stream);
+    let mut lines = reader.lines();
+    if let Some(Ok(line)) = lines.next() {
+        let v: serde_json::Value = serde_json::from_str(&line).unwrap_or_default();
+        if let Some(err) = v.get("error").and_then(|e| e.as_str()) {
+            return Err(MeshError::Join(err.to_string()));
+        }
+    }
+    Ok(())
 }
 
 /// Ask a remote peer what IP it observes us on. Used by restart flow to

--- a/layers/hypervisor/src/mesh/mod.rs
+++ b/layers/hypervisor/src/mesh/mod.rs
@@ -11,8 +11,8 @@ mod state;
 pub use address::MeshId;
 pub use error::MeshError;
 pub use join::{
-    generate_pin, join_mesh, mesh_listener, request_peer_removal, whoami, PeerInfo,
-    DEFAULT_JOIN_PORT, DEFAULT_PEERING_TIMEOUT,
+    generate_pin, join_mesh, mesh_listener, request_peer_removal, request_raft_write, whoami,
+    PeerInfo, DEFAULT_JOIN_PORT, DEFAULT_PEERING_TIMEOUT,
 };
 pub use key::KeyPair;
 pub use peer::MeshPeer;

--- a/tests/test-chaos-304.sh
+++ b/tests/test-chaos-304.sh
@@ -247,11 +247,28 @@ ok "cluster fully recovered — $final_alive/$NODE_COUNT nodes alive"
 # ═══════════════════════════════════════════════════════════════════
 # CHAOS PHASE 4: functional consensus check
 # Prove the cluster can still do Raft writes post-recovery:
+# 0. a new leader was elected post-restart (state-machine applies ran)
 # 1. remove a peer via CLI (issues DELETE hypervisor through Raft)
 # 2. verify every non-victim node's reconciler picks up the change
 # ═══════════════════════════════════════════════════════════════════
 log ""
 log "═══ CHAOS PHASE 4: functional consensus check ═══"
+
+# A new leader emits a blank entry on election; every node then applies it
+# through its state machine. If no leader was elected, nothing applies and
+# grep returns 0. Time-bound: by this point in the test we've already slept
+# 15s for stabilization, so any missing applies here are a real failure.
+log "  ▶ verifying a leader was elected after restart"
+leader_elected=false
+for ip in "${IPS[@]}"; do
+    if ssh_node "$ip" "grep -q 'sm: apply' /tmp/nauka-restart.log 2>/dev/null"; then
+        leader_elected=true
+        break
+    fi
+done
+$leader_elected \
+    || die "no 'sm: apply' found on any node post-restart — no leader was elected within the stabilization window"
+ok "  leader election confirmed (state-machine applied post-restart)"
 
 VICTIM_IDX=$((NODE_COUNT - 1))
 VICTIM_IP=${IPS[$VICTIM_IDX]}
@@ -260,10 +277,9 @@ VICTIM_PK=$(ssh_node "$VICTIM_IP" \
 [[ -n $VICTIM_PK ]] || die "could not read victim pubkey"
 log "  victim: node-$((VICTIM_IDX + 1)) ($VICTIM_IP) pk=$VICTIM_PK"
 
-# Raft writes must land on the leader; post-chaos the leader is whichever
-# node won the re-election, not necessarily node-1. Daemons today don't
-# forward to the leader (separate concern), so we try every non-victim
-# node until one — the leader — accepts.
+# The peer-remove CLI talks to the local daemon, which forwards the write
+# to the leader via the Raft RPC channel (#315). Any node should accept.
+# We still probe each one so the test prints which node is the leader.
 log "  ▶ nauka mesh peer remove (probing every node for the leader)"
 remove_ok=false
 for i in "${!IPS[@]}"; do

--- a/tests/test-issue-314.sh
+++ b/tests/test-issue-314.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# tests/test-issue-314.sh — Verify Raft snapshot compaction actually fires.
+#
+# Uses NAUKA_SNAPSHOT_THRESHOLD=3 so the init+join sequence (which produces
+# ~5 log entries) reliably crosses the threshold and triggers a snapshot.
+# Then asserts the `raft: built snapshot` tracing event appears in logs.
+set -euo pipefail
+
+NAUKA_BIN="${NAUKA_BIN:-target/x86_64-unknown-linux-musl/release/nauka}"
+SSH_KEY_NAME="${SSH_KEY_NAME:-nauka-agent-local}"
+SERVER_TYPE="${SERVER_TYPE:-cpx22}"
+LOCATION="${LOCATION:-fsn1}"
+IMAGE="${IMAGE:-ubuntu-24.04}"
+
+RUN_DIR="/tmp/nauka-issue-314/$(date -u +%Y%m%dT%H%M%SZ)-$$"
+mkdir -p "$RUN_DIR"
+
+[[ -x $NAUKA_BIN ]] || { echo "✗ NAUKA_BIN not executable" >&2; exit 1; }
+
+NAMES=(nauka-dev-1 nauka-dev-2)
+IPS=("" "")
+
+log()  { printf "\033[36m[%s] %s\033[0m\n" "$(date -u +%H:%M:%S)" "$*"; }
+ok()   { printf "\033[32m✓ %s\033[0m\n" "$*"; }
+fail() { printf "\033[31m✗ %s\033[0m\n" "$*" >&2; }
+die()  { fail "$*"; exit 1; }
+
+cleanup() {
+    local rc=$?
+    if [[ ${KEEP_SERVERS:-0} == 1 && $rc -eq 0 ]]; then
+        log "KEEP_SERVERS=1 — leaving servers"
+        return
+    fi
+    log "tearing down..."
+    for n in "${NAMES[@]}"; do hcloud server delete "$n" >/dev/null 2>&1 || true; done
+    [[ $rc -ne 0 ]] && fail "FAILED — logs in $RUN_DIR"
+}
+trap cleanup EXIT
+
+ssh_node() {
+    local ip=$1; shift
+    ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+        -o LogLevel=ERROR -o ConnectTimeout=10 "root@$ip" "$@"
+}
+scp_to() {
+    local ip=$1 src=$2 dst=$3
+    scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+        -o LogLevel=ERROR "$src" "root@$ip:$dst"
+}
+wait_ssh() {
+    local ip=$1
+    for _ in $(seq 1 60); do ssh_node "$ip" true 2>/dev/null && return 0; sleep 4; done
+    die "SSH never came up on $ip"
+}
+wait_port() {
+    local ip=$1 port=$2
+    for _ in $(seq 1 30); do
+        ssh_node "$ip" "ss -tln | grep -q ':$port '" 2>/dev/null && return 0
+        sleep 2
+    done
+    return 1
+}
+
+# ─── Wipe + Provision ────────────────────────────────────────────────
+for n in "${NAMES[@]}"; do hcloud server delete "$n" >/dev/null 2>&1 || true; done
+log "▶ provisioning 2 servers"
+for i in "${!NAMES[@]}"; do
+    out=$(hcloud server create --name "${NAMES[$i]}" --type "$SERVER_TYPE" --image "$IMAGE" \
+        --location "$LOCATION" --ssh-key "$SSH_KEY_NAME" --output json 2>/dev/null)
+    IPS[$i]=$(echo "$out" | jq -r '.server.public_net.ipv4.ip // empty')
+    [[ -n ${IPS[$i]} ]] || die "${NAMES[$i]}: no IPv4"
+    log "    ${NAMES[$i]} → ${IPS[$i]}"
+done
+for ip in "${IPS[@]}"; do wait_ssh "$ip"; done
+ok "provisioned"
+
+log "▶ deploying binary"
+for ip in "${IPS[@]}"; do
+    scp_to "$ip" "$NAUKA_BIN" /usr/local/bin/nauka >/dev/null
+    ssh_node "$ip" 'chmod +x /usr/local/bin/nauka'
+done
+ok "deployed"
+
+NODE1=${IPS[0]}
+NODE2=${IPS[1]}
+
+# ═══════════════════════════════════════════════════════════════════
+# Run with a low snapshot threshold so the init+join sequence alone
+# crosses it and forces the snapshot + log purge path to exercise.
+# ═══════════════════════════════════════════════════════════════════
+log ""
+log "═══ init + join with NAUKA_SNAPSHOT_THRESHOLD=3 ═══"
+ssh_node "$NODE1" 'NAUKA_SNAPSHOT_THRESHOLD=3 setsid nauka mesh up </dev/null >/tmp/nauka.log 2>&1 &'
+wait_port "$NODE1" 51821 || die "peering never started"
+PIN=$(ssh_node "$NODE1" "grep -oP 'join pin:\s+\K\S+' /tmp/nauka.log" 2>/dev/null || true)
+[[ -n $PIN ]] || die "no PIN"
+ok "node-1 up (pin: $PIN)"
+
+ssh_node "$NODE2" "NAUKA_SNAPSHOT_THRESHOLD=3 setsid nauka mesh join $NODE1 --pin '$PIN' </dev/null >/tmp/nauka.log 2>&1 &"
+wait_port "$NODE2" 4001 || die "node-2 raft never started"
+ok "node-2 joined"
+
+# Give Raft time to replicate, apply, build the snapshot and purge logs.
+sleep 10
+
+# ═══════════════════════════════════════════════════════════════════
+# Pull the snapshot tracing event from the leader.
+# ═══════════════════════════════════════════════════════════════════
+log "▶ checking for 'raft: built snapshot' tracing events"
+SNAP_LINE=$(ssh_node "$NODE1" 'grep -h "raft: built snapshot" /tmp/nauka.log 2>/dev/null | head -1' || true)
+if [[ -z $SNAP_LINE ]]; then
+    ssh_node "$NODE1" 'cat /tmp/nauka.log' > "$RUN_DIR/node-1.log" 2>/dev/null || true
+    die "no 'raft: built snapshot' in node-1 log — compaction didn't fire"
+fi
+ok "  snapshot fired: $SNAP_LINE"
+
+log "▶ checking for 'raft: purged log entries' tracing events"
+PURGE_LINE=$(ssh_node "$NODE1" 'grep -h "raft: purged log entries" /tmp/nauka.log 2>/dev/null | head -1' || true)
+if [[ -z $PURGE_LINE ]]; then
+    ssh_node "$NODE1" 'cat /tmp/nauka.log' > "$RUN_DIR/node-1.log" 2>/dev/null || true
+    die "no 'raft: purged log entries' in node-1 log — purge didn't fire"
+fi
+ok "  purge fired: $PURGE_LINE"
+
+# ─── Collect logs ────────────────────────────────────────────────────
+for i in 0 1; do
+    ip=${IPS[$i]}
+    mkdir -p "$RUN_DIR/node-$((i+1))"
+    ssh_node "$ip" 'cat /tmp/nauka.log' > "$RUN_DIR/node-$((i+1))/daemon.log" 2>/dev/null || true
+done
+
+echo ""
+ok "═══ ALL CHECKS PASSED ═══"
+ok "  NAUKA_SNAPSHOT_THRESHOLD=3 triggers snapshot + purge on Hetzner"
+ok "  logs: $RUN_DIR"

--- a/tests/test-issue-315.sh
+++ b/tests/test-issue-315.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# tests/test-issue-315.sh — Verify restart actively refreshes a stale endpoint.
+#
+# Hetzner's primary IP can't be swapped under a live VM without significant
+# ceremony, so instead we simulate the "my IP changed while I was down"
+# scenario by corrupting the cluster's stored view of a node's endpoint,
+# then restarting the node and asserting the refresh task puts it back.
+#
+# 1. 2 nodes — init + join, cluster healthy
+# 2. From node-1, write a bogus endpoint for node-2 via debug raft-write
+# 3. Confirm node-1's reconciler picked up the bogus endpoint on WG
+# 4. Restart node-2 — its refresh_own_endpoint task should whoami node-1,
+#    see the DB has the wrong endpoint, and UPDATE back to the real one
+# 5. Confirm node-1's WG peer for node-2 is back to the real endpoint
+set -euo pipefail
+
+NAUKA_BIN="${NAUKA_BIN:-target/x86_64-unknown-linux-musl/release/nauka}"
+SSH_KEY_NAME="${SSH_KEY_NAME:-nauka-agent-local}"
+SERVER_TYPE="${SERVER_TYPE:-cpx22}"
+LOCATION="${LOCATION:-fsn1}"
+IMAGE="${IMAGE:-ubuntu-24.04}"
+
+RUN_DIR="/tmp/nauka-issue-315/$(date -u +%Y%m%dT%H%M%SZ)-$$"
+mkdir -p "$RUN_DIR"
+
+[[ -x $NAUKA_BIN ]] || { echo "✗ NAUKA_BIN not executable" >&2; exit 1; }
+
+NAMES=(nauka-dev-1 nauka-dev-2)
+IPS=("" "")
+
+log()  { printf "\033[36m[%s] %s\033[0m\n" "$(date -u +%H:%M:%S)" "$*"; }
+ok()   { printf "\033[32m✓ %s\033[0m\n" "$*"; }
+fail() { printf "\033[31m✗ %s\033[0m\n" "$*" >&2; }
+die()  { fail "$*"; exit 1; }
+
+cleanup() {
+    local rc=$?
+    if [[ ${KEEP_SERVERS:-0} == 1 && $rc -eq 0 ]]; then
+        log "KEEP_SERVERS=1 — leaving servers"
+        return
+    fi
+    log "tearing down..."
+    for n in "${NAMES[@]}"; do hcloud server delete "$n" >/dev/null 2>&1 || true; done
+    [[ $rc -ne 0 ]] && fail "FAILED — logs in $RUN_DIR"
+}
+trap cleanup EXIT
+
+ssh_node() {
+    local ip=$1; shift
+    ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+        -o LogLevel=ERROR -o ConnectTimeout=10 "root@$ip" "$@"
+}
+scp_to() {
+    local ip=$1 src=$2 dst=$3
+    scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+        -o LogLevel=ERROR "$src" "root@$ip:$dst"
+}
+wait_ssh() {
+    local ip=$1
+    for _ in $(seq 1 60); do ssh_node "$ip" true 2>/dev/null && return 0; sleep 4; done
+    die "SSH never came up on $ip"
+}
+wait_port() {
+    local ip=$1 port=$2
+    for _ in $(seq 1 30); do
+        ssh_node "$ip" "ss -tln | grep -q ':$port '" 2>/dev/null && return 0
+        sleep 2
+    done
+    return 1
+}
+
+# ─── Wipe + Provision ────────────────────────────────────────────────
+for n in "${NAMES[@]}"; do hcloud server delete "$n" >/dev/null 2>&1 || true; done
+log "▶ provisioning 2 servers"
+for i in "${!NAMES[@]}"; do
+    out=$(hcloud server create --name "${NAMES[$i]}" --type "$SERVER_TYPE" --image "$IMAGE" \
+        --location "$LOCATION" --ssh-key "$SSH_KEY_NAME" --output json 2>/dev/null)
+    IPS[$i]=$(echo "$out" | jq -r '.server.public_net.ipv4.ip // empty')
+    [[ -n ${IPS[$i]} ]] || die "${NAMES[$i]}: no IPv4"
+    log "    ${NAMES[$i]} → ${IPS[$i]}"
+done
+for ip in "${IPS[@]}"; do wait_ssh "$ip"; done
+ok "provisioned"
+
+log "▶ deploying binary"
+for ip in "${IPS[@]}"; do
+    scp_to "$ip" "$NAUKA_BIN" /usr/local/bin/nauka >/dev/null
+    ssh_node "$ip" 'chmod +x /usr/local/bin/nauka'
+done
+ok "deployed"
+
+NODE1=${IPS[0]}
+NODE2=${IPS[1]}
+
+# ═══════════════════════════════════════════════════════════════════
+# Init + join
+# ═══════════════════════════════════════════════════════════════════
+log ""
+log "═══ bring up 2-node mesh ═══"
+ssh_node "$NODE1" 'setsid nauka mesh up </dev/null >/tmp/nauka.log 2>&1 &'
+wait_port "$NODE1" 51821 || die "peering never started"
+PIN=$(ssh_node "$NODE1" "grep -oP 'join pin:\s+\K\S+' /tmp/nauka.log" 2>/dev/null || true)
+[[ -n $PIN ]] || die "no PIN"
+ok "node-1 up (pin: $PIN)"
+
+ssh_node "$NODE2" "setsid nauka mesh join $NODE1 --pin '$PIN' </dev/null >/tmp/nauka.log 2>&1 &"
+wait_port "$NODE2" 4001 || die "node-2 raft never started"
+ok "node-2 joined"
+
+# Wait for voter promotion so raft.write from node-1 will commit.
+sleep 15
+ssh_node "$NODE1" 'grep -q "raft voter:" /tmp/nauka.log' || die "node-2 never promoted to voter"
+ok "node-2 promoted to voter"
+
+# Grab node-2's public key for the poison query.
+NODE2_PK=$(ssh_node "$NODE2" "grep -oP 'public key:\s+\K\S+' /tmp/nauka.log | head -1")
+[[ -n $NODE2_PK ]] || die "could not read node-2 pubkey"
+log "  node-2 pubkey: $NODE2_PK"
+log "  real node-2 endpoint: $NODE2:51820"
+
+# ═══════════════════════════════════════════════════════════════════
+# Poison node-2's endpoint, THEN kill node-2 immediately so its
+# keepalives stop flowing — otherwise WireGuard's endpoint roaming
+# would re-learn the real IP from the inbound packets and overwrite
+# whatever the reconciler just configured.
+# ═══════════════════════════════════════════════════════════════════
+log ""
+log "═══ poison node-2's endpoint to 9.9.9.9:51820 ═══"
+BOGUS="9.9.9.9:51820"
+ssh_node "$NODE1" "nauka mesh debug raft-write \"UPDATE hypervisor SET endpoint = '$BOGUS' WHERE public_key = '$NODE2_PK'\"" \
+    || die "debug raft-write failed"
+ok "bogus endpoint written via Raft"
+
+# Kill node-2 right away; WG on node-1 will stop receiving packets from
+# the real IP and keep whatever endpoint the reconciler installs.
+ssh_node "$NODE2" 'kill $(pgrep -x nauka) 2>/dev/null || true'
+ok "node-2 stopped (no more keepalives to node-1)"
+
+# Let reconciler on node-1 pick up the bogus endpoint (5s cycle).
+sleep 12
+log "▶ confirming node-1's WG view of node-2 is now bogus"
+PEER_EP=$(ssh_node "$NODE1" 'nauka mesh status 2>/dev/null | tr -d "\n" | grep -oP "endpoint: Some\(\s*\K[^,)]+" | head -1' || true)
+log "    node-1 sees node-2 at: $PEER_EP"
+if [[ $PEER_EP != "$BOGUS" ]]; then
+    log "DIAG: last 20 lines of node-1 daemon log:"
+    ssh_node "$NODE1" 'tail -20 /tmp/nauka.log' || true
+    die "reconciler didn't pick up bogus endpoint (got: $PEER_EP)"
+fi
+ok "node-1's WG now targets $BOGUS for node-2 (cluster state is poisoned)"
+
+# ═══════════════════════════════════════════════════════════════════
+# Restart node-2 — refresh_own_endpoint should correct the cluster view
+# ═══════════════════════════════════════════════════════════════════
+log ""
+log "═══ restart node-2 ═══"
+ssh_node "$NODE2" 'setsid nauka mesh start </dev/null >/tmp/nauka-restart.log 2>&1 &'
+wait_port "$NODE2" 4001 || die "node-2 raft port not back after restart"
+ok "node-2 restarted"
+
+# The refresh task sleeps 3s then runs once; give Raft apply + reconciler
+# cycle time on top of that.
+log "  waiting 20s for refresh + Raft replication + reconciler..."
+sleep 20
+
+# ═══════════════════════════════════════════════════════════════════
+# Verify the correct endpoint was restored
+# ═══════════════════════════════════════════════════════════════════
+log "▶ checking node-1's WG view of node-2 is back to the real IP"
+PEER_EP2=$(ssh_node "$NODE1" 'nauka mesh status 2>/dev/null | tr -d "\n" | grep -oP "endpoint: Some\(\s*\K[^,)]+" | head -1' || true)
+log "    node-1 sees node-2 at: $PEER_EP2"
+EXPECTED="$NODE2:51820"
+if [[ $PEER_EP2 != "$EXPECTED" ]]; then
+    log "DIAG: raw 'nauka mesh status' on node-1:"
+    ssh_node "$NODE1" 'nauka mesh status 2>&1' || true
+    log "DIAG: node-2 refresh log:"
+    ssh_node "$NODE2" 'grep -E "endpoint refresh|sm: apply|reconciler" /tmp/nauka-restart.log 2>/dev/null | head -30' || true
+    log "DIAG: node-1 recent log:"
+    ssh_node "$NODE1" 'grep -E "endpoint refresh|sm: apply|reconciler" /tmp/nauka.log 2>/dev/null | tail -20' || true
+    die "endpoint not restored (got: $PEER_EP2, want: $EXPECTED)"
+fi
+ok "endpoint restored — restart detected the mismatch and UPDATEd via Raft"
+
+# Also confirm node-2's refresh task actively propagated the correction.
+ssh_node "$NODE2" 'grep -q "endpoint refresh: propagated via Raft" /tmp/nauka-restart.log' \
+    || die "node-2's refresh task didn't propagate via Raft"
+ok "node-2's refresh task logged propagation via Raft"
+
+# ─── Collect logs ────────────────────────────────────────────────────
+for i in 0 1; do
+    ip=${IPS[$i]}
+    mkdir -p "$RUN_DIR/node-$((i+1))"
+    ssh_node "$ip" 'cat /tmp/nauka.log /tmp/nauka-restart.log 2>/dev/null' \
+        > "$RUN_DIR/node-$((i+1))/daemon.log" 2>/dev/null || true
+done
+
+echo ""
+ok "═══ ALL CHECKS PASSED ═══"
+ok "  restart-time endpoint refresh corrects a stale cluster view"
+ok "  logs: $RUN_DIR"


### PR DESCRIPTION
Closes #310, #314, #315.

After auditing the six merged PRs against the original acceptance criteria, three issues had AC items not strictly met. This PR closes those gaps without re-touching the mechanisms.

## Summary

### #310 — post-restart leader election check
Phase 4 of the chaos test used to only probe for a leader via the peer-remove. Now it also asserts at least one node applied a state-machine entry post-restart (grep \`sm: apply\` in the restart log), which only happens after a new leader is elected. Gives a clean error instead of the generic probe-exhausted message. Also removes a stale comment about followers not forwarding — they do since #315.

### #314 — prove snapshots fire on Hetzner
- \`NAUKA_SNAPSHOT_THRESHOLD\` env var, read by the daemon at startup. Falls back to \`nauka_state::raft::SNAPSHOT_THRESHOLD\` (1000) when unset or invalid.
- New \`tests/test-issue-314.sh\`: sets threshold=3, runs init+join (~5 log entries) on 2 Hetzner VMs, asserts \`raft: built snapshot\` and \`raft: purged log entries\` both appear in the daemon log.

### #315 — end-to-end changed-IP scenario
- New \`nauka mesh debug raft-write <query>\` CLI. **Loopback-only** — the listener rejects non-loopback callers. Lets operators (and this test) manipulate replicated state without poking SurrealDB directly.
- New \`tests/test-issue-315.sh\`: 2-node mesh, poisons node-2's endpoint via \`debug raft-write\`, kills node-2 immediately so WG endpoint-roaming doesn't silently heal the poison, waits for node-1's reconciler to install the bogus endpoint on WG, restarts node-2, asserts (a) \`endpoint refresh: propagated via Raft\` in the restart log, (b) node-1's WG view is back to the real IP.

## Notes on #313

Left as-is. The AC said "no \`format!\` over user/peer-controlled values" but the PR kept \`format!\` at three sites where inputs are already parsed as typed values (\`Key::from_str\`, \`SocketAddr::parse\`, \`IpAddrMask::parse\`). Moving to \`.bind()\` isn't viable because the query is serialised as a String into the Raft log, not executed with bound parameters. The letter of the AC wasn't met but the security property it was protecting (no SurQL injection) is enforced by validation at the boundary. Closing #313 separately with a comment.

## Test plan

- [x] \`cargo test\` — passes
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] Hetzner \`test-chaos-304.sh\` — PASS with new leader-election check
- [x] Hetzner \`test-issue-314.sh\` — PASS, both tracing events captured
- [x] Hetzner \`test-issue-315.sh\` — PASS, poison → restart → refresh end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)